### PR TITLE
Filemerger test fixes

### DIFF
--- a/root/io/filemerger/execTestMultiMerge.C
+++ b/root/io/filemerger/execTestMultiMerge.C
@@ -79,7 +79,11 @@ int execTestMultiMerge()
    result += testSimpleFile("hsimple.root",25000,1,414415, kIs32bits ? 10 : 8);
    result += testSimpleFile("hsimple9.root",25000,9,432029,3);
    // Increasing tolerance due test fail for fast-math builds and i686
-   result += testSimpleFile("hsimple101.root",25000,101,414590, kIs32bits ? 10 : 8);
+#ifdef R__FAST_MATH
+   result += testSimpleFile("hsimple101.root",25000,101,414590, 10);
+#else
+   result += testSimpleFile("hsimple101.root",25000,101,414590, kIs32bits ? 12 : 3);   
+#endif
    result += testSimpleFile("hsimple106.root",25000,106,432127,3);
 #ifdef R__FAST_MATH
    // Increasing tolerance due test fail for fast-math builds

--- a/root/io/filemerger/execTestMultiMerge.C
+++ b/root/io/filemerger/execTestMultiMerge.C
@@ -76,9 +76,11 @@ int execTestMultiMerge()
    result += testMergedFile("mzlibfile1-4.root",106,4917, kIs32bits ? 2 : 0);
    result += testSimpleFile("hsimple.root",25000,1,414415, kIs32bits ? 10 : 8);
    result += testSimpleFile("hsimple9.root",25000,9,432029,3);
-   result += testSimpleFile("hsimple101.root",25000,101,414590,3);
+   // Increasing tolerance due test fail for fast builds and i686
+   result += testSimpleFile("hsimple101.root",25000,101,414590, kIs32bits ? 10 : 8);
    result += testSimpleFile("hsimple106.root",25000,106,432127,3);
-   result += testSimpleFile("hsimple109.root",25000,109,432038,3);
+   // Increasing tolerance due test fail for fast builds (was 3)
+   result += testSimpleFile("hsimple109.root",25000,109,432038,4);
    result += testSimpleFile("hsimple9x2.root",2*25000,9,851123,9);
    result += testSimpleFile("hsimple109x2.root",2*25000,109,851134,9);
    result += testSimpleFile("hsimple209.root",25000,209,394077,8);

--- a/root/io/filemerger/execTestMultiMerge.C
+++ b/root/io/filemerger/execTestMultiMerge.C
@@ -1,4 +1,5 @@
 #include "TFile.h"
+#include <RConfig.h>
 
 extern "C" uint32_t lzma_version_number(void);
 
@@ -70,21 +71,31 @@ int testSimpleFile(const char *filename, Long64_t entries, Int_t compSetting, Lo
 int execTestMultiMerge()
 {
    Int_t result = 0;
-   int hsimpleFTolerance = 10; // 5 for non fst builds
+   // Increasing tolerance due test fail for aarch64 builds with native compiler
+   int hsimpleFTolerance = 10;
    result += testMergedFile("mzfile1-4.root",206,4992, kIs32bits ? 2 : 0);
    result += testMergedFile("mlz4file1-4.root",406,5029, kIs32bits ? 2 : 0);
    result += testMergedFile("mzlibfile1-4.root",106,4917, kIs32bits ? 2 : 0);
    result += testSimpleFile("hsimple.root",25000,1,414415, kIs32bits ? 10 : 8);
    result += testSimpleFile("hsimple9.root",25000,9,432029,3);
-   // Increasing tolerance due test fail for fast builds and i686
+   // Increasing tolerance due test fail for fast-math builds and i686
    result += testSimpleFile("hsimple101.root",25000,101,414590, kIs32bits ? 10 : 8);
    result += testSimpleFile("hsimple106.root",25000,106,432127,3);
-   // Increasing tolerance due test fail for fast builds (was 3)
+#ifdef R__FAST_MATH
+   // Increasing tolerance due test fail for fast-math builds
    result += testSimpleFile("hsimple109.root",25000,109,432038,4);
+#else
+   result += testSimpleFile("hsimple109.root",25000,109,432038,3);
+#endif
    result += testSimpleFile("hsimple9x2.root",2*25000,9,851123,9);
    result += testSimpleFile("hsimple109x2.root",2*25000,109,851134,9);
    result += testSimpleFile("hsimple209.root",25000,209,394077,8);
+#ifdef R__FAST_MATH
+   // Increasing tolerance due test fail for fast-math builds
+   result += testSimpleFile("hsimple401.root",25000,401,416534,14);
+#else
    result += testSimpleFile("hsimple401.root",25000,401,416534,8);
+#endif
    result += testSimpleFile("hsimple406.root",25000,406,516373,8);
    result += testSimpleFile("hsimple409.root",25000,409,516321,8);
    result += testSimpleFile("hsimpleK.root",6*25000,209,2298976,16);

--- a/root/io/filemerger/execTestMultiMerge.C
+++ b/root/io/filemerger/execTestMultiMerge.C
@@ -70,7 +70,7 @@ int testSimpleFile(const char *filename, Long64_t entries, Int_t compSetting, Lo
 int execTestMultiMerge()
 {
    Int_t result = 0;
-   int hsimpleFTolerance = 6; // 5 for non fst builds
+   int hsimpleFTolerance = 10; // 5 for non fst builds
    result += testMergedFile("mzfile1-4.root",206,4992, kIs32bits ? 2 : 0);
    result += testMergedFile("mlz4file1-4.root",406,5029, kIs32bits ? 2 : 0);
    result += testMergedFile("mzlibfile1-4.root",106,4917, kIs32bits ? 2 : 0);


### PR DESCRIPTION
Investigation doesn't show any data differences in histograms, comparison shows that for TH1F/TH2F was added extra bytes, not affecting data of histograms. Hsimple101.root reference was updated according hsimple.root (with hadd -f1 option and default ZLIB algorithm)