### PR TITLE
[TDF] Improvements to test_read_leaves[_nodict]

### DIFF
--- a/root/dataframe/CMakeLists.txt
+++ b/root/dataframe/CMakeLists.txt
@@ -167,13 +167,11 @@ ROOTTEST_GENERATE_EXECUTABLE(read_leaves test_read_leaves.cxx LIBRARIES ${DFLIBR
 ROOTTEST_ADD_TEST(read_leaves
                   EXEC read_leaves
                   COPY_TO_BUILDDIR test_read_leaves.h
-                  OUTREF read_leaves.ref
                   DEPENDS ${GENERATE_EXECUTABLE_TEST})
 
 ROOTTEST_GENERATE_EXECUTABLE(read_leaves_nodict test_read_leaves_nodict.cxx LIBRARIES ${DFLIBRARIES})
 ROOTTEST_ADD_TEST(read_leaves_nodict
                   EXEC read_leaves_nodict
-                  OUTREF read_leaves_nodict.ref
                   DEPENDS ${GENERATE_EXECUTABLE_TEST} read_leaves)
 
 ROOTTEST_ADD_TEST(test_readTotemNtuple

--- a/root/dataframe/read_leaves_nodict.ref
+++ b/root/dataframe/read_leaves_nodict.ref
@@ -1,2 +1,0 @@
-Warning in <TClass::Init>: no dictionary for class W is available
-Warning in <TClass::Init>: no dictionary for class V is available

--- a/root/dataframe/test_read_leaves.cxx
+++ b/root/dataframe/test_read_leaves.cxx
@@ -10,18 +10,18 @@ using namespace ROOT::Experimental;
 int main()
 {
    {
-   TFile f("test_read_leaves.root","RECREATE");
-   TTree t("t", "t");
+      TFile f("test_read_leaves.root", "RECREATE");
+      TTree t("t", "t");
 
-   V v{1, 2};
-   t.Branch("v", &v, "a/I:b/I");
+      V v{1, 2};
+      t.Branch("v", &v, "a/I:b/I");
 
-   gROOT->ProcessLine(".L test_read_leaves.h+");
-   W w;
-   t.Branch("w", &w);
+      gROOT->ProcessLine(".L test_read_leaves.h+");
+      W w;
+      t.Branch("w", &w);
 
-   t.Fill();
-   t.Write();
+      t.Fill();
+      t.Write();
    }
 
    TDataFrame d("t", "test_read_leaves.root");

--- a/root/dataframe/test_read_leaves.cxx
+++ b/root/dataframe/test_read_leaves.cxx
@@ -18,9 +18,10 @@ int main()
       V v{1, 2};
       t.Branch("v", &v, "a/I:b/I");
 
-      gROOT->ProcessLine(".L test_read_leaves.h+");
-      W w;
-      t.Branch("w", &w);
+      // TODO add checks for reading of "w.v.a" when ROOT-9312 is solved and TDF supports "w.v.a" nested notation
+      //gROOT->ProcessLine(".L test_read_leaves.h+");
+      //W w;
+      //t.Branch("w", &w);
 
       t.Fill();
       t.Write();

--- a/root/dataframe/test_read_leaves.cxx
+++ b/root/dataframe/test_read_leaves.cxx
@@ -2,6 +2,7 @@
 #include <ROOT/TVec.hxx>
 #include <TTree.h>
 #include <TFile.h>
+#include <TSystem.h>
 
 #include "test_read_leaves.h"
 
@@ -26,6 +27,7 @@ int main()
 
    TDataFrame d("t", "test_read_leaves.root");
    d.Filter(check_a_b, {"v.a", "v.b"}).Report();
+   gSystem->Unlink("test_read_leaves.root");
    return 0;
 }
 

--- a/root/dataframe/test_read_leaves.cxx
+++ b/root/dataframe/test_read_leaves.cxx
@@ -3,6 +3,7 @@
 #include <TTree.h>
 #include <TFile.h>
 #include <TSystem.h>
+#include <cassert>
 
 #include "test_read_leaves.h"
 
@@ -26,7 +27,13 @@ int main()
    }
 
    TDataFrame d("t", "test_read_leaves.root");
-   d.Filter(check_a_b, {"v.a", "v.b"}).Report();
+   auto check_a_b = [](int a, int b) {
+      assert(a == 1);
+      assert(b == 2);
+      return true;
+   };
+   auto c = d.Filter(check_a_b, {"v.a", "v.b"}).Count();
+   assert(*c == 1u);
    gSystem->Unlink("test_read_leaves.root");
    return 0;
 }

--- a/root/dataframe/test_read_leaves.h
+++ b/root/dataframe/test_read_leaves.h
@@ -5,10 +5,3 @@ struct V {
 struct W {
    V v;
 };
-
-
-// checkers
-bool check_a_b (int , int )
-{
-   return true;
-}

--- a/root/dataframe/test_read_leaves_nodict.cxx
+++ b/root/dataframe/test_read_leaves_nodict.cxx
@@ -26,7 +26,13 @@ int main()
    }
 
    TDataFrame d("t", "test_read_leaves_nodict.root");
-   d.Filter(check_a_b, {"v.a", "v.b"}).Report();
+   auto check_a_b = [](int a, int b) {
+      assert(a == 1);
+      assert(b == 2);
+      return true;
+   };
+   auto c = d.Filter(check_a_b, {"v.a", "v.b"}).Count();
+   assert(*c == 1u);
    gSystem->Unlink("test_read_leaves_nodict.root");
    return 0;
 }

--- a/root/dataframe/test_read_leaves_nodict.cxx
+++ b/root/dataframe/test_read_leaves_nodict.cxx
@@ -17,9 +17,10 @@ int main()
       V v{1, 2};
       t.Branch("v", &v, "a/I:b/I");
 
-      gROOT->ProcessLine(".L test_read_leaves.h+");
-      W w;
-      t.Branch("w", &w);
+      // TODO add checks for reading of "w.v.a" when ROOT-9312 is solved and TDF supports "w.v.a" nested notation
+      //gROOT->ProcessLine(".L test_read_leaves.h+");
+      //W w;
+      //t.Branch("w", &w);
 
       t.Fill();
       t.Write();

--- a/root/dataframe/test_read_leaves_nodict.cxx
+++ b/root/dataframe/test_read_leaves_nodict.cxx
@@ -9,7 +9,22 @@ using namespace ROOT::Experimental;
 
 int main()
 {
-   TDataFrame d("t", "test_read_leaves.root");
+   {
+      TFile f("test_read_leaves_nodict.root", "RECREATE");
+      TTree t("t", "t");
+
+      V v{1, 2};
+      t.Branch("v", &v, "a/I:b/I");
+
+      gROOT->ProcessLine(".L test_read_leaves.h+");
+      W w;
+      t.Branch("w", &w);
+
+      t.Fill();
+      t.Write();
+   }
+
+   TDataFrame d("t", "test_read_leaves_nodict.root");
    d.Filter(check_a_b, {"v.a", "v.b"}).Report();
    return 0;
 }

--- a/root/dataframe/test_read_leaves_nodict.cxx
+++ b/root/dataframe/test_read_leaves_nodict.cxx
@@ -2,6 +2,7 @@
 #include <ROOT/TVec.hxx>
 #include <TTree.h>
 #include <TFile.h>
+#include <TSystem.h>
 
 #include "test_read_leaves.h"
 
@@ -26,6 +27,7 @@ int main()
 
    TDataFrame d("t", "test_read_leaves_nodict.root");
    d.Filter(check_a_b, {"v.a", "v.b"}).Report();
+   gSystem->Unlink("test_read_leaves_nodict.root");
    return 0;
 }
 


### PR DESCRIPTION
It seems the data read from `Filter(check_a_b, {"v.a", "v.b"})` is wrong, so the modified tests are expected to fail. To be investigated.