### PR TITLE
Adjust file size tolerances to reflect improvements in LZ4 1.8.2

### DIFF
--- a/root/io/filemerger/execTestMultiMerge.C
+++ b/root/io/filemerger/execTestMultiMerge.C
@@ -93,21 +93,21 @@ int execTestMultiMerge()
    bool lz4default = false;
 #endif
    Int_t result = 0;
-   int hsimpleFTolerance = 16;
+   int hsimpleFTolerance = 25;
    result += testMergedFile("mzfile1-4.root",206,3614 + lz4default*841 + kIs32bits*2 - kIs32bits*lz4default*16, kIs32bits ? 2 : 0);
    result += testMergedFile("mlz4file1-4.root",406,4554 + lz4default*841 + kIs32bits*2 - kIs32bits*lz4default*16, kIs32bits ? 2 : 0);
    result += testMergedFile("mzlibfile1-4.root",106,3724 + lz4default*841 + kIs32bits*2 - kIs32bits*lz4default*16, kIs32bits ? 2 : 0);
    result += testSimpleFile("hsimple.root",25000,expectedcomplevel,413154 + lz4default*104060 + kIs32bits*2 + kIs32bits*lz4default*19, kIs32bits ? (12 + fastMath*10) : (8 + fastMath*10));
-   result += testSimpleFile("hsimple9.root",25000,9,430625 + lz4default*86230 + kIs32bits*10 - kIs32bits*lz4default*8,4 + fastMath*27);
+   result += testSimpleFile("hsimple9.root",25000,9,430625 + lz4default*86230 + kIs32bits*10 - kIs32bits*lz4default*8,19 + fastMath*27);
    result += testSimpleFile("hsimple101.root",25000,101,412925 + lz4default*1667, kIs32bits ? 12 : (3 + fastMath*14));
    result += testSimpleFile("hsimple106.root",25000,106,429227 + lz4default*1931 + kIs32bits*4,3 + fastMath*20);
    result += testSimpleFile("hsimple109.root",25000,109,428937 + lz4default*1931 + kIs32bits*10,3 + fastMath*28);
-   result += testSimpleFile("hsimple9x2.root",2*25000,9,849733 + lz4default*169479 + kIs32bits*10,9 + fastMath*56);
+   result += testSimpleFile("hsimple9x2.root",2*25000,9,849733 + lz4default*169479 + kIs32bits*10,25 + fastMath*56);
    result += testSimpleFile("hsimple109x2.root",2*25000,109,848047 + lz4default*1931 + kIs32bits*5,9 + fastMath*52);
    result += testSimpleFile("hsimple209.root",25000,209,390662 + lz4default*1931,8 + fastMath*24);
    result += testSimpleFile("hsimple401.root",25000,401,416807 + lz4default*102982,8 + fastMath*31);
    result += testSimpleFile("hsimple406.root",25000,406,515005 + lz4default*1931,8);
-   result += testSimpleFile("hsimple409.root",25000,409,514933 + lz4default*1931,8);
+   result += testSimpleFile("hsimple409.root",25000,409,514933 + lz4default*1931,18);
    result += testSimpleFile("hsimpleK.root",6*25000,209,2295549 + lz4default*1931,16 + fastMath*120);
    if (lzma_version_number() < 50020010) {
       // lzma v5.2.0 produced larger files ...
@@ -116,7 +116,7 @@ int execTestMultiMerge()
    } else {
       result += testSimpleFile("hsimpleK202.root",12*25000,202,4628153 + lz4default*1931,16 + fastMath*104);
    }
-   result += testSimpleFile("hsimpleK409.root",24*25000,409,12045145 + lz4default*1931,16);
+   result += testSimpleFile("hsimpleK409.root",24*25000,409,12045145 + lz4default*1931,110);
    result += testSimpleFile("hsimpleF.root",30*25000,9,12581073 + lz4default*2472134,hsimpleFTolerance + fastMath*1090);
    return result;
 }


### PR DESCRIPTION
Fixes a test case failure when ROOT is built against liblz4 1.8.2.  The ROOT files where the file size is different have been compared with the ones produced by a built-in LZ4 ROOT using [a macro to convert the contents to JSON](https://github.com/jblomer/hjson/blob/roottest-fix-lz4-1.8/hjson.C).