### PR TITLE
[TDF] test_read_leaves_nodict should use no dictionaries

### DIFF
--- a/root/dataframe/test_read_leaves_nodict.cxx
+++ b/root/dataframe/test_read_leaves_nodict.cxx
@@ -18,7 +18,6 @@ int main()
       t.Branch("v", &v, "a/I:b/I");
 
       // TODO add checks for reading of "w.v.a" when ROOT-9312 is solved and TDF supports "w.v.a" nested notation
-      //gROOT->ProcessLine(".L test_read_leaves.h+");
       //W w;
       //t.Branch("w", &w);
 


### PR DESCRIPTION
Reverting a (harmless) copy-paste mistake