### PR TITLE
[TDF] Add regression_snapshot2

### DIFF
--- a/root/dataframe/CMakeLists.txt
+++ b/root/dataframe/CMakeLists.txt
@@ -7,6 +7,11 @@ endif()
 
 set(DFLIBRARIES Core TreePlayer Hist Tree RIO MathCore)
 
+ROOTTEST_GENERATE_EXECUTABLE(regression_snapshot2 regression_snapshot2.cxx LIBRARIES ${DFLIBRARIES})
+ROOTTEST_ADD_TEST(regression_snapshot2
+                  EXEC regression_snapshot2
+                  DEPENDS ${GENERATE_EXECUTABLE_TEST})
+
 ROOTTEST_ADD_TEST(test_snapshotNFiles
                   MACRO test_snapshotNFiles.C)
 

--- a/root/dataframe/regression_snapshot2.cxx
+++ b/root/dataframe/regression_snapshot2.cxx
@@ -1,0 +1,7 @@
+#include "ROOT/TDataFrame.hxx"
+
+int main() {
+   ROOT::Experimental::TDataFrame d(1);
+   *(d.Define("b", []{ return 1; }).Filter("b > 0").Count());
+   return 0;
+}


### PR DESCRIPTION
It tests jitting in the case of an empty-source TDataFrame (fixed by ROOT PR #662)