### PR TITLE
[TDF] Adapt test_reduce after removal of one overload

### DIFF
--- a/root/dataframe/test_reduce.C
+++ b/root/dataframe/test_reduce.C
@@ -41,7 +41,7 @@ void test_reduce() {
    ROOT::Experimental::TDataFrame d("reduceTree", fileName, {"i"});
    auto r = d.Reduce([](int a, int b) { return a + b; }, {"i"});
    auto rDefBranch = d.Filter([]() { return true; })
-                      .Reduce([](int a, int b) { return a*b; }, 1);
+                      .Reduce([](int a, int b) { return a*b; }, "", 1);
    auto rNoDefCtor = d.Reduce(
       [](const NoDefCtor& a, const NoDefCtor& b) { return NoDefCtor(a.GetInt() + b.GetInt()); },
       {"o"},


### PR DESCRIPTION
The breaking change has been introduced by a PR in root [here](https://github.com/root-project/root/pull/1473).