### PR TITLE
Revert "Undo two transaction in execUnloading Enum"

### DIFF
--- a/root/meta/execUnloading.C
+++ b/root/meta/execUnloading.C
@@ -50,7 +50,7 @@ void execUnloading(){
    } else {
       cerr << "<<MyEnum>> is declared, but not valid.\n";
    }
-   gROOT->ProcessLine(".undo 2");
+   gROOT->ProcessLine(".undo 1");
    // Verify the enum constants are invalidated from the list of globals.
    TGlobal* enumConstVar = (TGlobal*)gROOT->GetListOfGlobals()->FindObject("c1");
    if (enumConstVar != NULL) {


### PR DESCRIPTION
This reverts commit 732d4a30bfa402473640673bec1cc66bb32f43c6.

This depends on #2093. We removed RAII because we are not listening to
deserialization listener anymore.

I believe this fixes recent unstable execUnloading test.