### PR TITLE
Pass through CMAKE_AR when building external projects

### DIFF
--- a/cmake/modules/SearchInstalledSoftwareRoottest.cmake
+++ b/cmake/modules/SearchInstalledSoftwareRoottest.cmake
@@ -29,6 +29,7 @@ ExternalProject_Add(
                   -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
                   -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                   -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+                  -DCMAKE_AR=${CMAKE_AR}
                   -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
     # Disable install step
     INSTALL_COMMAND ""


### PR DESCRIPTION
In particular, needed when building googletest.
Original patch by chrisburr at https://github.com/root-project/root/pull/2995