### PR TITLE
[cxxmodules] Stabilize the test.

### DIFF
--- a/root/meta/CMakeLists.txt
+++ b/root/meta/CMakeLists.txt
@@ -48,12 +48,8 @@ configure_file(templateAutoload.rootmap . COPYONLY)
 configure_file(typelist.v5.txt . COPYONLY)
 configure_file(typelist.v6.txt . COPYONLY)
 
-# FIXME: Temporary workaround for runtime_cxxmodules;
-if(NOT ROOT_runtime_cxxmodules_FOUND)
 ROOTTEST_ADD_AUTOMACROS(DEPENDS ANSTmpltInt.C TmpltInt0.C TmpltInt1.C TmpltFloat.C
                                 TmpltNoSpec.C Event.cxx ${COMPILE_MACRO_TEST})
-endif()
-
 
 ROOTTEST_ADD_TEST(drawing
                   COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/DrawTest.sh

--- a/root/meta/MemberComments.ref
+++ b/root/meta/MemberComments.ref
@@ -479,38 +479,6 @@ OBJ: TList	TList	Doubly linked list : 0
       void TAttFill::StreamerNVirtual(TBuffer& ClassDef_StreamerNVirtual_b)
  OBJ: TMethod	SysError	 : 0
       void TObject::SysError(const char* method, const char* msgfmt) const
- OBJ: TMethod	TArrow	 : 0
-      TArrow TArrow::TArrow()
- OBJ: TMethod	TArrow	 : 0
-      TArrow TArrow::TArrow(Double_t x1, Double_t y1, Double_t x2, Double_t y2, Float_t arrowsize = 0.050000000000000003, Option_t* option = ">")
- OBJ: TMethod	TArrow	 : 0
-      TArrow TArrow::TArrow(const TArrow& arrow)
- OBJ: TMethod	TAttBBox2D	 : 0
-      TAttBBox2D TAttBBox2D::TAttBBox2D(const TAttBBox2D&)
- OBJ: TMethod	TAttBBox2D	 : 0
-      TAttBBox2D TAttBBox2D::TAttBBox2D()
- OBJ: TMethod	TAttFill	 : 0
-      TAttFill TAttFill::TAttFill()
- OBJ: TMethod	TAttFill	 : 0
-      TAttFill TAttFill::TAttFill(Color_t fcolor, Style_t fstyle)
- OBJ: TMethod	TAttFill	 : 0
-      TAttFill TAttFill::TAttFill(const TAttFill&)
- OBJ: TMethod	TAttLine	 : 0
-      TAttLine TAttLine::TAttLine()
- OBJ: TMethod	TAttLine	 : 0
-      TAttLine TAttLine::TAttLine(Color_t lcolor, Style_t lstyle, Width_t lwidth)
- OBJ: TMethod	TAttLine	 : 0
-      TAttLine TAttLine::TAttLine(const TAttLine&)
- OBJ: TMethod	TLine	 : 0
-      TLine TLine::TLine()
- OBJ: TMethod	TLine	 : 0
-      TLine TLine::TLine(Double_t x1, Double_t y1, Double_t x2, Double_t y2)
- OBJ: TMethod	TLine	 : 0
-      TLine TLine::TLine(const TLine& line)
- OBJ: TMethod	TObject	 : 0
-      TObject TObject::TObject()
- OBJ: TMethod	TObject	 : 0
-      TObject TObject::TObject(const TObject& object)
  OBJ: TMethod	TestBit	 : 0
       Bool_t TObject::TestBit(UInt_t f) const
  OBJ: TMethod	TestBits	 : 0
@@ -527,46 +495,6 @@ OBJ: TList	TList	Doubly linked list : 0
       void TLine::ls(Option_t* option = "") const
  OBJ: TMethod	ls	 : 0
       void TObject::ls(Option_t* option = "") const
- OBJ: TMethod	operator delete	 : 0
-      void TObject::operator delete(void* ptr)
- OBJ: TMethod	operator delete	 : 0
-      void TObject::operator delete(void* ptr, void* vp)
- OBJ: TMethod	operator delete[]	 : 0
-      void TObject::operator delete[](void* ptr)
- OBJ: TMethod	operator delete[]	 : 0
-      void TObject::operator delete[](void* ptr, void* vp)
- OBJ: TMethod	operator new	 : 0
-      void* TObject::operator new(size_t sz)
- OBJ: TMethod	operator new	 : 0
-      void* TObject::operator new(size_t sz, void* vp)
- OBJ: TMethod	operator new[]	 : 0
-      void* TObject::operator new[](size_t sz)
- OBJ: TMethod	operator new[]	 : 0
-      void* TObject::operator new[](size_t sz, void* vp)
- OBJ: TMethod	operator=	 : 0
-      TArrow& TArrow::operator=(const TArrow&)
- OBJ: TMethod	operator=	 : 0
-      TLine& TLine::operator=(const TLine&)
- OBJ: TMethod	operator=	 : 0
-      TObject& TObject::operator=(const TObject& rhs)
- OBJ: TMethod	operator=	 : 0
-      TAttLine& TAttLine::operator=(const TAttLine&)
- OBJ: TMethod	operator=	 : 0
-      TAttBBox2D& TAttBBox2D::operator=(const TAttBBox2D&)
- OBJ: TMethod	operator=	 : 0
-      TAttFill& TAttFill::operator=(const TAttFill&)
- OBJ: TMethod	~TArrow	 : 0
-      void TArrow::~TArrow()
- OBJ: TMethod	~TAttBBox2D	 : 0
-      void TAttBBox2D::~TAttBBox2D()
- OBJ: TMethod	~TAttFill	 : 0
-      void TAttFill::~TAttFill()
- OBJ: TMethod	~TAttLine	 : 0
-      void TAttLine::~TAttLine()
- OBJ: TMethod	~TLine	 : 0
-      void TLine::~TLine()
- OBJ: TMethod	~TObject	 : 0
-      void TObject::~TObject()
 
 TH1::Class()->GetMenuItems():
 OBJ: TList	TList	Doubly linked list : 0
@@ -624,13 +552,6 @@ OBJ: TList	TList	Doubly linked list : 0
       void TAttMarker::SetMarkerAttributes()
 
 childCl::Class()->GetListOfAllPublicMethods():
-childCl::childCl() // 
-childCl::childCl(const childCl&) // 
 childCl::fGetIndex(Int_t aIndex) // Title Derived
-childCl::operator=(const childCl&) // 
-childCl::~childCl() // 
-baseCl::baseCl() // 
-baseCl::baseCl(const baseCl&) // 
+baseCl::Deleted()//
 baseCl::fGetIndex(Int_t aIndex = 0) // Title Base
-baseCl::operator=(const baseCl&) // 
-baseCl::~baseCl() // 

--- a/root/meta/runMemberComments.C
+++ b/root/meta/runMemberComments.C
@@ -5,9 +5,8 @@ class baseCl {
 public:
    baseCl() {}
    baseCl(const baseCl&) {}
-#if __cplusplus >= 201103L
-   baseCl &operator=(baseCl&&) = delete;
-#endif
+   int Deleted() = delete;
+
 public:
    virtual int fGetIndex(Int_t aIndex=0) { return 42; } // Title Base
 };
@@ -16,9 +15,7 @@ class basePrCl {
 public:
    basePrCl() {}
    basePrCl(const basePrCl&) {}
-#if __cplusplus >= 201103L
-   basePrCl &operator=(basePrCl&&) = delete;
-#endif
+
 public:
    virtual int fGetPrIndex(Int_t aIndex=0) { return 52; } // Title Base
 };
@@ -30,6 +27,14 @@ public:
    virtual int fGetIndex(Int_t aIndex); // Title Derived
 };
 
+static bool IsSpecialMember(TMethod& m) {
+   if (strstr(m.GetName(), m.GetClass()->GetName()))
+      return true;
+   if (strstr(m.GetName(), "operator"))
+      return true;
+   return false;
+}
+
 void runMemberComments() {
    printf("\nTH1F::Class()->GetListOfAllPublicDataMembers():\n");
    TH1F::Class()->GetListOfAllPublicDataMembers()->ls("noaddr");
@@ -37,6 +42,7 @@ void runMemberComments() {
    printf("\nTArrow::Class()->GetListOfAllPublicMethods():\n");
    TList arrowPubMeths;
    for (TObject* pubMeth: *TArrow::Class()->GetListOfAllPublicMethods()) {
+      if (IsSpecialMember(*static_cast<TMethod*>(pubMeth))) continue;
       arrowPubMeths.AddLast(pubMeth);
    }
    arrowPubMeths.Sort();
@@ -52,8 +58,7 @@ void runMemberComments() {
    TIter iPubMeth(pubMeth);
    TMethod* meth = 0;
    while ((meth = (TMethod*)iPubMeth())) {
-      // skip C++11 move c'tor, move op=
-      if (strstr(meth->GetSignature(), "&&")) continue;
+      if (IsSpecialMember(*meth)) continue;
       printf("%s::%s%s // %s\n", meth->GetClass()->GetName(), meth->GetName(), meth->GetSignature(),
              meth->GetTitle());
    }


### PR DESCRIPTION
Copy and move ctors are lazily synthesized by clang on demand. Runtime cxxmodules
introduce yet another step of lazyness which causes this test to fluctuate.

We have seen fluctuations with this test when we upgrade llvm.

Patch by Axel Nauman and me!