### PR TITLE
Update the reference `TTree::Print` outputs.

### DIFF
--- a/root/io/treeForeign/testForeignDraw.ref
+++ b/root/io/treeForeign/testForeignDraw.ref
@@ -10,23 +10,23 @@ Warning in <TClass::Init>: no dictionary for class MyClass is available
 *Entries :        2 : BranchElement (see below)                              *
 *............................................................................*
 *Br    0 :myvar     : Int_t                                                  *
-*Entries :        2 : Total  Size=        555 bytes  File Size  =         77 *
+*Entries :        2 : Total  Size=        566 bytes  File Size  =         77 *
 *Baskets :        1 : Basket Size=      32000 bytes  Compression=   1.00     *
 *............................................................................*
 *Br    1 :arr       : Int_t arr_                                             *
-*Entries :        2 : Total  Size=       2699 bytes  File Size  =         91 *
+*Entries :        2 : Total  Size=       2754 bytes  File Size  =         91 *
 *Baskets :        1 : Basket Size=      32000 bytes  Compression=   1.00     *
 *............................................................................*
 *Br    2 :arr.fUniqueID : UInt_t fUniqueID[arr_]                             *
-*Entries :        2 : Total  Size=        691 bytes  File Size  =        106 *
+*Entries :        2 : Total  Size=        702 bytes  File Size  =        106 *
 *Baskets :        1 : Basket Size=      32000 bytes  Compression=   1.03     *
 *............................................................................*
 *Br    3 :arr.fBits : UInt_t fBits[arr_]                                     *
-*Entries :        2 : Total  Size=        671 bytes  File Size  =        104 *
+*Entries :        2 : Total  Size=        682 bytes  File Size  =        104 *
 *Baskets :        1 : Basket Size=      32000 bytes  Compression=   1.01     *
 *............................................................................*
 *Br    4 :arr.chunk : MyClass* chunk[arr_]                                   *
-*Entries :        2 : Total  Size=        759 bytes  File Size  =        147 *
+*Entries :        2 : Total  Size=        770 bytes  File Size  =        147 *
 *Baskets :        1 : Basket Size=      32000 bytes  Compression=   1.31     *
 *............................................................................*
 ************************

--- a/root/io/treeproblem/writer.ref
+++ b/root/io/treeproblem/writer.ref
@@ -2,23 +2,23 @@
 Processing writer.C...
 ******************************************************************************
 *Tree    :tree      : tree                                                   *
-*Entries :      100 : Total =            8722 bytes  File  Size =          0 *
+*Entries :      100 : Total =            8777 bytes  File  Size =          0 *
 *        :          : Tree compression factor =   1.00                       *
 ******************************************************************************
 *Br    0 :foo       : Int_t foo_                                             *
-*Entries :      100 : Total  Size=       8846 bytes  One basket in memory    *
+*Entries :      100 : Total  Size=       8901 bytes  One basket in memory    *
 *Baskets :        0 : Basket Size=      32000 bytes  Compression=   1.00     *
 *............................................................................*
 *Br    1 :foo.fUniqueID : UInt_t fUniqueID[foo_]                             *
-*Entries :      100 : Total  Size=       2362 bytes  One basket in memory    *
+*Entries :      100 : Total  Size=       2373 bytes  One basket in memory    *
 *Baskets :        0 : Basket Size=      32000 bytes  Compression=   1.00     *
 *............................................................................*
 *Br    2 :foo.fBits : UInt_t fBits[foo_]                                     *
-*Entries :      100 : Total  Size=       2338 bytes  One basket in memory    *
+*Entries :      100 : Total  Size=       2349 bytes  One basket in memory    *
 *Baskets :        0 : Basket Size=      32000 bytes  Compression=   1.00     *
 *............................................................................*
 *Br    3 :foo.fFoo  : Int_t fFoo[foo_]                                       *
-*Entries :      100 : Total  Size=       2332 bytes  One basket in memory    *
+*Entries :      100 : Total  Size=       2343 bytes  One basket in memory    *
 *Baskets :        0 : Basket Size=      32000 bytes  Compression=   1.00     *
 *............................................................................*
 (int) 0

--- a/root/tree/chain/subdir.ref
+++ b/root/tree/chain/subdir.ref
@@ -9,11 +9,11 @@ OBJ: TChain	tree	 : 0
 ******************************************************************************
 ******************************************************************************
 *Tree    :tree      : tree                                                   *
-*Entries :        3 : Total =             874 bytes  File  Size =        395 *
+*Entries :        3 : Total =             896 bytes  File  Size =        395 *
 *        :          : Tree compression factor =   1.00                       *
 ******************************************************************************
 *Br    0 :var       : var/I                                                  *
-*Entries :        3 : Total  Size=        548 bytes  File Size  =         82 *
+*Entries :        3 : Total  Size=        559 bytes  File Size  =         82 *
 *Baskets :        1 : Basket Size=        100 bytes  Compression=   1.00     *
 *............................................................................*
 Trying subdir.root/data2.root
@@ -24,11 +24,11 @@ OBJ: TChain	tree	 : 0
 ******************************************************************************
 ******************************************************************************
 *Tree    :tree      : tree                                                   *
-*Entries :        3 : Total =             874 bytes  File  Size =        395 *
+*Entries :        3 : Total =             896 bytes  File  Size =        395 *
 *        :          : Tree compression factor =   1.00                       *
 ******************************************************************************
 *Br    0 :var       : var/I                                                  *
-*Entries :        3 : Total  Size=        548 bytes  File Size  =         82 *
+*Entries :        3 : Total  Size=        559 bytes  File Size  =         82 *
 *Baskets :        1 : Basket Size=        100 bytes  Compression=   1.00     *
 *............................................................................*
 TChain::Add
@@ -41,11 +41,11 @@ OBJ: TChain	tree	 : 0
 ******************************************************************************
 ******************************************************************************
 *Tree    :tree      : tree                                                   *
-*Entries :        3 : Total =             874 bytes  File  Size =        395 *
+*Entries :        3 : Total =             896 bytes  File  Size =        395 *
 *        :          : Tree compression factor =   1.00                       *
 ******************************************************************************
 *Br    0 :var       : var/I                                                  *
-*Entries :        3 : Total  Size=        548 bytes  File Size  =         82 *
+*Entries :        3 : Total  Size=        559 bytes  File Size  =         82 *
 *Baskets :        1 : Basket Size=        100 bytes  Compression=   1.00     *
 *............................................................................*
 ******************************************************************************
@@ -53,11 +53,11 @@ OBJ: TChain	tree	 : 0
 ******************************************************************************
 ******************************************************************************
 *Tree    :tree      : tree                                                   *
-*Entries :        3 : Total =             874 bytes  File  Size =        395 *
+*Entries :        3 : Total =             896 bytes  File  Size =        395 *
 *        :          : Tree compression factor =   1.00                       *
 ******************************************************************************
 *Br    0 :var       : var/I                                                  *
-*Entries :        3 : Total  Size=        548 bytes  File Size  =         82 *
+*Entries :        3 : Total  Size=        559 bytes  File Size  =         82 *
 *Baskets :        1 : Basket Size=        100 bytes  Compression=   1.00     *
 *............................................................................*
 Trying subdir.root/data*.root/tree
@@ -69,11 +69,11 @@ OBJ: TChain	tree	 : 0
 ******************************************************************************
 ******************************************************************************
 *Tree    :tree      : tree                                                   *
-*Entries :        3 : Total =             874 bytes  File  Size =        395 *
+*Entries :        3 : Total =             896 bytes  File  Size =        395 *
 *        :          : Tree compression factor =   1.00                       *
 ******************************************************************************
 *Br    0 :var       : var/I                                                  *
-*Entries :        3 : Total  Size=        548 bytes  File Size  =         82 *
+*Entries :        3 : Total  Size=        559 bytes  File Size  =         82 *
 *Baskets :        1 : Basket Size=        100 bytes  Compression=   1.00     *
 *............................................................................*
 ******************************************************************************
@@ -81,11 +81,11 @@ OBJ: TChain	tree	 : 0
 ******************************************************************************
 ******************************************************************************
 *Tree    :tree      : tree                                                   *
-*Entries :        3 : Total =             874 bytes  File  Size =        395 *
+*Entries :        3 : Total =             896 bytes  File  Size =        395 *
 *        :          : Tree compression factor =   1.00                       *
 ******************************************************************************
 *Br    0 :var       : var/I                                                  *
-*Entries :        3 : Total  Size=        548 bytes  File Size  =         82 *
+*Entries :        3 : Total  Size=        559 bytes  File Size  =         82 *
 *Baskets :        1 : Basket Size=        100 bytes  Compression=   1.00     *
 *............................................................................*
 Trying subdir.root/data1.root/tree
@@ -96,11 +96,11 @@ OBJ: TChain	tree	 : 0
 ******************************************************************************
 ******************************************************************************
 *Tree    :tree      : tree                                                   *
-*Entries :        3 : Total =             874 bytes  File  Size =        395 *
+*Entries :        3 : Total =             896 bytes  File  Size =        395 *
 *        :          : Tree compression factor =   1.00                       *
 ******************************************************************************
 *Br    0 :var       : var/I                                                  *
-*Entries :        3 : Total  Size=        548 bytes  File Size  =         82 *
+*Entries :        3 : Total  Size=        559 bytes  File Size  =         82 *
 *Baskets :        1 : Basket Size=        100 bytes  Compression=   1.00     *
 *............................................................................*
 Trying subdir.root/data2.root
@@ -111,10 +111,10 @@ OBJ: TChain	tree	 : 0
 ******************************************************************************
 ******************************************************************************
 *Tree    :tree      : tree                                                   *
-*Entries :        3 : Total =             874 bytes  File  Size =        395 *
+*Entries :        3 : Total =             896 bytes  File  Size =        395 *
 *        :          : Tree compression factor =   1.00                       *
 ******************************************************************************
 *Br    0 :var       : var/I                                                  *
-*Entries :        3 : Total  Size=        548 bytes  File Size  =         82 *
+*Entries :        3 : Total  Size=        559 bytes  File Size  =         82 *
 *Baskets :        1 : Basket Size=        100 bytes  Compression=   1.00     *
 *............................................................................*

--- a/root/tree/cloning/exectrim.ref
+++ b/root/tree/cloning/exectrim.ref
@@ -38,91 +38,91 @@ Warning in <TClass::Init>: no dictionary for class Belle2::ModuleStatistics is a
 Warning in <TClass::Init>: no dictionary for class Belle2::CalcMeanCov<2,double> is available
 ******************************************************************************
 *Tree    :tree      : tree                                                   *
-*Entries :       10 : Total =            8885 bytes  File  Size =       1668 *
+*Entries :       10 : Total =            8907 bytes  File  Size =       1681 *
 *        :          : Tree compression factor =   1.30                       *
 ******************************************************************************
 *Br    0 :StrSimHits : Int_t StrSimHits_                                     *
-*Entries :       10 : Total  Size=        674 bytes  File Size  =        127 *
+*Entries :       10 : Total  Size=        685 bytes  File Size  =        127 *
 *Baskets :        1 : Basket Size=      32000 bytes  Compression=   1.30     *
 *............................................................................*
 ******************************************************************************
 *Tree    :tree      : tree                                                   *
-*Entries :       10 : Total =           22463 bytes  File  Size =       5362 *
+*Entries :       10 : Total =           22683 bytes  File  Size =       5406 *
 *        :          : Tree compression factor =   1.18                       *
 ******************************************************************************
 *Br    0 :StrSimHits : Int_t StrSimHits_                                     *
-*Entries :       10 : Total  Size=      12266 bytes  File Size  =        127 *
+*Entries :       10 : Total  Size=      12486 bytes  File Size  =        127 *
 *Baskets :        1 : Basket Size=      32000 bytes  Compression=   1.30     *
 *............................................................................*
 *Br    1 :StrSimHits.fUniqueID : UInt_t fUniqueID[StrSimHits_]               *
-*Entries :       10 : Total  Size=        767 bytes  File Size  =        115 *
+*Entries :       10 : Total  Size=        778 bytes  File Size  =        115 *
 *Baskets :        1 : Basket Size=       4654 bytes  Compression=   1.17     *
 *............................................................................*
 *Br    2 :StrSimHits.fBits : UInt_t fBits[StrSimHits_]                       *
-*Entries :       10 : Total  Size=        747 bytes  File Size  =        111 *
+*Entries :       10 : Total  Size=        758 bytes  File Size  =        111 *
 *Baskets :        1 : Basket Size=       4654 bytes  Compression=   1.18     *
 *............................................................................*
 *Br    3 :StrSimHits.m_backgroundTag : UShort_t m_backgroundTag[StrSimHits_] *
-*Entries :       10 : Total  Size=        797 bytes  File Size  =        121 *
+*Entries :       10 : Total  Size=        808 bytes  File Size  =        121 *
 *Baskets :        1 : Basket Size=       4654 bytes  Compression=   1.17     *
 *............................................................................*
 *Br    4 :StrSimHits.m_CellId : Int_t m_CellId[StrSimHits_]                  *
-*Entries :       10 : Total  Size=        762 bytes  File Size  =        114 *
+*Entries :       10 : Total  Size=        773 bytes  File Size  =        114 *
 *Baskets :        1 : Basket Size=       4654 bytes  Compression=   1.18     *
 *............................................................................*
 *Br    5 :StrSimHits.m_TrackId : Int_t m_TrackId[StrSimHits_]                *
-*Entries :       10 : Total  Size=        767 bytes  File Size  =        115 *
+*Entries :       10 : Total  Size=        778 bytes  File Size  =        115 *
 *Baskets :        1 : Basket Size=       4654 bytes  Compression=   1.17     *
 *............................................................................*
 *Br    6 :StrSimHits.m_Pdg : Int_t m_Pdg[StrSimHits_]                        *
-*Entries :       10 : Total  Size=        747 bytes  File Size  =        111 *
+*Entries :       10 : Total  Size=        758 bytes  File Size  =        111 *
 *Baskets :        1 : Basket Size=       4654 bytes  Compression=   1.18     *
 *............................................................................*
 *Br    7 :StrSimHits.m_FlightTime : Float_t m_FlightTime[StrSimHits_]        *
-*Entries :       10 : Total  Size=        782 bytes  File Size  =        118 *
+*Entries :       10 : Total  Size=        793 bytes  File Size  =        118 *
 *Baskets :        1 : Basket Size=       4654 bytes  Compression=   1.17     *
 *............................................................................*
 *Br    8 :StrSimHits.m_Edep : Float_t m_Edep[StrSimHits_]                    *
-*Entries :       10 : Total  Size=        752 bytes  File Size  =        112 *
+*Entries :       10 : Total  Size=        763 bytes  File Size  =        112 *
 *Baskets :        1 : Basket Size=       4654 bytes  Compression=   1.18     *
 *............................................................................*
 *Br    9 :StrSimHits.m_Momentum.fUniqueID : UInt_t fUniqueID[StrSimHits_]    *
-*Entries :       10 : Total  Size=        800 bytes  File Size  =        126 *
+*Entries :       10 : Total  Size=        811 bytes  File Size  =        126 *
 *Baskets :        1 : Basket Size=       4654 bytes  Compression=   1.16     *
 *............................................................................*
 *Br   10 :StrSimHits.m_Momentum.fBits : UInt_t fBits[StrSimHits_]            *
-*Entries :       10 : Total  Size=        780 bytes  File Size  =        122 *
+*Entries :       10 : Total  Size=        791 bytes  File Size  =        122 *
 *Baskets :        1 : Basket Size=       4654 bytes  Compression=   1.16     *
 *............................................................................*
 *Br   11 :StrSimHits.m_Momentum.fX : Double_t fX[StrSimHits_]                *
-*Entries :       10 : Total  Size=        765 bytes  File Size  =        119 *
+*Entries :       10 : Total  Size=        776 bytes  File Size  =        119 *
 *Baskets :        1 : Basket Size=       4654 bytes  Compression=   1.17     *
 *............................................................................*
 *Br   12 :StrSimHits.m_Momentum.fY : Double_t fY[StrSimHits_]                *
-*Entries :       10 : Total  Size=        765 bytes  File Size  =        119 *
+*Entries :       10 : Total  Size=        776 bytes  File Size  =        119 *
 *Baskets :        1 : Basket Size=       4654 bytes  Compression=   1.17     *
 *............................................................................*
 *Br   13 :StrSimHits.m_Momentum.fZ : Double_t fZ[StrSimHits_]                *
-*Entries :       10 : Total  Size=        765 bytes  File Size  =        119 *
+*Entries :       10 : Total  Size=        776 bytes  File Size  =        119 *
 *Baskets :        1 : Basket Size=       4654 bytes  Compression=   1.17     *
 *............................................................................*
 *Br   14 :StrSimHits.m_Position.fUniqueID : UInt_t fUniqueID[StrSimHits_]    *
-*Entries :       10 : Total  Size=        800 bytes  File Size  =        126 *
+*Entries :       10 : Total  Size=        811 bytes  File Size  =        126 *
 *Baskets :        1 : Basket Size=       4654 bytes  Compression=   1.16     *
 *............................................................................*
 *Br   15 :StrSimHits.m_Position.fBits : UInt_t fBits[StrSimHits_]            *
-*Entries :       10 : Total  Size=        780 bytes  File Size  =        122 *
+*Entries :       10 : Total  Size=        791 bytes  File Size  =        122 *
 *Baskets :        1 : Basket Size=       4654 bytes  Compression=   1.16     *
 *............................................................................*
 *Br   16 :StrSimHits.m_Position.fX : Double_t fX[StrSimHits_]                *
-*Entries :       10 : Total  Size=        765 bytes  File Size  =        119 *
+*Entries :       10 : Total  Size=        776 bytes  File Size  =        119 *
 *Baskets :        1 : Basket Size=       4654 bytes  Compression=   1.17     *
 *............................................................................*
 *Br   17 :StrSimHits.m_Position.fY : Double_t fY[StrSimHits_]                *
-*Entries :       10 : Total  Size=        765 bytes  File Size  =        119 *
+*Entries :       10 : Total  Size=        776 bytes  File Size  =        119 *
 *Baskets :        1 : Basket Size=       4654 bytes  Compression=   1.17     *
 *............................................................................*
 *Br   18 :StrSimHits.m_Position.fZ : Double_t fZ[StrSimHits_]                *
-*Entries :       10 : Total  Size=        765 bytes  File Size  =        119 *
+*Entries :       10 : Total  Size=        776 bytes  File Size  =        119 *
 *Baskets :        1 : Basket Size=       4654 bytes  Compression=   1.17     *
 *............................................................................*

--- a/root/tree/readcin/readcin.ref
+++ b/root/tree/readcin/readcin.ref
@@ -1,29 +1,29 @@
 ******************************************************************************
 *Tree    :test      : test                                                   *
-*Entries :      101 : Total =            6773 bytes  File  Size =          0 *
+*Entries :      101 : Total =            6850 bytes  File  Size =          0 *
 *        :          : Tree compression factor =   1.00                       *
 ******************************************************************************
 *Br    0 :EventNumber : EventNumber/F                                        *
-*Entries :      101 : Total  Size=       1074 bytes  One basket in memory    *
+*Entries :      101 : Total  Size=       1085 bytes  One basket in memory    *
 *Baskets :        0 : Basket Size=      32000 bytes  Compression=   1.00     *
 *............................................................................*
 *Br    1 :mg_reweight_1 : mg_reweight_1/F                                    *
-*Entries :      101 : Total  Size=       1086 bytes  One basket in memory    *
+*Entries :      101 : Total  Size=       1097 bytes  One basket in memory    *
 *Baskets :        0 : Basket Size=      32000 bytes  Compression=   1.00     *
 *............................................................................*
 *Br    2 :mg_reweight_2 : mg_reweight_2/F                                    *
-*Entries :      101 : Total  Size=       1086 bytes  One basket in memory    *
+*Entries :      101 : Total  Size=       1097 bytes  One basket in memory    *
 *Baskets :        0 : Basket Size=      32000 bytes  Compression=   1.00     *
 *............................................................................*
 *Br    3 :mg_reweight_3 : mg_reweight_3/F                                    *
-*Entries :      101 : Total  Size=       1086 bytes  One basket in memory    *
+*Entries :      101 : Total  Size=       1097 bytes  One basket in memory    *
 *Baskets :        0 : Basket Size=      32000 bytes  Compression=   1.00     *
 *............................................................................*
 *Br    4 :mg_reweight_4 : mg_reweight_4/F                                    *
-*Entries :      101 : Total  Size=       1086 bytes  One basket in memory    *
+*Entries :      101 : Total  Size=       1097 bytes  One basket in memory    *
 *Baskets :        0 : Basket Size=      32000 bytes  Compression=   1.00     *
 *............................................................................*
 *Br    5 :mg_reweight_5 : mg_reweight_5/F                                    *
-*Entries :      101 : Total  Size=       1086 bytes  One basket in memory    *
+*Entries :      101 : Total  Size=       1097 bytes  One basket in memory    *
 *Baskets :        0 : Basket Size=      32000 bytes  Compression=   1.00     *
 *............................................................................*

--- a/root/tree/split/execUnrollWithConst.ref
+++ b/root/tree/split/execUnrollWithConst.ref
@@ -2,36 +2,36 @@
 Processing execUnrollWithConst.cxx+...
 ******************************************************************************
 *Tree    :T         : T                                                      *
-*Entries :        0 : Total =            4494 bytes  File  Size =          0 *
+*Entries :        0 : Total =            4593 bytes  File  Size =          0 *
 *        :          : Tree compression factor =   1.00                       *
 ******************************************************************************
 *Branch  :object                                                             *
 *Entries :        0 : BranchElement (see below)                              *
 *............................................................................*
 *Br    0 :fValue    :                                                        *
-*Entries :        0 : Total  Size=       1521 bytes  One basket in memory    *
+*Entries :        0 : Total  Size=       1554 bytes  One basket in memory    *
 *Baskets :        0 : Basket Size=      32000 bytes  Compression=   1.00     *
 *............................................................................*
 *Br    1 :fValue.fOne : Int_t                                                *
-*Entries :        0 : Total  Size=        502 bytes  One basket in memory    *
+*Entries :        0 : Total  Size=        513 bytes  One basket in memory    *
 *Baskets :        0 : Basket Size=      32000 bytes  Compression=   1.00     *
 *............................................................................*
 *Br    2 :fValue.fTwo : Int_t                                                *
-*Entries :        0 : Total  Size=        502 bytes  One basket in memory    *
+*Entries :        0 : Total  Size=        513 bytes  One basket in memory    *
 *Baskets :        0 : Basket Size=      32000 bytes  Compression=   1.00     *
 *............................................................................*
 *Branch  :wrapper                                                            *
 *Entries :        0 : BranchElement (see below)                              *
 *............................................................................*
 *Br    3 :fObj      :                                                        *
-*Entries :        0 : Total  Size=       1553 bytes  One basket in memory    *
+*Entries :        0 : Total  Size=       1586 bytes  One basket in memory    *
 *Baskets :        0 : Basket Size=      32000 bytes  Compression=   1.00     *
 *............................................................................*
 *Br    4 :fObj.fValue.fOne : Int_t                                           *
-*Entries :        0 : Total  Size=        522 bytes  One basket in memory    *
+*Entries :        0 : Total  Size=        533 bytes  One basket in memory    *
 *Baskets :        0 : Basket Size=      32000 bytes  Compression=   1.00     *
 *............................................................................*
 *Br    5 :fObj.fValue.fTwo : Int_t                                           *
-*Entries :        0 : Total  Size=        522 bytes  One basket in memory    *
+*Entries :        0 : Total  Size=        533 bytes  One basket in memory    *
 *Baskets :        0 : Basket Size=      32000 bytes  Compression=   1.00     *
 *............................................................................*


### PR DESCRIPTION
When `TIOFeatures` was serialized as part of the `TTree` and `TBranch`, it changed the number of bytes in the files -- requiring an update to the relevant tests.

Should fix the test failures in https://github.com/root-project/root/pull/1217

@pcanal 