### PR TITLE
Temporary disabling roottest_root_treeformula_sync_make test for rt c…

### DIFF
--- a/root/treeformula/sync/CMakeLists.txt
+++ b/root/treeformula/sync/CMakeLists.txt
@@ -4,4 +4,6 @@
 # define a CTest test that calls 'make' in ${CMAKE_CURRENT_SOURCE_DIR}
 #
 #-------------------------------------------------------------------------------
-ROOTTEST_ADD_OLDTEST()
+if(NOT ROOT_runtime_cxxmodules_FOUND)
+  ROOTTEST_ADD_OLDTEST()
+endif()


### PR DESCRIPTION
…xxmodules

Error is visible only on Jenkins and non deterministic:
--- Using ROOT from /mnt/build/jenkins/workspace/root-pullrequests-build/build
./copiedEvent: symbol lookup error: ./libEvent.so: undefined symbol: _ZN5TROOT14RegisterModuleEPKcPS1_S2_S1_S1_PFvvERKSt6vectorISt4pairISsiESaIS7_EES2_b