### PR TITLE
Explicitly test LZ4 in the existing compression tests.

### DIFF
--- a/root/io/compression/Makefile
+++ b/root/io/compression/Makefile
@@ -30,5 +30,7 @@ compressionTest: ./Event$(ExeSuf) ./libEvent.$(DllSuf)
 	$(CMDECHO)./Event 20 201 1 20  >> Event.read.log
 	$(CMDECHO)./Event 20 301 1  1  >> Event.write.log
 	$(CMDECHO)./Event 20 301 1 20  >> Event.read.log
+	$(CMDECHO)./Event 20 401 1  1  >> Event.write.log
+	$(CMDECHO)./Event 20 401 1 20  >> Event.read.log
 	$(CMDECHO)./Event 20   5 1  1  >> Event.write.log
 	$(CMDECHO)./Event 20   5 1 20  >> Event.read.log


### PR DESCRIPTION
Sadly, when I forcibly create corruptions in the files (causing the LZ4 checksum to fail), the unittest crashes instead of exiting cleanly.

Regardless, corruptions cause this test to fail.

This tweak was done for https://github.com/root-project/root/pull/907 -- but can go in independently of that PR.

@pcanal 