### PR TITLE
[TDF] Take `regression_zeroentries` out until ROOT-8924 is solved

### DIFF
--- a/root/dataframe/CMakeLists.txt
+++ b/root/dataframe/CMakeLists.txt
@@ -126,10 +126,11 @@ ROOTTEST_ADD_TEST(regression_invalidref
 
 
 
-ROOTTEST_GENERATE_EXECUTABLE(regression_zeroentries regression_zeroentries.cxx LIBRARIES ${DFLIBRARIES})
-ROOTTEST_ADD_TEST(regression_zeroentries
-                  EXEC regression_zeroentries
-                  DEPENDS ${GENERATE_EXECUTABLE_TEST})
+# TODO uncomment (or delete forever) after ROOT-8924 is resolved
+#ROOTTEST_GENERATE_EXECUTABLE(regression_zeroentries regression_zeroentries.cxx LIBRARIES ${DFLIBRARIES})
+#ROOTTEST_ADD_TEST(regression_zeroentries
+#                  EXEC regression_zeroentries
+#                  DEPENDS ${GENERATE_EXECUTABLE_TEST})
 
 
 ROOTTEST_GENERATE_EXECUTABLE(foreach test_foreach.cxx LIBRARIES ${DFLIBRARIES})


### PR DESCRIPTION
This test was meant to check that TDF does not assume that the input
TTree has entries (formerly we crashed badly in the case of TTrees
with zero entries). Instead we see warnings coming from TChain due
to the reading of uninitialized memory. The test will be brought
back or deleted after we clarify whether a TTree with zero entries
is a case we want to support or not.