### PR TITLE
Implement a REQUIRES clause for tests.

### DIFF
--- a/root/meta/CMakeLists.txt
+++ b/root/meta/CMakeLists.txt
@@ -7,6 +7,7 @@ ROOTTEST_ADD_TEST(countIncludePaths
 ROOTTEST_GENERATE_REFLEX_DICTIONARY(expressiveErrorMessages expressiveErrorMessages.h SELECTION expressiveErrorMessages_selection.xml)
 
 ROOTTEST_ADD_TEST(expressiveErrorMessages
+                  ENABLE_IF pch
                   MACRO  expressiveErrorMessages.C
                   OUTREF expressiveErrorMessages.ref
                   PASSRC 1


### PR DESCRIPTION
This enables us to run tests only when certain ROOT feature is
enabled.