### PR TITLE
[cxxmodules] Fix mangling difference between libEvent and libCore

### DIFF
--- a/root/io/event/Makefile
+++ b/root/io/event/Makefile
@@ -18,7 +18,7 @@ include $(ROOTTEST_HOME)/scripts/Event.mk
 
 #.SUFFIXES: .cxx .o .so
 
-CXXOPT:=-Z7
+CXXOPT:=-Z7 -std=c++11
 LDOPT:=-debug
 
 #all: bigeventTest


### PR DESCRIPTION
In libEvent, RegisterModule was mangled as
_ZN5TROOT14RegisterModuleEPKcPS1_S2_S1_S1_PFvvERKSt6vectorISt4pairISsiESaIS7_EES2_b

However in libCore, it is mangled as
_ZN5TROOT14RegisterModuleEPKcPS1_S2_S1_S1_PFvvERKSt6vectorISt4pairINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEiESaISD_EES2_b

So we should compile libEvent with c++11, too.