### PR TITLE
[TDF] Fix test_templateRecursionLimit after interfaces changes in TDF

### DIFF
--- a/root/dataframe/test_templateRecursionLimit.C
+++ b/root/dataframe/test_templateRecursionLimit.C
@@ -5,7 +5,7 @@ using TDFDEF = ROOT::Experimental::TDF::TInterface<ROOT::Detail::TDF::TCustomCol
 TDFDEF defineRecursive(TDFDEF& d, int n)
 {
     std::string name = "a_" + std::to_string(n);
-    auto d2 = d.Define(name, [](){return 1.;});
+    auto d2 = TDFDEF(d.Define(name, [](){return 1.;}));
     if (n == 1) return d2;
     return defineRecursive(d2, n - 1);
 }
@@ -13,7 +13,7 @@ TDFDEF defineRecursive(TDFDEF& d, int n)
 int test_templateRecursionLimit()
 {
     ROOT::Experimental::TDataFrame tdf(1);
-    TDFDEF d = tdf.Define("a_0", [](){return 1.;});
+    TDFDEF d(tdf.Define("a_0", [](){return 1.;}));
 
     auto d_final = defineRecursive(d, 96); //66 limit with 1024 on linux
 


### PR DESCRIPTION
Fixes breakage introduced by PR #869 in `roottest/root`.