### PR TITLE
Correctly check for exit code 1 in selectUnion test.

### DIFF
--- a/root/meta/rootcling/CMakeLists.txt
+++ b/root/meta/rootcling/CMakeLists.txt
@@ -10,4 +10,5 @@ ROOTTEST_ADD_TEST(includeInLinkdef
 # ROOT-8492
 ROOTTEST_ADD_TEST(selectUnion
                   COMMAND ${ROOT_rootcling_CMD} -f NestedClassOff.Dict.cc ${CMAKE_CURRENT_SOURCE_DIR}/NestedClassOff.h ${CMAKE_CURRENT_SOURCE_DIR}/NestedClassOff.LinkDef.h
-                  OUTREF selectUnion.ref)
+                  OUTREF selectUnion.ref
+                  PASSRC 1)


### PR DESCRIPTION
This test is supposed to contain an error, but we actually expect that that
rootcling returns 0 which it no longer does in the latest root master
where we fixed the rootcling exit codes.