### PR TITLE
[DF] Use ROOT::ROOTDataFrame instead of ROOTDataFrame as a dependency

### DIFF
--- a/root/dataframe/CMakeLists.txt
+++ b/root/dataframe/CMakeLists.txt
@@ -7,7 +7,7 @@ if(ROOTTEST_OS_ID MATCHES Ubuntu)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-as-needed")
 endif()
 
-set(DFLIBRARIES Core ROOTDataFrame Hist Tree RIO MathCore)
+set(DFLIBRARIES ROOT::ROOTDataFrame Hist Tree RIO)
 
 # Linked to ROOT-9773: train cache with TTreeReader
 ROOTTEST_ADD_TEST(test_trainCache


### PR DESCRIPTION
The former correctly brings in all of RDataFrame's library dependencies
also in the case of roottest being built against an already installed
version of ROOT.