### PR TITLE
Try again to use a system version of pytest if available

### DIFF
--- a/python/common.py
+++ b/python/common.py
@@ -10,11 +10,13 @@ import os, sys, unittest, warnings
 # avoid conflict wuth the local pytest and py modules and the one from LCG pytools
 warnings.filterwarnings('ignore', message=r'Module .*? is being added to sys\.path', append=True)
 
-
-# add local pytest dir to sys.path to make pytest available
-toplevel = os.path.dirname(os.path.realpath(__file__))
-sys.path.insert(0, os.path.join(toplevel, 'pytest'))
-
+try:
+   import pytest, pytest_cov
+except:
+   # pytest not found in the system, use local copy
+   toplevel = os.path.dirname(os.path.realpath(__file__))
+   sys.path.insert(0, os.path.join(toplevel, 'pytest'))
+   import pytest, pytest_cov
 
 if sys.hexversion >= 0x3000000:
    pylong = int
@@ -41,18 +43,9 @@ FIXCLING = '--fixcling' in sys.argv
 if 'FIXCLING' in os.environ:
    FIXCLING = os.environ['FIXCLING'] == 'yes'
 
-
 def run_pytest(test_file=None):
-    # add local pytest dir to sys.path
-    toplevel = os.path.dirname(os.path.realpath(__file__))
-    sys.path.insert(0, os.path.join(toplevel, 'pytest'))
-    import pytest
-    import pytest_cov
-    # file to run, if any (search used otherwise)
     if '-i' in sys.argv:
         args = filter(lambda x: not x in (test_file, '-i'), sys.argv)
-    else:
-        args = ['--color=no', '--result-log=stdout', '--minimal=yes']
-    if test_file: args += [test_file]
-    # actual test run
+    elif test_file:
+        args = test_file
     return pytest.main(args, plugins=[pytest_cov])

--- a/root/meta/rlibmapLauncher.py
+++ b/root/meta/rlibmapLauncher.py
@@ -34,5 +34,5 @@ if which(rlibmapName):
    sys.exit(subprocess.call(rlibmapName, shell=True))
 else:
    # Fake rlibmap
-   print errmsg
+   print(errmsg)
    sys.exit(1)


### PR DESCRIPTION
I tried before, but incompatibilities with accepted options of `pytest.main` made some tests fail. If removing the options does not make any test fail, then we can merge this and update the bundled version of pytest, which is already quite old (2.5.2, and I have 3.2.2 on my computer). The problem with using the builtin is that if there is also another version in the system, several tests fail (e.g. roottest-python-basic-basic) due to incompatibility with new interfaces:
```
$ ctest -VV -R roottest-python-basic-basic
UpdateCTestConfiguration  from :/home/amadio/build/gcc7.3/DartConfiguration.tcl
Parse Config file:/home/amadio/build/gcc7.3/DartConfiguration.tcl
 Add coverage exclude regular expressions.
SetCTestConfiguration:CMakeCommand:/usr/bin/cmake
UpdateCTestConfiguration  from :/home/amadio/build/gcc7.3/DartConfiguration.tcl
Parse Config file:/home/amadio/build/gcc7.3/DartConfiguration.tcl
Test project /home/amadio/build/gcc7.3
Constructing a list of tests
Ignore test: test-stressproof
Ignore test: roottest-cling-parsing-semicolon
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 923
    Start 923: roottest-python-basic-basic

923: Test command: /usr/bin/cmake "-DCMD=/usr/bin/python^/home/amadio/src/roottest/python/basic/PyROOT_basictests.py^--fixcling" "-DPRE=/home/amadio/build/gcc7.3/bin/root.exe^-b^-q^-l^-e^.L ArgumentPassingCompiled.C+" "-DOUT=/home/amadio/build/gcc7.3/roottest/python/basic/basic.log" "-DCWD=/home/amadio/build/gcc7.3/roottest/python/basic" "-DDIFFCMD=/home/amadio/src/roottest/scripts/custom_diff.py" "-DCHECKOUT=true" "-DCHECKERR=true" "-DSYS=/home/amadio/build/gcc7.3" "-DENV=ROOTSYS@/home/amadio/build/gcc7.3#PATH@/home/amadio/build/gcc7.3/bin:/usr/lib/ccache/bin:/usr/x86_64-pc-linux-gnu/gcc-bin/7.3.0:/usr/lib/llvm/5/bin:/usr/lib/llvm/4/bin:/usr/local/bin:/usr/bin:/bin:/opt/bin:/usr/games/bin:/opt/cuda/bin:/opt/root/6.12/bin:/home/amadio/bin:.#PYTHONPATH@/home/amadio/build/gcc7.3/lib:/opt/root/6.12/lib#LD_LIBRARY_PATH@/home/amadio/build/gcc7.3/lib:/usr/bin/../lib:" "-DCOPY=/home/amadio/src/roottest/python/basic/ArgumentPassingCompiled.C^/home/amadio/src/roottest/python/basic/ReturnValues.C^/home/amadio/src/roottest/python/basic/SimpleClass.C^/home/amadio/src/roottest/python/basic/ArgumentPassingInterpreted.C" "-P" "/home/amadio/src/root/cmake/modules/RootTestDriver.cmake"
923: Test timeout computed to be: 300
923: Info in <TUnixSystem::ACLiC>: creating shared library /home/amadio/build/gcc7.3/roottest/python/basic/./ArgumentPassingCompiled_C.so
923: 
923: -- TEST COMMAND -- 
923: cd /home/amadio/build/gcc7.3/roottest/python/basic
923: /usr/bin/python /home/amadio/src/roottest/python/basic/PyROOT_basictests.py --fixcling
923: -- BEGIN TEST OUTPUT --
923: Traceback (most recent call last):
923:   File "/home/amadio/src/roottest/python/basic/PyROOT_basictests.py", line 414, in <module>
923:     result = run_pytest(__file__)
923:   File "/home/amadio/src/roottest/python/common.py", line 54, in run_pytest
923:     return pytest.main(args, plugins=[pytest_cov])
923:   File "/home/amadio/src/roottest/python/pytest/_pytest/config.py", line 19, in main
923:     config = _prepareconfig(args, plugins)
923:   File "/home/amadio/src/roottest/python/pytest/_pytest/config.py", line 63, in _prepareconfig
923:     pluginmanager=pluginmanager, args=args)
923:   File "/home/amadio/src/roottest/python/pytest/_pytest/core.py", line 377, in __call__
923:     return self._docall(methods, kwargs)
923:   File "/home/amadio/src/roottest/python/pytest/_pytest/core.py", line 388, in _docall
923:     res = mc.execute()
923:   File "/home/amadio/src/roottest/python/pytest/_pytest/core.py", line 289, in execute
923:     res = method(**kwargs)
923:   File "/home/amadio/src/roottest/python/pytest/_pytest/helpconfig.py", line 27, in pytest_cmdline_parse
923:     config = __multicall__.execute()
923:   File "/home/amadio/src/roottest/python/pytest/_pytest/core.py", line 289, in execute
923:     res = method(**kwargs)
923:   File "/home/amadio/src/roottest/python/pytest/_pytest/config.py", line 618, in pytest_cmdline_parse
923:     self.parse(args)
923:   File "/home/amadio/src/roottest/python/pytest/_pytest/config.py", line 711, in parse
923:     self._preparse(args)
923:   File "/home/amadio/src/roottest/python/pytest/_pytest/config.py", line 688, in _preparse
923:     self.pluginmanager.consider_setuptools_entrypoints()
923:   File "/home/amadio/src/roottest/python/pytest/_pytest/core.py", line 177, in consider_setuptools_entrypoints
923:     plugin = ep.load()
923:   File "/usr/lib64/python3.6/site-packages/pkg_resources/__init__.py", line 2408, in load
923:     return self.resolve()
923:   File "/usr/lib64/python3.6/site-packages/pkg_resources/__init__.py", line 2414, in resolve
923:     module = __import__(self.module_name, fromlist=['__name__'], level=0)
923:   File "/home/amadio/build/gcc7.3/lib/ROOT.py", line 318, in _importhook
923:     return _orig_ihook( name, *args, **kwds )
923:   File "/usr/lib64/python3.6/site-packages/pytest_timeout.py", line 36, in <module>
923:     @pytest.hookimpl
923: AttributeError: module 'pytest' has no attribute 'hookimpl'
923: 
923: -- END TEST OUTPUT --
923: CMake Error at /home/amadio/src/root/cmake/modules/RootTestDriver.cmake:186 (message):
923:   got exit code 1 but expected 0
923: 
923: 
1/1 Test #923: roottest-python-basic-basic ......***Failed    2.82 sec

0% tests passed, 1 tests failed out of 1

Total Test time (real) =   3.68 sec

The following tests FAILED:
	923 - roottest-python-basic-basic (Failed)
Errors while running CTest
```