### PR TITLE
[PyROOT] Fix operator test with new str behaviour

### DIFF
--- a/python/basic/PyROOT_operatortests.py
+++ b/python/basic/PyROOT_operatortests.py
@@ -95,11 +95,11 @@ class Cpp2ConverterOperatorsTestCase( MyTestCase ):
 
       o = OperatorCharStar()
       self.assertEqual( o.m_str, 'OperatorCharStar' )
-      self.assertEqual( str(o),  'OperatorCharStar' )
+      self.assertIn( 'OperatorCharStar', repr(o) )
 
       o = OperatorConstCharStar()
       self.assertEqual( o.m_str, 'OperatorConstCharStar' )
-      self.assertEqual( str(o),  'OperatorConstCharStar' )
+      self.assertIn( 'OperatorConstCharStar', repr(o) )
 
       o = OperatorInt(); o.m_int = -13
       self.assertEqual( o.m_int,   -13 )


### PR DESCRIPTION
Fixes PyROOT test of basic operators, which compares `str(...)` output to expectation. The behaviour changes with the new pretty-printing feature [in this PR to ROOT](https://github.com/root-project/root/pull/2097).

The changes are backward compatible because `repr(...)` is similar to `str(...)` in the old behaviour.

