### PR TITLE
[ROOT-9836] Add test for templated function in a namespace

### DIFF
--- a/python/cpp/PyROOT_advancedtests.py
+++ b/python/cpp/PyROOT_advancedtests.py
@@ -295,6 +295,32 @@ class Cpp02TemplateLookup( MyTestCase ):
       obj = ROOT.MyTemplateTypedef()
       obj.set( 'hi' )   # used to fail with TypeError
 
+   def test9TemplatedFunctionNamespace(self):
+      """Test template function in a namespace, lookup and calls"""
+
+      f = ROOT.MyNamespace.MyTemplatedFunctionNamespace
+
+      val = 1.0
+      v = ROOT.std.vector("float")()
+      v.push_back(val)
+
+      # Test basic type
+      self.assertEqual(f("float")(val), val)
+      self.assertEqual(type(f("float")(val)), type(val))
+
+      # Test typedef resolution
+      self.assertEqual(f("Float_t")(val), val)
+      self.assertEqual(type(f("Float_t")(val)), type(val))
+
+      # Test no namespace specification
+      self.assertEqual(f("vector<float>")(v)[0], val)
+      self.assertEqual(type(f("vector<float>")(v)), type(v))
+
+      # Test incomplete type specification
+      # Complete type is std::vector<float, std::allocator<float>>
+      self.assertEqual(f("std::vector<float>")(v)[0], val)
+      self.assertEqual(type(f("std::vector<float>")(v)), type(v))
+
 
 ### C++ by-non-const-ref arguments tests =====================================
 class Cpp03PassByNonConstRef( MyTestCase ):

--- a/python/cpp/Template.C
+++ b/python/cpp/Template.C
@@ -24,6 +24,11 @@ typedef MyTemplatedClass2< std::string > MyTemplateTypedef;
 template< class T >
 T MyTemplatedFunction( T t ) { return t; }
 
+namespace MyNamespace {
+   template <typename T>
+   T MyTemplatedFunctionNamespace(T t) { return t; }
+};
+
 #ifdef __CINT__
 #pragma link C++ class MyTemplatedClass< vector< float > >;
 #pragma link C++ function MyTemplatedFunction< int >( int );


### PR DESCRIPTION
This tests the failing cases described here:

https://sft.its.cern.ch/jira/browse/ROOT-9836
