### PR TITLE
Fixing new reference size for filemerger test in case of lzma_version < 5002

### DIFF
--- a/root/io/filemerger/execTestMultiMerge.C
+++ b/root/io/filemerger/execTestMultiMerge.C
@@ -89,7 +89,7 @@ int execTestMultiMerge()
    if (lzma_version_number() < 50020010) {
       // lzma v5.2.0 produced larger files ...
       // but even older version (eg v5.0.0) produced smaller files ...
-      result += testSimpleFile("hsimpleK202.root",6*25000,202,1938720,700);
+      result += testSimpleFile("hsimpleK202.root",12*25000,202,4631252,700);
    } else {
       result += testSimpleFile("hsimpleK202.root",12*25000,202,4631252,16);
    }


### PR DESCRIPTION
Fixing incrementals..