### PR TITLE
[TDF] Fix numeric_limits::min/lowest mismatch in regression test

### DIFF
--- a/root/dataframe/regression_zeroentries.cxx
+++ b/root/dataframe/regression_zeroentries.cxx
@@ -37,7 +37,7 @@ int main() {
    d.Foreach([&fc]() { ++fc; });
 
    assert(*min == std::numeric_limits<double>::max());
-   assert(*max == std::numeric_limits<double>::min());
+   assert(*max == std::numeric_limits<double>::lowest());
    assert(*mean == 0);
    assert(h->GetEntries() == 0);
    assert(*c == 0);


### PR DESCRIPTION
Test is expected to start failing after the fixes introduced by [979](https://github.com/root-project/root/pull/979).