### PR TITLE
Update LZ4 test to reflect change in compression ratio.

### DIFF
--- a/root/io/treeForeign/testForeignDrawLZ4.ref
+++ b/root/io/treeForeign/testForeignDrawLZ4.ref
@@ -4,7 +4,7 @@ Warning in <TClass::Init>: no dictionary for class Wrapper is available
 Warning in <TClass::Init>: no dictionary for class MyClass is available
 ******************************************************************************
 *Tree    :T         : T                                                      *
-*Entries :        2 : Total =            4215 bytes  File  Size =       1569 *
+*Entries :        2 : Total =            4215 bytes  File  Size =       1567 *
 *        :          : Tree compression factor =   1.06                       *
 ******************************************************************************
 *Branch  :obj                                                                *


### PR DESCRIPTION
Corresponds to https://github.com/root-project/root/pull/2775

Looks like setting `fLenType` in the `TLeafElement` resulted in a very small compression ratio change in one of the unittests.  This is the corresponding change.