### PR TITLE
Std less cms fwd decl

### DIFF
--- a/cling/dict/fwd-decl-stdless/.rootrc
+++ b/cling/dict/fwd-decl-stdless/.rootrc
@@ -1,0 +1,1 @@
+Rint.History:            .root_hist

--- a/cling/dict/fwd-decl-stdless/CMakeLists.txt
+++ b/cling/dict/fwd-decl-stdless/CMakeLists.txt
@@ -1,0 +1,6 @@
+ROOTTEST_GENERATE_DICTIONARY(lessyDict       lessy.h       LINKDEF lessyLinkDef.h)
+
+ROOTTEST_ADD_TEST(execLessyTest
+                  MACRO execLessyTest.C
+                  DEPENDS lessyDict-build
+                  LABELS roottest regression cling)

--- a/cling/dict/fwd-decl-stdless/execLessyTest.C
+++ b/cling/dict/fwd-decl-stdless/execLessyTest.C
@@ -1,3 +1,16 @@
+// CMS saw an issue with loading dictionaries that fwd declare std::less
+// (because of specializations that their code provides). Because Sema sees
+// re-decls of the default template arguments in these fwd decls it marks the
+// most recent redecl of std::less as invalid.
+// Subsequent use of std::less - in their case as a template template argument -
+// causes errors.
+//
+// This test is producing such a dictionary and using std::less after parsing
+// the fwd decls from the dictionary, as template template argument of UseLess.
+// If std::less is marked invalid, the return value of
+//   gInterpreter->ProcessLine("useless.get()")
+// will be 0.
+
 const char* code = R"CODE(
 template <int I, template <class> class L>
 struct UseLess{
@@ -9,20 +22,20 @@ UseLess<1001, std::less> useless;)CODE";
 
 int execLessyTest()
 {
-   // Trigger autoload.
-   edm::AJet a;
-
    // Check whether std::less became invalid:
    TInterpreter::EErrorCode err = TInterpreter::kNoError;
-   if (!gInterpreter->Declare(code))
+   gInterpreter->ProcessLine(code, &err);
+   if (err != TInterpreter::kNoError)
       return 1;
-   long res = gInterpreter->ProcessLine("useless.get()", &err);
 
+   long res = gInterpreter->ProcessLine("useless.get()", &err);
    if (err != TInterpreter::kNoError)
       return 2;
+
    if (res != 1001) {
       printf("RES=%ld\n", res);
       return 3;
    }
+
    return 0;
 }

--- a/cling/dict/fwd-decl-stdless/execLessyTest.C
+++ b/cling/dict/fwd-decl-stdless/execLessyTest.C
@@ -1,0 +1,28 @@
+const char* code = R"CODE(
+template <int I, template <class> class L>
+struct UseLess{
+   int get() {
+      return L<edm::AJet>()(edm::AJet{12.}, edm::AJet{13.}) ? I : 17;
+   }
+};
+UseLess<1001, std::less> useless;)CODE";
+
+int execLessyTest()
+{
+   // Trigger autoload.
+   edm::AJet a;
+
+   // Check whether std::less became invalid:
+   TInterpreter::EErrorCode err = TInterpreter::kNoError;
+   if (!gInterpreter->Declare(code))
+      return 1;
+   long res = gInterpreter->ProcessLine("useless.get()", &err);
+
+   if (err != TInterpreter::kNoError)
+      return 2;
+   if (res != 1001) {
+      printf("RES=%ld\n", res);
+      return 3;
+   }
+   return 0;
+}

--- a/cling/dict/fwd-decl-stdless/lessy.h
+++ b/cling/dict/fwd-decl-stdless/lessy.h
@@ -1,0 +1,16 @@
+#include <utility>
+
+namespace edm {
+  struct AJet {
+    float m_E;
+  };
+} // edm
+
+namespace std {
+  template <>
+  struct less<edm::AJet> {
+    bool operator()(edm::AJet one, edm::AJet two) const {
+      return one.m_E < two.m_E;
+    }
+  };
+}

--- a/cling/dict/fwd-decl-stdless/lessyLinkDef.h
+++ b/cling/dict/fwd-decl-stdless/lessyLinkDef.h
@@ -1,0 +1,4 @@
+
+#pragma link C++ namespace edm;
+#pragma link C++ class edm::AJet+;
+#pragma link C++ class std::less<edm::AJet>;


### PR DESCRIPTION
Test for `std::less` forward decl from dictionary, which clang flags as invalid due to re-declared default arguments. This fixed an issue seen by CMS.