### PR TITLE
[cxxmodules] Fix a test for modules

### DIFF
--- a/root/meta/CMakeLists.txt
+++ b/root/meta/CMakeLists.txt
@@ -7,7 +7,7 @@ ROOTTEST_ADD_TEST(countIncludePaths
 # This test checks that the payload is properly printed in case of errors for
 # debugging reasons. With modules, the concept of payload is not really valid and
 # the test has no reason to run.
-if(NOT ROOT_MODULES)
+if(NOT ROOT_runtime_cxxmodules_FOUND)
 ROOTTEST_GENERATE_REFLEX_DICTIONARY(expressiveErrorMessages expressiveErrorMessages.h SELECTION expressiveErrorMessages_selection.xml)
 
 ROOTTEST_ADD_TEST(expressiveErrorMessages


### PR DESCRIPTION
Follow up patch for 25b8f34a1f98b9af1199b5b27bcbff9870c4d9b6, as it was
excluding ROOT_MODULES which was cxxmodules not runtime_cxxmodules.