### PR TITLE
Fix root/multicore/ttree/read_imt, libImt started with 6.10

### DIFF
--- a/root/multicore/CMakeLists.txt
+++ b/root/multicore/CMakeLists.txt
@@ -133,7 +133,7 @@ if(ROOT_imt_FOUND)
    ROOTTEST_ADD_TEST(generate_imt_tree
                      MACRO generate_imt_tree.C+)
 
-   ROOTTEST_GENERATE_EXECUTABLE(ttree_read_imt ttree_read_imt.cpp LIBRARIES Core Thread Tree RIO Imt)
+   ROOTTEST_GENERATE_EXECUTABLE(ttree_read_imt ttree_read_imt.cpp LIBRARIES Core Thread Tree RIO)
 
    ROOTTEST_ADD_TEST(ttree_read_imt
                      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/ttree_read_imt.sh


### PR DESCRIPTION
Bug introduced by commit 90e787de1b0811759f6628e3070d72785718e8b1.