### PR TITLE
[genreflex] Add tests for noStreamer and noInputOperator xml attribute

### DIFF
--- a/root/meta/genreflex/noStreamer_noInputOperator/.rootrc
+++ b/root/meta/genreflex/noStreamer_noInputOperator/.rootrc
@@ -1,0 +1,1 @@
+Rint.History:            .root_hist

--- a/root/meta/genreflex/noStreamer_noInputOperator/CMakeLists.txt
+++ b/root/meta/genreflex/noStreamer_noInputOperator/CMakeLists.txt
@@ -1,0 +1,45 @@
+ROOTTEST_ADD_TESTDIRS()
+
+# ------------------------------------------------------------------------------
+# noStreamer tests
+ROOTTEST_ADD_TEST(invalidNoStreamerGenreflex
+                  COMMAND ${ROOT_genreflex_CMD} foo.h -o ${CMAKE_CURRENT_BINARY_DIR}/invalidNoStreamer_rflx.cpp  --selection_file=invalidNoStreamer_selection.xml
+                  WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+                  OUTREF invalidNoStreamerGenreflex.ref)
+
+ROOTTEST_ADD_TEST(noStreamerGenreflex
+                  COMMAND ${ROOT_genreflex_CMD} foo.h -o ${CMAKE_CURRENT_BINARY_DIR}/noStreamer_rflx.cpp  --selection_file=noStreamer_selection.xml
+                  WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+                  OUTREF emptyGenreflexOutput.ref)
+
+ROOTTEST_ADD_TEST(noStreamerDict
+                  COMMAND grep -v "void Foo::Streamer(TBuffer &R__b)" ${CMAKE_CURRENT_BINARY_DIR}/noStreamer_rflx.cpp
+                  WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+                  DEPENDS noStreamerGenreflex)
+
+ROOTTEST_ADD_TEST(noStreamerFalseGenreflex
+                  COMMAND ${ROOT_genreflex_CMD} foo.h -o ${CMAKE_CURRENT_BINARY_DIR}/noStreamer_false_rflx.cpp  --selection_file=noStreamer_false_selection.xml
+                  WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+                  OUTREF emptyGenreflexOutput.ref)
+
+ROOTTEST_ADD_TEST(noStreamerFalseDict
+                  COMMAND grep "void Foo::Streamer(TBuffer &R__b)" ${CMAKE_CURRENT_BINARY_DIR}/noStreamer_false_rflx.cpp
+                  WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+                  DEPENDS noStreamerFalseGenreflex)
+
+# ------------------------------------------------------------------------------
+# noInputOperator tests
+ROOTTEST_ADD_TEST(invalidNoInpuOperatorGenreflex
+                  COMMAND ${ROOT_genreflex_CMD} foo.h -o ${CMAKE_CURRENT_BINARY_DIR}/invalidNoInputOperator_rflx.cpp  --selection_file=invalidNoInputOperator_selection.xml
+                  WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+                  OUTREF invalidNoInputOperatorGenreflex.ref)
+
+ROOTTEST_ADD_TEST(noInputOperatorGenreflex
+                  COMMAND ${ROOT_genreflex_CMD} foo_custom_input_operator.h -o ${CMAKE_CURRENT_BINARY_DIR}/noInputOperator_rflx.cpp  --selection_file=noInputOperator_selection.xml
+                  WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+                  OUTREF emptyGenreflexOutput.ref)
+
+ROOTTEST_ADD_TEST(noInputOperatorFalseGenreflex
+                  COMMAND ${ROOT_genreflex_CMD} foo_custom_input_operator.h -o ${CMAKE_CURRENT_BINARY_DIR}/noInputOperator_false_rflx.cpp  --selection_file=noInputOperator_false_selection.xml
+                  WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+                  OUTREF emptyGenreflexOutput.ref)

--- a/root/meta/genreflex/noStreamer_noInputOperator/CMakeLists.txt
+++ b/root/meta/genreflex/noStreamer_noInputOperator/CMakeLists.txt
@@ -2,44 +2,40 @@ ROOTTEST_ADD_TESTDIRS()
 
 # ------------------------------------------------------------------------------
 # noStreamer tests
+
+#   invalid noStreamer attribute
 ROOTTEST_ADD_TEST(invalidNoStreamerGenreflex
                   COMMAND ${ROOT_genreflex_CMD} foo.h -o ${CMAKE_CURRENT_BINARY_DIR}/invalidNoStreamer_rflx.cpp  --selection_file=invalidNoStreamer_selection.xml
                   WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
                   OUTREF invalidNoStreamerGenreflex.ref)
 
-ROOTTEST_ADD_TEST(noStreamerGenreflex
-                  COMMAND ${ROOT_genreflex_CMD} foo.h -o ${CMAKE_CURRENT_BINARY_DIR}/noStreamer_rflx.cpp  --selection_file=noStreamer_selection.xml
-                  WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-                  OUTREF emptyGenreflexOutput.ref)
+#   custom streamer
+ROOTTEST_GENERATE_REFLEX_DICTIONARY(customStreamer_rflx foo_custom_streamer.h SELECTION noStreamer_selection.xml)
 
-ROOTTEST_ADD_TEST(noStreamerDict
-                  COMMAND grep -v "void Foo::Streamer(TBuffer &R__b)" ${CMAKE_CURRENT_BINARY_DIR}/noStreamer_rflx.cpp
-                  WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-                  DEPENDS noStreamerGenreflex)
+ROOTTEST_ADD_TEST(customStreamer
+                  MACRO  customStreamer.C
+                  OUTREF customStreamer.ref
+                  DEPENDS ${GENERATE_REFLEX_TEST})
 
-ROOTTEST_ADD_TEST(noStreamerFalseGenreflex
-                  COMMAND ${ROOT_genreflex_CMD} foo.h -o ${CMAKE_CURRENT_BINARY_DIR}/noStreamer_false_rflx.cpp  --selection_file=noStreamer_false_selection.xml
-                  WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-                  OUTREF emptyGenreflexOutput.ref)
+#   generated streamer
+ROOTTEST_GENERATE_REFLEX_DICTIONARY(noStreamer_false_rflx foo.h SELECTION noStreamer_false_selection.xml)
 
 ROOTTEST_ADD_TEST(noStreamerFalseDict
-                  COMMAND grep "void Foo::Streamer(TBuffer &R__b)" ${CMAKE_CURRENT_BINARY_DIR}/noStreamer_false_rflx.cpp
+                  COMMAND grep "void Foo::Streamer(TBuffer &R__b)" ${CMAKE_CURRENT_BINARY_DIR}/noStreamer_false_rflx.cxx
                   WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-                  DEPENDS noStreamerFalseGenreflex)
+                  DEPENDS ${GENERATE_REFLEX_TEST})
 
 # ------------------------------------------------------------------------------
 # noInputOperator tests
+
+#   invalid noInputOperator attribute
 ROOTTEST_ADD_TEST(invalidNoInpuOperatorGenreflex
                   COMMAND ${ROOT_genreflex_CMD} foo.h -o ${CMAKE_CURRENT_BINARY_DIR}/invalidNoInputOperator_rflx.cpp  --selection_file=invalidNoInputOperator_selection.xml
                   WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
                   OUTREF invalidNoInputOperatorGenreflex.ref)
 
-ROOTTEST_ADD_TEST(noInputOperatorGenreflex
-                  COMMAND ${ROOT_genreflex_CMD} foo_custom_input_operator.h -o ${CMAKE_CURRENT_BINARY_DIR}/noInputOperator_rflx.cpp  --selection_file=noInputOperator_selection.xml
-                  WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-                  OUTREF emptyGenreflexOutput.ref)
+#   noInputOperator = true
+ROOTTEST_GENERATE_REFLEX_DICTIONARY(noInputOperator_rflx foo_custom_input_operator.h SELECTION noInputOperator_selection.xml)
 
-ROOTTEST_ADD_TEST(noInputOperatorFalseGenreflex
-                  COMMAND ${ROOT_genreflex_CMD} foo_custom_input_operator.h -o ${CMAKE_CURRENT_BINARY_DIR}/noInputOperator_false_rflx.cpp  --selection_file=noInputOperator_false_selection.xml
-                  WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-                  OUTREF emptyGenreflexOutput.ref)
+#   noInputOperator = false
+ROOTTEST_GENERATE_REFLEX_DICTIONARY(noInputOperator_false_rflx foo_custom_input_operator.h SELECTION noInputOperator_false_selection.xml)

--- a/root/meta/genreflex/noStreamer_noInputOperator/Makefile
+++ b/root/meta/genreflex/noStreamer_noInputOperator/Makefile
@@ -1,0 +1,18 @@
+CLEAN_TARGETS += *.log xr.* dummy* *pcm *o *rflx.* $(ALL_LIBRARIES)
+TEST_TARGETS += noStreamer
+
+ifeq ($(strip $(ROOTTEST_HOME)),)
+   export ROOTTEST_HOME := $(shell git rev-parse --show-toplevel)/
+   ifeq ($(strip $(ROOTTEST_HOME)),)
+      export ROOTTEST_HOME := $(shell expr $(CURDIR) : '\(.*/roottest/\)')
+   endif
+   ifeq ($(strip $(ROOTTEST_HOME)),)
+      $(error The head of roottest was not found.  Set ROOTTEST_HOME)
+   endif
+endif
+
+include $(ROOTTEST_HOME)/scripts/Rules.mk
+include $(ROOTTEST_HOME)/scripts/Reflex.mk
+
+# Create the dict source
+# execdummy.log:  foo_rflx.cpp

--- a/root/meta/genreflex/noStreamer_noInputOperator/customStreamer.C
+++ b/root/meta/genreflex/noStreamer_noInputOperator/customStreamer.C
@@ -1,0 +1,8 @@
+{
+   gSystem->Load("libcustomStreamer_rflx_dictrflx");
+   FooCustomStreamer foo;
+   TBufferFile read_buffer(TBuffer::EMode::kRead);
+   foo.Streamer(read_buffer);
+   TBufferFile write_buffer(TBuffer::EMode::kWrite);
+   foo.Streamer(write_buffer);
+}

--- a/root/meta/genreflex/noStreamer_noInputOperator/customStreamer.ref
+++ b/root/meta/genreflex/noStreamer_noInputOperator/customStreamer.ref
@@ -1,0 +1,4 @@
+
+Processing customStreamer.C...
+Custom streamer reading
+Custom streamer writing

--- a/root/meta/genreflex/noStreamer_noInputOperator/foo.h
+++ b/root/meta/genreflex/noStreamer_noInputOperator/foo.h
@@ -1,0 +1,10 @@
+#include <Rtypes.h>
+
+class Foo {
+public:
+  Foo() {}
+
+private:
+  int fData = 3;
+  ClassDefNV(Foo, 1);
+};

--- a/root/meta/genreflex/noStreamer_noInputOperator/foo_custom_input_operator.h
+++ b/root/meta/genreflex/noStreamer_noInputOperator/foo_custom_input_operator.h
@@ -1,0 +1,14 @@
+#include <Rtypes.h>
+#include <TBuffer.h>
+
+class Foo {
+public:
+  Foo() {}
+
+private:
+  int fData = 3;
+  ClassDefNV(Foo, 1);
+};
+
+TBuffer &operator<<(TBuffer &buffer, const Foo *foo) { return buffer; }
+TBuffer &operator>>(TBuffer &buffer, Foo *&) { return buffer; }

--- a/root/meta/genreflex/noStreamer_noInputOperator/foo_custom_streamer.h
+++ b/root/meta/genreflex/noStreamer_noInputOperator/foo_custom_streamer.h
@@ -1,0 +1,20 @@
+#include <Rtypes.h>
+#include <TBuffer.h>
+#include <iostream>
+
+class FooCustomStreamer {
+public:
+  FooCustomStreamer() {}
+
+private:
+  int fData = 3;
+  ClassDefNV(FooCustomStreamer, 1);
+};
+
+inline void FooCustomStreamer::Streamer(TBuffer &R__b) {
+  if (R__b.IsReading()) {
+    std::cout << "Custom streamer reading" << std::endl;
+  } else {
+    std::cout << "Custom streamer writing" << std::endl;
+  }
+}

--- a/root/meta/genreflex/noStreamer_noInputOperator/invalidNoInputOperatorGenreflex.ref
+++ b/root/meta/genreflex/noStreamer_noInputOperator/invalidNoInputOperatorGenreflex.ref
@@ -1,0 +1,1 @@
+Error: XML at line 3: class attribute 'noInputOperator' must be 'true' or 'false' (it was invalid)

--- a/root/meta/genreflex/noStreamer_noInputOperator/invalidNoInputOperator_selection.xml
+++ b/root/meta/genreflex/noStreamer_noInputOperator/invalidNoInputOperator_selection.xml
@@ -1,0 +1,5 @@
+<lcgdict>
+<selection>
+<class name="Foo" noInputOperator="invalid" />
+</selection>
+</lcgdict>

--- a/root/meta/genreflex/noStreamer_noInputOperator/invalidNoStreamerGenreflex.ref
+++ b/root/meta/genreflex/noStreamer_noInputOperator/invalidNoStreamerGenreflex.ref
@@ -1,0 +1,1 @@
+Error: XML at line 3: class attribute 'noStreamer' must be 'true' or 'false' (it was invalid)

--- a/root/meta/genreflex/noStreamer_noInputOperator/invalidNoStreamer_selection.xml
+++ b/root/meta/genreflex/noStreamer_noInputOperator/invalidNoStreamer_selection.xml
@@ -1,0 +1,5 @@
+<lcgdict>
+<selection>
+<class name="Foo" noStreamer="invalid" />
+</selection>
+</lcgdict>

--- a/root/meta/genreflex/noStreamer_noInputOperator/noInputOperator_false_selection.xml
+++ b/root/meta/genreflex/noStreamer_noInputOperator/noInputOperator_false_selection.xml
@@ -1,0 +1,5 @@
+<lcgdict>
+<selection>
+<class name="Foo" noInputOperator="false" />
+</selection>
+</lcgdict>

--- a/root/meta/genreflex/noStreamer_noInputOperator/noInputOperator_selection.xml
+++ b/root/meta/genreflex/noStreamer_noInputOperator/noInputOperator_selection.xml
@@ -1,0 +1,5 @@
+<lcgdict>
+<selection>
+<class name="Foo" noInputOperator="true" />
+</selection>
+</lcgdict>

--- a/root/meta/genreflex/noStreamer_noInputOperator/noStreamer_false_selection.xml
+++ b/root/meta/genreflex/noStreamer_noInputOperator/noStreamer_false_selection.xml
@@ -1,0 +1,5 @@
+<lcgdict>
+<selection>
+<class name="Foo" noStreamer="false" />
+</selection>
+</lcgdict>

--- a/root/meta/genreflex/noStreamer_noInputOperator/noStreamer_selection.xml
+++ b/root/meta/genreflex/noStreamer_noInputOperator/noStreamer_selection.xml
@@ -1,0 +1,5 @@
+<lcgdict>
+<selection>
+<class name="Foo" noStreamer="true" />
+</selection>
+</lcgdict>

--- a/root/meta/genreflex/noStreamer_noInputOperator/noStreamer_selection.xml
+++ b/root/meta/genreflex/noStreamer_noInputOperator/noStreamer_selection.xml
@@ -1,5 +1,5 @@
 <lcgdict>
 <selection>
-<class name="Foo" noStreamer="true" />
+<class name="FooCustomStreamer" noStreamer="true" />
 </selection>
 </lcgdict>


### PR DESCRIPTION
What effect has `csr->SetRequestNoInputOperator(true);` on the dictionary generation?
I was expecting to find a `TBuffer &operator<<(TBuffer &buffer, const Foo *foo)` inside the dictionary if no input operator is set to false, but when I compared both options with:
```bash
diff -y roottest/root/meta/genreflex/noStreamer_noInputOperator/noInputOperator_rflx.cpp roottest/root/meta/genreflex/noStreamer_noInputOperator/noInputOperator_false_rflx.cpp
```
the only difference beside names was:
```
static ::ROOT::TGenericClassInfo 				      static ::ROOT::TGenericClassInfo 
         instance("Foo", ::Foo::Class_Version(), "", 9,		         instance("Foo", ::Foo::Class_Version(), "", 9,
                  typeid(::Foo), ::ROOT::Internal::DefineBeha	                  typeid(::Foo), ::ROOT::Internal::DefineBeha
                  &::Foo::Dictionary, isa_proxy, 6,	      |	                  &::Foo::Dictionary, isa_proxy, 4,
                  sizeof(::Foo) );				                  sizeof(::Foo) );
```

What am I missing?
