### PR TITLE
[Exp PyROOT] Temporarily disable PyROOT tests in experimental mode

### DIFF
--- a/cling/functionTemplate/CMakeLists.txt
+++ b/cling/functionTemplate/CMakeLists.txt
@@ -10,13 +10,15 @@ ROOTTEST_ADD_TEST(runreferenceuse
                   DEPENDS MyClassReferenceUse.C
                   LABELS roottest regression cling)
 
-ROOTTEST_ADD_TEST(testcint
-                  MACRO testcint.py
-                  PRECMD root -b -q -l -e .L\ t.h+
-                  OUTREF pythoncintrun.ref
-                  OUTCNVCMD grep -v "just a comment"
-                  WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-                  LABELS roottest regression cling)
+if(NOT pyroot_experimental)
+  ROOTTEST_ADD_TEST(testcint
+                    MACRO testcint.py
+                    PRECMD root -b -q -l -e .L\ t.h+
+                    OUTREF pythoncintrun.ref
+                    OUTCNVCMD grep -v "just a comment"
+                    WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+                    LABELS roottest regression cling)
+endif()
 
 if(ROOT_cintex_FOUND)
   ROOTTEST_ADD_TEST(testreflex

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,1 +1,3 @@
-ROOTTEST_ADD_TESTDIRS()
+if(NOT pyroot_experimental)
+  ROOTTEST_ADD_TESTDIRS()
+endif()

--- a/root/roofitstats/CMakeLists.txt
+++ b/root/roofitstats/CMakeLists.txt
@@ -1,8 +1,10 @@
 if(ROOT_roofit_FOUND)
-  ROOTTEST_ADD_TEST(read-scientificnotation
-                    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/read_scientific_notation.py
-                    OUTCNVCMD grep -v -e "Wouter"
-                    OUTREF read_scientific_notation.ref)
+  if (NOT pyroot_experimental)
+    ROOTTEST_ADD_TEST(read-scientificnotation
+                      COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/read_scientific_notation.py
+                      OUTCNVCMD grep -v -e "Wouter"
+                      OUTREF read_scientific_notation.ref)
+  endif()
 
   ROOTTEST_ADD_TEST(RooDataSet_ASCII_in
                     MACRO ${CMAKE_CURRENT_SOURCE_DIR}/ASCII-in-out.C


### PR DESCRIPTION
A number of test failures have to be fixed in the experimental PyROOT builds:

https://epsft-jenkins.cern.ch/job/root-exp-pyroot/8/

This PR temporarily disables those failing tests for the experimental PyROOT builds, and they will be re-enabled progressively as they are fixed.