### PR TITLE
[TREEPROCMT] Go back to using multiple files in "friends" test

### DIFF
--- a/root/multicore/tp_process_imt.cpp
+++ b/root/multicore/tp_process_imt.cpp
@@ -102,12 +102,12 @@ int main(int argc, char** argv) {
   else if (kConstructor == "friends") {
      TChain chain(kTreeName.c_str());
      chain.Add(kFileName.c_str());
-     //chain.Add(kFileName.c_str()); TODO uncomment when "too many open files" error is fixed
+     chain.Add(kFileName.c_str());
 
      // Create an identical friend with an alias
      TChain friendChain(kTreeName.c_str());
      friendChain.Add(kFileName.c_str());
-     //friendChain.Add(kFileName.c_str()); TODO uncomment when "too many open files" error is fixed
+     friendChain.Add(kFileName.c_str());
      chain.AddFriend(&friendChain, "myfriend");
 
      tp.reset(new ROOT::TTreeProcessorMT(chain));


### PR DESCRIPTION
Commit 9a915397ad in root master fixed the "too many open files" issue.