### PR TITLE
[RooFit] Add test for ROOT-9571

### DIFF
--- a/root/roofitstats/CMakeLists.txt
+++ b/root/roofitstats/CMakeLists.txt
@@ -6,8 +6,14 @@ ROOTTEST_ADD_TEST(read-scientificnotation
                   OUTCNVCMD grep -v -e "Wouter"
                   OUTREF read_scientific_notation.ref)
 
-ROOTTEST_GENERATE_EXECUTABLE(test_destruct_RooGaussian testDestructRooGaussian testDestructRooGaussian.cxx LIBRARIES ${ROOFITLIBRARIES})
+ROOTTEST_GENERATE_EXECUTABLE(testDestructRooGaussian
+                  testDestructRooGaussian testDestructRooGaussian.cxx LIBRARIES ${ROOFITLIBRARIES})
+ROOTTEST_ADD_TEST(testDestructRooGaussian
+                  EXEC ./testDestructRooGaussian
+                  DEPENDS ${GENERATE_EXECUTABLE_TEST})
 
-ROOTTEST_ADD_TEST(test_destruct_RooGaussian
-                  EXEC ./test_destruct_RooGaussian )
+ROOTTEST_GENERATE_EXECUTABLE(testRooSetMemPools testRooSetMemPools testRooSetMemPools.cxx LIBRARIES ${ROOFITLIBRARIES})
+ROOTTEST_ADD_TEST(testRooSetMemPools
+                  EXEC ./testRooSetMemPools
+                  DEPENDS ${GENERATE_EXECUTABLE_TEST})
 endif()

--- a/root/roofitstats/CMakeLists.txt
+++ b/root/roofitstats/CMakeLists.txt
@@ -1,6 +1,13 @@
 if(ROOT_roofit_FOUND)
-  ROOTTEST_ADD_TEST(read-scientificnotation
-                    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/read_scientific_notation.py
-                    OUTCNVCMD grep -v -e "Wouter"
-                    OUTREF read_scientific_notation.ref)
+set(ROOFITLIBRARIES RooFitCore RooFit HistFactory)
+
+ROOTTEST_ADD_TEST(read-scientificnotation
+                  COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/read_scientific_notation.py
+                  OUTCNVCMD grep -v -e "Wouter"
+                  OUTREF read_scientific_notation.ref)
+
+ROOTTEST_GENERATE_EXECUTABLE(test_destruct_RooGaussian testDestructRooGaussian testDestructRooGaussian.cxx LIBRARIES ${ROOFITLIBRARIES})
+
+ROOTTEST_ADD_TEST(test_destruct_RooGaussian
+                  EXEC ./test_destruct_RooGaussian )
 endif()

--- a/root/roofitstats/testDestructRooGaussian.cxx
+++ b/root/roofitstats/testDestructRooGaussian.cxx
@@ -1,9 +1,5 @@
-#include <random>
-#include "RooDataSet.h"
-#include "RooArgSet.h"
 #include "RooRealVar.h"
 #include "RooGaussian.h"
-#include "RooPlot.h"
 
 int main()
 {
@@ -13,8 +9,5 @@ int main()
 
   RooGaussian g("gaus", "", x, mass, sigma);
   auto f = mass.frame();
-  //f->ResetBit(kCanDelete);
   g.plotOn(f);
-  //  f->Draw();
-  //delete f; 
 }

--- a/root/roofitstats/testDestructRooGaussian.cxx
+++ b/root/roofitstats/testDestructRooGaussian.cxx
@@ -1,0 +1,20 @@
+#include <random>
+#include "RooDataSet.h"
+#include "RooArgSet.h"
+#include "RooRealVar.h"
+#include "RooGaussian.h"
+#include "RooPlot.h"
+
+int main()
+{
+  RooRealVar mass("mass","",3.0,3.2);
+  RooRealVar x("x","",3.0,3.2);
+  RooRealVar sigma("sigma","",3.0,3.2);
+
+  RooGaussian g("gaus", "", x, mass, sigma);
+  auto f = mass.frame();
+  //f->ResetBit(kCanDelete);
+  g.plotOn(f);
+  //  f->Draw();
+  //delete f; 
+}

--- a/root/roofitstats/testRooSetMemPools.cxx
+++ b/root/roofitstats/testRooSetMemPools.cxx
@@ -1,0 +1,69 @@
+#include "RooDataSet.h"
+#include "RooArgSet.h"
+#include <memory>
+#include <vector>
+#include <set>
+
+/**
+ * RooArgSets and RooDataSets are assumed to be unique in RooFit when their pointer is unique.
+ * Therefore, they were using (broken: static destruction problems) custom allocators.
+ * This test tests a memory pool that enforces the same uniqueness, but solves the static
+ * destruction problems.
+ *
+ * When the memory pool becomes obsolete, so becomes this test. For this, RooArgSets need
+ * to be identified using a unique ID instead of their pointer.
+ */
+
+
+typedef std::vector<std::unique_ptr<RooArgSet>>  ArgVec_t;
+typedef std::vector<std::unique_ptr<RooDataSet>> DataVec_t;
+std::set<void*> seenPtrs;
+
+template <class Set_t>
+void populate(std::vector<std::unique_ptr<Set_t>> & theVec, std::size_t n) {
+  for (std::size_t i = 0; i < n; ++i) {
+      theVec.emplace_back(new Set_t());
+
+      auto success = seenPtrs.insert(theVec.back().get());
+      if (! success.second) {
+        std::cerr << theVec.back().get() << " doesn't seem to be unique." << std::endl;
+        throw;
+      }
+
+    }
+}
+
+template <class T>
+void testAllocs() {
+    std::vector<std::unique_ptr<T>> theSets;
+    theSets.reserve(10000);
+    populate(theSets, 5000);
+    std::cout << "Allocated " << theSets.size() << " sets." << std::endl;
+
+    theSets.resize(2000);
+    std::cout << "Down to " << theSets.size() << " sets." << std::endl;
+    populate(theSets, 5000);
+    std::cout << "Up to " << theSets.size() << " sets." << std::endl;
+
+
+    std::srand(1337);
+    theSets.erase(std::remove_if(theSets.begin(),
+        theSets.end(),
+        [](std::unique_ptr<T> &){return std::rand() % 20 < 18;}),
+        theSets.end());
+    std::cout << "Random deletions leave " << theSets.size() << " sets." << std::endl;
+
+    populate(theSets, 5000);
+    std::cout << "More allocations: " << theSets.size() << " sets." << std::endl;
+    theSets.clear();
+    std::cout << "Cleared." << std::endl;
+    seenPtrs.clear();
+    std::cout << "Done.\n\n" << std::endl;
+}
+
+int main()
+{
+  testAllocs<RooArgSet>();
+
+  testAllocs<RooDataSet>();
+}


### PR DESCRIPTION
Test proper order of static destructions when RooFit objects in a RooPlot reach the end of main.