### PR TITLE
Revert "Disabling NestedClasses and slaveDict tests for rt cxxmodules"

### DIFF
--- a/cling/template/CMakeLists.txt
+++ b/cling/template/CMakeLists.txt
@@ -11,9 +11,7 @@ ROOTTEST_ADD_TEST(templateSingleton
                   DEPENDS Singleton.h
                   LABELS roottest regression cling)
 
-if(NOT ROOT_runtime_cxxmodules_FOUND)
-  ROOTTEST_GENERATE_DICTIONARY(slaveDict        slave.h        LINKDEF slaveLinkDef.h)
-endif()
+ROOTTEST_GENERATE_DICTIONARY(slaveDict        slave.h        LINKDEF slaveLinkDef.h)
 ROOTTEST_GENERATE_DICTIONARY(masterDict       master.h       LINKDEF masterLinkDef.h)
 ROOTTEST_GENERATE_DICTIONARY(forwardDict      forward.C      LINKDEF linkdef.h)
 ROOTTEST_GENERATE_DICTIONARY(constructorDict  constructor.hh LINKDEF linkdef.h)

--- a/root/meta/autoloading/NestedClasses/CMakeLists.txt
+++ b/root/meta/autoloading/NestedClasses/CMakeLists.txt
@@ -14,9 +14,8 @@ ROOTTEST_ADD_TEST(nestedTemplate
 ROOTTEST_GENERATE_REFLEX_DICTIONARY(nestedClasses
                                     nestedClasses.h
                                     SELECTION nestedClasses_selection.xml)
-if(NOT ROOT_runtime_cxxmodules_FOUND)
+
 ROOTTEST_ADD_TEST(nestedClasses
                   MACRO execNestedClasses.C
                   OUTREF execNestedClasses.ref
                   DEPENDS ${GENERATE_REFLEX_TEST})
-endif()


### PR DESCRIPTION
This reverts commit 4ef956dcd566c5d03ac900772ad5a75869f5f070.

This PR is for testing failures