### PR TITLE
[JupyROOT] C++Kernel: do not run each cell in a separate thread

### DIFF
--- a/python/JupyROOT/CMakeLists.txt
+++ b/python/JupyROOT/CMakeLists.txt
@@ -8,8 +8,9 @@ set(NBDIFFUTIL ${CMAKE_CURRENT_SOURCE_DIR}/nbdiff.py )
 # documentation and as tutorials. In order to spot problems with downloads
 # one should not use GLOB but rather list explicitely all the files
 set(NOTEBOOKS ${CMAKE_CURRENT_SOURCE_DIR}/importROOT.ipynb
-              ${CMAKE_CURRENT_SOURCE_DIR}/simpleCppMagic.ipynb)
-#             ${CMAKE_CURRENT_SOURCE_DIR}/ROOT_kernel.ipynb)
+              ${CMAKE_CURRENT_SOURCE_DIR}/simpleCppMagic.ipynb
+              ${CMAKE_CURRENT_SOURCE_DIR}/thread_local.ipynb
+              ${CMAKE_CURRENT_SOURCE_DIR}/ROOT_kernel.ipynb)
 
 find_python_module(IPython QUIET)
 
@@ -20,17 +21,15 @@ if(PY_IPYTHON_FOUND)
     get_filename_component(SHORTPYFILE ${pyfile} NAME_WE)
     if (NOT ${SHORTPYFILE} STREQUAL "__init__")
       ROOTTEST_ADD_TEST(${SHORTPYFILE}_doctest
-                        COMMAND ${PYTHON_EXECUTABLE} -m doctest ${pyfile}
-                        RUN_SERIAL)
+                        COMMAND ${PYTHON_EXECUTABLE} -m doctest ${pyfile})
     endif()
   endforeach()
 
 # Test all notebooks available
   foreach(NOTEBOOK ${NOTEBOOKS})
     get_filename_component(NOTEBOOKBASE ${NOTEBOOK} NAME_WE)
-    ROOTTEST_ADD_TEST(${NOTEBOOKBASE}
-                      COMMAND ${PYTHON_EXECUTABLE} ${NBDIFFUTIL} ${NOTEBOOK}
-                      RUN_SERIAL)
+    ROOTTEST_ADD_TEST(${NOTEBOOKBASE}_notebook
+                      COMMAND ${PYTHON_EXECUTABLE} ${NBDIFFUTIL} ${NOTEBOOK})
   endforeach()
 endif()
 

--- a/python/JupyROOT/thread_local.ipynb
+++ b/python/JupyROOT/thread_local.ipynb
@@ -1,0 +1,78 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Info in <TUnixSystem::ACLiC>: creating shared library /home/dpiparo/RootDevel/Root6/head/build/ddcf9c12_C.so\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%cpp -a\n",
+    "\n",
+    "#include <iostream>\n",
+    "\n",
+    "thread_local int i = 0;\n",
+    "void incrementAndPrint()\n",
+    "{\n",
+    "    std::cout << i++ << std::endl;\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n"
+     ]
+    }
+   ],
+   "source": [
+    "incrementAndPrint()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n"
+     ]
+    }
+   ],
+   "source": [
+    "incrementAndPrint()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ROOT C++",
+   "language": "c++",
+   "name": "root"
+  },
+  "language_info": {
+   "codemirror_mode": "text/x-c++src",
+   "file_extension": ".C",
+   "mimetype": " text/x-c++src",
+   "name": "c++"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Improve notebook testing via nbdiff
- Add suffix "notebook" to tests which run notebooks
- Allow to run root notebooks
- Add new thread_local notebook to test that every cell is executed within the same thread
- Add to the battery the existing root notebooks previously disabled