### PR TITLE
Fixing parallel builds for roottest

### DIFF
--- a/root/tree/cloning/CMakeLists.txt
+++ b/root/tree/cloning/CMakeLists.txt
@@ -37,7 +37,9 @@ if(TARGET hsimple)
       set(HSimpleDependencies "hsimple")
 endif()
 
-# Using already generated hsimple.root from ${ROOTSYS}
+add_custom_command(OUTPUT hsimple.root
+                  COMMAND ${ROOT_root_CMD} -q -l -b hsimple.C > hsimple.out
+                  DEPENDS ${EventDependencies})
 add_custom_target(hsimple-file ALL DEPENDS ${ROOTSYS}/tutorials/hsimple.root)
 
 add_custom_command(

--- a/root/treeformula/event/EventLinkDef.h
+++ b/root/treeformula/event/EventLinkDef.h
@@ -11,17 +11,17 @@
 #pragma link C++ class vector<EventHeader>;
 #pragma link C++ class vector<Track*>;
 
-#pragma ifdef G__INTEL_COMPILER
+#ifdef __INTEL_COMPILER
 #pragma link C++ typedef vector<EventHeader>::iterator;
 #pragma link C++ typedef vector<Track*>::iterator;
-#pragma else G__WIN32
+#elseif _WIN32
 // Intentionally empty because of vc8 (we do not compile the dictionary in
 // this dictionary with the 'right' switches.
-#pragma else
+#else
 #pragma link C++ class vector<EventHeader>::iterator-;
 #pragma link C++ class vector<Track*>::iterator-;
 #pragma link C++ function operator!=(vector<EventHeader>::iterator,vector<EventHeader>::iterator);
 #pragma link C++ function operator!=(vector<Track*>::iterator,vector<Track*>::iterator);
-#pragma endif
+#endif
 
 #endif


### PR DESCRIPTION
Add missing dependency for hsimple.
In highly parallel builds we end up executing hsimple before ROOT is fully built. 
This patch fixes a regression seen in the master.