### PR TITLE
Update constant for invalid compression algorithm.

### DIFF
--- a/root/io/compression/Event.cxx
+++ b/root/io/compression/Event.cxx
@@ -350,7 +350,7 @@ void Event::SetRandomVertex() {
 void Event::ShowLachaud() {
    
    vector<string>::iterator R__k;
-   printf("Lachaud vector has %d entries\n",fLachaud.size());
+   printf("Lachaud vector has %u entries\n", fLachaud.size());
    for (R__k = fLachaud.begin(); R__k != fLachaud.end(); ++R__k) {
       printf(" %s\n",(*R__k).c_str());
    }

--- a/root/io/compression/MainEvent.cxx
+++ b/root/io/compression/MainEvent.cxx
@@ -145,7 +145,7 @@ int main(int argc, char **argv)
    if (message->GetCompressionSettings() != 301) exit(153);
 
    message->SetCompressionSettings(202);
-   message->SetCompressionAlgorithm(4);
+   message->SetCompressionAlgorithm(99);
    if (message->GetCompressionSettings() != 2) exit(154);
 
    message->SetCompressionSettings(202);
@@ -156,7 +156,7 @@ int main(int argc, char **argv)
    message->SetCompressionLevel(-1);
    if (message->GetCompressionSettings() != 0) exit(156);
 
-   message->SetCompressionSettings(402);
+   message->SetCompressionSettings(9902);
    message->SetCompressionLevel(0);
    if (message->GetCompressionSettings() != 0) exit(157);
 
@@ -214,7 +214,7 @@ int main(int argc, char **argv)
    if (socket->GetCompressionSettings() != 301) exit(218);
 
    socket->SetCompressionSettings(202);
-   socket->SetCompressionAlgorithm(4);
+   socket->SetCompressionAlgorithm(99);
    if (socket->GetCompressionSettings() != 2) exit(219);
 
    socket->SetCompressionSettings(202);
@@ -225,7 +225,7 @@ int main(int argc, char **argv)
    socket->SetCompressionLevel(-1);
    if (socket->GetCompressionSettings() != 0) exit(221);
 
-   socket->SetCompressionSettings(402);
+   socket->SetCompressionSettings(9902);
    socket->SetCompressionLevel(0);
    if (socket->GetCompressionSettings() != 0) exit(222);
 
@@ -399,7 +399,7 @@ int main(int argc, char **argv)
       if (hfile->GetCompressionSettings() != 301) exit(18);
 
       hfile->SetCompressionSettings(202);
-      hfile->SetCompressionAlgorithm(4);
+      hfile->SetCompressionAlgorithm(99);
       if (hfile->GetCompressionSettings() != 2) exit(19);
 
       hfile->SetCompressionSettings(202);
@@ -410,7 +410,7 @@ int main(int argc, char **argv)
       hfile->SetCompressionLevel(-1);
       if (hfile->GetCompressionSettings() != 0) exit(21);
 
-      hfile->SetCompressionSettings(402);
+      hfile->SetCompressionSettings(9902);
       hfile->SetCompressionLevel(0);
       if (hfile->GetCompressionSettings() != 0) exit(22);
 
@@ -482,7 +482,7 @@ int main(int argc, char **argv)
       if (testBranch->GetCompressionSettings() != 301) exit(118);
 
       testBranch->SetCompressionSettings(202);
-      testBranch->SetCompressionAlgorithm(4);
+      testBranch->SetCompressionAlgorithm(99);
       if (testBranch->GetCompressionSettings() != 2) exit(119);
 
       testBranch->SetCompressionSettings(202);
@@ -493,7 +493,7 @@ int main(int argc, char **argv)
       testBranch->SetCompressionLevel(-1);
       if (testBranch->GetCompressionSettings() != 0) exit(121);
 
-      testBranch->SetCompressionSettings(402);
+      testBranch->SetCompressionSettings(9902);
       testBranch->SetCompressionLevel(0);
       if (testBranch->GetCompressionSettings() != 0) exit(122);
 

--- a/root/io/filemerger/execTestMultiMerge.C
+++ b/root/io/filemerger/execTestMultiMerge.C
@@ -79,7 +79,11 @@ int execTestMultiMerge()
    result += testSimpleFile("hsimple.root",25000,1,414415, kIs32bits ? 10 : 8);
    result += testSimpleFile("hsimple9.root",25000,9,432029,3);
    // Increasing tolerance due test fail for fast-math builds and i686
-   result += testSimpleFile("hsimple101.root",25000,101,414590, kIs32bits ? 10 : 8);
+#ifdef R__FAST_MATH
+   result += testSimpleFile("hsimple101.root",25000,101,414590, 10);
+#else
+   result += testSimpleFile("hsimple101.root",25000,101,414590, kIs32bits ? 12 : 3);   
+#endif
    result += testSimpleFile("hsimple106.root",25000,106,432127,3);
 #ifdef R__FAST_MATH
    // Increasing tolerance due test fail for fast-math builds

--- a/root/io/filemerger/execTestMultiMerge.C
+++ b/root/io/filemerger/execTestMultiMerge.C
@@ -76,9 +76,11 @@ int execTestMultiMerge()
    result += testMergedFile("mzlibfile1-4.root",106,4917, kIs32bits ? 2 : 0);
    result += testSimpleFile("hsimple.root",25000,1,414415, kIs32bits ? 10 : 8);
    result += testSimpleFile("hsimple9.root",25000,9,432029,3);
-   result += testSimpleFile("hsimple101.root",25000,101,414590,3);
+   // Increasing tolerance due test fail for fast builds and i686
+   result += testSimpleFile("hsimple101.root",25000,101,414590, kIs32bits ? 10 : 8);
    result += testSimpleFile("hsimple106.root",25000,106,432127,3);
-   result += testSimpleFile("hsimple109.root",25000,109,432038,3);
+   // Increasing tolerance due test fail for fast builds (was 3)
+   result += testSimpleFile("hsimple109.root",25000,109,432038,4);
    result += testSimpleFile("hsimple9x2.root",2*25000,9,851123,9);
    result += testSimpleFile("hsimple109x2.root",2*25000,109,851134,9);
    result += testSimpleFile("hsimple209.root",25000,209,394077,8);

--- a/root/io/filemerger/execTestMultiMerge.C
+++ b/root/io/filemerger/execTestMultiMerge.C
@@ -1,4 +1,5 @@
 #include "TFile.h"
+#include <RConfig.h>
 
 extern "C" uint32_t lzma_version_number(void);
 
@@ -70,21 +71,31 @@ int testSimpleFile(const char *filename, Long64_t entries, Int_t compSetting, Lo
 int execTestMultiMerge()
 {
    Int_t result = 0;
-   int hsimpleFTolerance = 10; // 5 for non fst builds
+   // Increasing tolerance due test fail for aarch64 builds with native compiler
+   int hsimpleFTolerance = 10;
    result += testMergedFile("mzfile1-4.root",206,4992, kIs32bits ? 2 : 0);
    result += testMergedFile("mlz4file1-4.root",406,5029, kIs32bits ? 2 : 0);
    result += testMergedFile("mzlibfile1-4.root",106,4917, kIs32bits ? 2 : 0);
    result += testSimpleFile("hsimple.root",25000,1,414415, kIs32bits ? 10 : 8);
    result += testSimpleFile("hsimple9.root",25000,9,432029,3);
-   // Increasing tolerance due test fail for fast builds and i686
+   // Increasing tolerance due test fail for fast-math builds and i686
    result += testSimpleFile("hsimple101.root",25000,101,414590, kIs32bits ? 10 : 8);
    result += testSimpleFile("hsimple106.root",25000,106,432127,3);
-   // Increasing tolerance due test fail for fast builds (was 3)
+#ifdef R__FAST_MATH
+   // Increasing tolerance due test fail for fast-math builds
    result += testSimpleFile("hsimple109.root",25000,109,432038,4);
+#else
+   result += testSimpleFile("hsimple109.root",25000,109,432038,3);
+#endif
    result += testSimpleFile("hsimple9x2.root",2*25000,9,851123,9);
    result += testSimpleFile("hsimple109x2.root",2*25000,109,851134,9);
    result += testSimpleFile("hsimple209.root",25000,209,394077,8);
+#ifdef R__FAST_MATH
+   // Increasing tolerance due test fail for fast-math builds
+   result += testSimpleFile("hsimple401.root",25000,401,416534,14);
+#else
    result += testSimpleFile("hsimple401.root",25000,401,416534,8);
+#endif
    result += testSimpleFile("hsimple406.root",25000,406,516373,8);
    result += testSimpleFile("hsimple409.root",25000,409,516321,8);
    result += testSimpleFile("hsimpleK.root",6*25000,209,2298976,16);

--- a/root/io/filemerger/execTestMultiMerge.C
+++ b/root/io/filemerger/execTestMultiMerge.C
@@ -1,5 +1,5 @@
 #include "TFile.h"
-#include <RConfig.h>
+#include "RConfig.h"
 
 extern "C" uint32_t lzma_version_number(void);
 

--- a/root/io/filemerger/execTestMultiMerge.C
+++ b/root/io/filemerger/execTestMultiMerge.C
@@ -70,7 +70,7 @@ int testSimpleFile(const char *filename, Long64_t entries, Int_t compSetting, Lo
 int execTestMultiMerge()
 {
    Int_t result = 0;
-   int hsimpleFTolerance = 6; // 5 for non fst builds
+   int hsimpleFTolerance = 10; // 5 for non fst builds
    result += testMergedFile("mzfile1-4.root",206,4992, kIs32bits ? 2 : 0);
    result += testMergedFile("mlz4file1-4.root",406,5029, kIs32bits ? 2 : 0);
    result += testMergedFile("mzlibfile1-4.root",106,4917, kIs32bits ? 2 : 0);


### PR DESCRIPTION
Previously, `4` was used to indicate an invalid compression algorithm
number.

Bump this in preparation for assigning compression algorithm `4`
to LZ4.