### PR TITLE
[TDF] Add test for handling of column re-Definition

### DIFF
--- a/root/dataframe/CMakeLists.txt
+++ b/root/dataframe/CMakeLists.txt
@@ -14,6 +14,11 @@ ROOTTEST_ADD_TEST(missingBranches
                   MACRO test_missingBranches.C
                   ERRREF test_missingBranches.eref)
 
+ROOTTEST_GENERATE_EXECUTABLE(test_columnoverride test_columnoverride.cxx LIBRARIES ${DFLIBRARIES})
+ROOTTEST_ADD_TEST(test_columnoverride
+                  EXEC test_columnoverride
+                  DEPENDS ${GENERATE_EXECUTABLE_TEST})
+
 ROOTTEST_GENERATE_EXECUTABLE(regression_ranges regression_ranges.cxx LIBRARIES ${DFLIBRARIES})
 ROOTTEST_ADD_TEST(regression_ranges
                   EXEC regression_ranges

--- a/root/dataframe/test_columnoverride.cxx
+++ b/root/dataframe/test_columnoverride.cxx
@@ -1,0 +1,43 @@
+// test that TDF correctly throws exceptions when users re-define a column already present in the dataframe
+#include "ROOT/TDataFrame.hxx"
+#include <stdexcept>
+#include <string>
+using namespace ROOT::Experimental;
+
+int main()
+{
+   auto exceptionCount = 0u;
+   const auto expectedExceptionCount = 2u;
+
+   // create tree
+   TDataFrame newd(1);
+   newd.Define("x", [] { return 1; }).Snapshot<int>("t", "coloverride.root", {"x"});
+
+   ROOT::Experimental::TDataFrame d("t", "coloverride.root");
+   // re-define TTree variable
+   try {
+      auto c = d.Define("x", [] { return 2; }).Count();
+   } catch (const std::runtime_error &e) {
+      std::string msg(e.what());
+      const auto expected_msg = "branch \"x\" already present in TTree";
+      if (msg.find(expected_msg) == std::string::npos)
+         throw;
+      exceptionCount++;
+   }
+
+   // re-define TTree variable (jitted `Define`)
+   try {
+      auto c = d.Define("x", "2").Count();
+   } catch (const std::runtime_error &e) {
+      std::string msg(e.what());
+      const auto expected_msg = "branch \"x\" already present in TTree";
+      if (msg.find(expected_msg) == std::string::npos)
+         throw;
+      exceptionCount++;
+   }
+
+   if (exceptionCount != expectedExceptionCount)
+      return 1;
+
+   return 0;
+}


### PR DESCRIPTION
It currently tests for `Define`s overriding a TTree branch.
It will be upgraded to also test for `Define`s overriding other
`Define`s as soon as we handle that case better.