### PR TITLE
Update references for root/io/filemerger test

### DIFF
--- a/root/io/filemerger/execTestMultiMerge.C
+++ b/root/io/filemerger/execTestMultiMerge.C
@@ -79,14 +79,14 @@ int execTestMultiMerge()
 #endif
    Int_t result = 0;
    int hsimpleFTolerance = 16;
-   result += testMergedFile("mzfile1-4.root",206,5051 + kIs32bits*2, kIs32bits ? 2 : 0);
-   result += testMergedFile("mlz4file1-4.root",406,5089 + kIs32bits*2, kIs32bits ? 2 : 0);
-   result += testMergedFile("mzlibfile1-4.root",106,4978 + kIs32bits*2, kIs32bits ? 2 : 0);
+   result += testMergedFile("mzfile1-4.root",206,5032 + kIs32bits*2, kIs32bits ? 2 : 0);
+   result += testMergedFile("mlz4file1-4.root",406,5070 + kIs32bits*2, kIs32bits ? 2 : 0);
+   result += testMergedFile("mzlibfile1-4.root",106,4959 + kIs32bits*2, kIs32bits ? 2 : 0);
    result += testSimpleFile("hsimple.root",25000,1,414668 + kIs32bits*2, kIs32bits ? (12 + fastMath*10) : (8 + fastMath*10));
-   result += testSimpleFile("hsimple9.root",25000,9,432268 + kIs32bits*10,3 + fastMath*27);
-   result += testSimpleFile("hsimple101.root",25000,101,414856, kIs32bits ? 12 : (3 + fastMath*14));
-   result += testSimpleFile("hsimple106.root",25000,106,432377 + kIs32bits*4,3 + fastMath*20);
-   result += testSimpleFile("hsimple109.root",25000,109,432278 + kIs32bits*10,3 + fastMath*28);
+   result += testSimpleFile("hsimple9.root",25000,9,432262 + kIs32bits*10,3 + fastMath*27);
+   result += testSimpleFile("hsimple101.root",25000,101,414848, kIs32bits ? 12 : (3 + fastMath*14));
+   result += testSimpleFile("hsimple106.root",25000,106,432370 + kIs32bits*4,3 + fastMath*20);
+   result += testSimpleFile("hsimple109.root",25000,109,432271 + kIs32bits*10,3 + fastMath*28);
    result += testSimpleFile("hsimple9x2.root",2*25000,9,851376 + kIs32bits*10,9 + fastMath*56);
    result += testSimpleFile("hsimple109x2.root",2*25000,109,851386 + kIs32bits*5,9 + fastMath*52);
    result += testSimpleFile("hsimple209.root",25000,209,394306,8 + fastMath*24);


### PR DESCRIPTION
The references shifted due to a change introduced by commit
4d26ab79cae22e598834dd2b95d4f5b266be8589 in root.git.