### PR TITLE
Undo two transaction in execUnloading Enum

### DIFF
--- a/root/meta/execUnloading.C
+++ b/root/meta/execUnloading.C
@@ -50,7 +50,7 @@ void execUnloading(){
    } else {
       cerr << "<<MyEnum>> is declared, but not valid.\n";
    }
-   gROOT->ProcessLine(".undo 1");
+   gROOT->ProcessLine(".undo 2");
    // Verify the enum constants are invalidated from the list of globals.
    TGlobal* enumConstVar = (TGlobal*)gROOT->GetListOfGlobals()->FindObject("c1");
    if (enumConstVar != NULL) {


### PR DESCRIPTION
Because we're adding RAII in TCling::UpdateEnumConstant, transaction is
separated and we have to unload two transaction rather than one.