### PR TITLE
Replace use of rmkdepend with standard makedepend

### DIFF
--- a/root/io/abstractclass/Makefile
+++ b/root/io/abstractclass/Makefile
@@ -85,7 +85,7 @@ $(CXXSO): $(CXXOBJS)
 #	$(CMDECHO)$(SOCMD) $(SOFLAGS) $(CXXOBJS) $(OutPutOpt)$(CXXSO) $(EXPLLINKLIBS)
 
 depend: FORCE
-	$(CMDECHO)rmkdepend -f Makefile $(INCLUDES) $(CXXSOURCE)
+	$(CMDECHO)makedepend -f Makefile $(INCLUDES) $(CXXSOURCE)
 
 tar: FORCE
 	tar cvf badio.tar Makefile LinkDef.h $(CINTLIST) $(CXXSOURCES) *.C *.root

--- a/scripts/Event.mk
+++ b/scripts/Event.mk
@@ -23,15 +23,15 @@ endif
 endif
 
 Event.d: Event.cxx Event.h
-	@touch Event.dd; rmkdepend -f Event.dd -I$(ROOTSYS)/include Event.cxx 2>/dev/null && \
+	@touch Event.dd; makedepend -f Event.dd -I$(ROOTSYS)/include Event.cxx 2>/dev/null && \
 	cat Event.dd | sed -e s/Event\\\.o/Event\\\.$(ObjSuf)/g > Event.d; rm Event.dd Event.dd.bak
 
 MainEvent.d: MainEvent.cxx Event.h
-	@touch MainEvent.dd; rmkdepend -f MainEvent.dd -I$(ROOTSYS)/include MainEvent.cxx 2>/dev/null && \
+	@touch MainEvent.dd; makedepend -f MainEvent.dd -I$(ROOTSYS)/include MainEvent.cxx 2>/dev/null && \
 	cat MainEvent.dd | sed -e s/MainEvent\\\.o/MainEvent\\\.$(ObjSuf)/g > MainEvent.d; rm MainEvent.dd MainEvent.dd.bak
 
 EventDict.d: EventDict.cxx Event.h
-	@touch EventDict.dd; rmkdepend -f EventDict.dd -I$(ROOTSYS)/include EventDict.cxx 2>/dev/null && \
+	@touch EventDict.dd; makedepend -f EventDict.dd -I$(ROOTSYS)/include EventDict.cxx 2>/dev/null && \
 	cat EventDict.dd | sed -e s/EventDict\\\.o/EventDict\\\.$(ObjSuf)/g > EventDict.d; rm EventDict.dd EventDict.dd.bak
 
 Event.$(ObjSuf): $(ROOTCORELIBS)


### PR DESCRIPTION
Just trying this out to see if the standard tool would work just fine for the few tests that still use it.