### PR TITLE
[TDF] Upgrade tests after removal of "custom column"s from the functional graph

### DIFF
--- a/root/dataframe/test_columnoverride.cxx
+++ b/root/dataframe/test_columnoverride.cxx
@@ -7,7 +7,7 @@ using namespace ROOT::Experimental;
 int main()
 {
    auto exceptionCount = 0u;
-   const auto expectedExceptionCount = 2u;
+   const auto expectedExceptionCount = 4u;
 
    // create tree
    TDataFrame newd(1);
@@ -31,6 +31,28 @@ int main()
    } catch (const std::runtime_error &e) {
       std::string msg(e.what());
       const auto expected_msg = "branch \"x\" already present in TTree";
+      if (msg.find(expected_msg) == std::string::npos)
+         throw;
+      exceptionCount++;
+   }
+
+   // re-define `Define`d column
+   try {
+      auto c = d.Define("y", [] { return 0; }).Define("y", [] { return 1; }).Count();
+   } catch (const std::runtime_error &e) {
+      std::string msg(e.what());
+      const auto expected_msg = "Redefinition of column \"y\"";
+      if (msg.find(expected_msg) == std::string::npos)
+         throw;
+      exceptionCount++;
+   }
+
+   // re-define `Define`d column (with a jitted Define)
+   try {
+      auto c = d.Define("y", [] { return 0; }).Define("y", "1").Count();
+   } catch (const std::runtime_error &e) {
+      std::string msg(e.what());
+      const auto expected_msg = "Redefinition of column \"y\"";
       if (msg.find(expected_msg) == std::string::npos)
          throw;
       exceptionCount++;

--- a/root/dataframe/test_templateRecursionLimit.C
+++ b/root/dataframe/test_templateRecursionLimit.C
@@ -1,11 +1,11 @@
 // See https://root-forum.cern.ch/t/increase-template-recursion-depth-for-tdataframe-snapshot/25411/5
 
-using TDFDEF = ROOT::Experimental::TDF::TInterface<ROOT::Detail::TDF::TCustomColumnBase>;
-
-TDFDEF defineRecursive(TDFDEF& d, int n)
+using namespace ROOT::Experimental::TDF;
+using namespace ROOT::Detail::TDF;
+TInterface<TLoopManager> defineRecursive(TInterface<TLoopManager> &d, int n)
 {
     std::string name = "a_" + std::to_string(n);
-    auto d2 = TDFDEF(d.Define(name, [](){return 1.;}));
+    auto d2 = d.Define(name, [](){return 1.;});
     if (n == 1) return d2;
     return defineRecursive(d2, n - 1);
 }
@@ -13,7 +13,7 @@ TDFDEF defineRecursive(TDFDEF& d, int n)
 int test_templateRecursionLimit()
 {
     ROOT::Experimental::TDataFrame tdf(1);
-    TDFDEF d(tdf.Define("a_0", [](){return 1.;}));
+    auto d = tdf.Define("a_0", [](){return 1.;});
 
     auto d_final = defineRecursive(d, 96); //66 limit with 1024 on linux
 


### PR DESCRIPTION
Fix breakage introduced by [this PR](https://github.com/root-project/root/pull/924),
and test for redefinition of custom columns with the same name.