### PR TITLE
[Exp PyROOT] Flag tests that now fail in PyROOT experimental

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,11 @@ if(ROOT_python_FOUND)
   find_package(PythonLibs)
 endif()
 
+#---Set flag for PyROOT tests that are expected to fail in experimental
+if(ROOT_pyroot_experimental_FOUND)
+  set(PYTESTS_WILLFAIL WILLFAIL)
+endif()
+
 # Find OpenGL 
 find_library(OPENGL_gl_LIBRARY NAMES GL)
 

--- a/cling/functionTemplate/CMakeLists.txt
+++ b/cling/functionTemplate/CMakeLists.txt
@@ -16,7 +16,8 @@ ROOTTEST_ADD_TEST(testcint
                   OUTREF pythoncintrun.ref
                   OUTCNVCMD grep -v "just a comment"
                   WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-                  LABELS roottest regression cling)
+                  LABELS roottest regression cling
+                  ${PYTESTS_WILLFAIL})
 
 if(ROOT_cintex_FOUND)
   ROOTTEST_ADD_TEST(testreflex

--- a/python/JupyROOT/CMakeLists.txt
+++ b/python/JupyROOT/CMakeLists.txt
@@ -29,7 +29,8 @@ if(PY_IPYTHON_FOUND)
   foreach(NOTEBOOK ${NOTEBOOKS})
     get_filename_component(NOTEBOOKBASE ${NOTEBOOK} NAME_WE)
     ROOTTEST_ADD_TEST(${NOTEBOOKBASE}_notebook
-                      COMMAND ${PYTHON_EXECUTABLE} ${NBDIFFUTIL} ${NOTEBOOK})
+                      COMMAND ${PYTHON_EXECUTABLE} ${NBDIFFUTIL} ${NOTEBOOK}
+                      ${PYTESTS_WILLFAIL})
   endforeach()
 endif()
 

--- a/python/basic/CMakeLists.txt
+++ b/python/basic/CMakeLists.txt
@@ -2,20 +2,24 @@ if(ROOT_python_FOUND)
   ROOTTEST_ADD_TEST(basic
                     MACRO PyROOT_basictests.py
                     COPY_TO_BUILDDIR ArgumentPassingCompiled.C ReturnValues.C SimpleClass.C ArgumentPassingInterpreted.C
-                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ ArgumentPassingCompiled.C+)
+                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ ArgumentPassingCompiled.C+
+                    ${PYTESTS_WILLFAIL})
 
   ROOTTEST_ADD_TEST(datatype
                     MACRO PyROOT_datatypetest.py
                     COPY_TO_BUILDDIR DataTypes.C DataTypes.h
-                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ DataTypes.C+ )
+                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ DataTypes.C+
+                    ${PYTESTS_WILLFAIL})
 
   ROOTTEST_ADD_TEST(operator
                     MACRO PyROOT_operatortests.py
                     COPY_TO_BUILDDIR Operators.C
-                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ Operators.C+)
+                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ Operators.C+
+                    ${PYTESTS_WILLFAIL})
 
   ROOTTEST_ADD_TEST(overload
                     MACRO PyROOT_overloadtests.py
                     COPY_TO_BUILDDIR Overloads.C Overloads.h
-                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ Overloads.C+)
+                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ Overloads.C+
+                    ${PYTESTS_WILLFAIL})
 endif()

--- a/python/cling/CMakeLists.txt
+++ b/python/cling/CMakeLists.txt
@@ -2,15 +2,18 @@ if(ROOT_python_FOUND)
   ROOTTEST_ADD_TEST(api
                     MACRO runPyAPITest.C
                     WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-                    OUTREF PyAPITest.ref)
+                    OUTREF PyAPITest.ref
+                    ${PYTESTS_WILLFAIL})
 
   ROOTTEST_ADD_TEST(class MACRO
                     runPyClassTest.C
                     WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-                    OUTREF PyClassTest.ref)
+                    OUTREF PyClassTest.ref
+                    ${PYTESTS_WILLFAIL})
 
   ROOTTEST_ADD_TEST(cling
                     MACRO PyROOT_clingtests.py
                     WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-                    OUTREF PyROOT_clingtests.ref)
+                    OUTREF PyROOT_clingtests.ref
+                    ${PYTESTS_WILLFAIL})
 endif()

--- a/python/cmdLineUtils/CMakeLists.txt
+++ b/python/cmdLineUtils/CMakeLists.txt
@@ -11,11 +11,13 @@ ROOTTEST_ADD_TEST(SimplePattern1
 
 ROOTTEST_ADD_TEST(SimplePattern2
                   COMMAND ${TESTPATTERN_EXE} test.root:tof
-                  OUTREF SimplePattern2.ref)
+                  OUTREF SimplePattern2.ref
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimplePattern3
                   COMMAND ${TESTPATTERN_EXE} test.root:*
-                  OUTREF SimplePattern3.ref)
+                  OUTREF SimplePattern3.ref
+                  ${PYTESTS_WILLFAIL})
 #########################################################################
 
 set(TOOLS_PREFIX ${ROOTSYS}/bin)
@@ -23,63 +25,77 @@ set(TOOLS_PREFIX ${ROOTSYS}/bin)
 ############################## ROOLS TESTS ##############################
 ROOTTEST_ADD_TEST(SimpleRootls1
                   COMMAND ${TOOLS_PREFIX}/rootls -1 test.root
-                  OUTREF SimpleRootls.ref)
+                  OUTREF SimpleRootls.ref
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootls2
                   COMMAND ${TOOLS_PREFIX}/rootls -1 test.root:*
-                  OUTREF SimpleRootls2.ref)
+                  OUTREF SimpleRootls2.ref
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootls3
                   COMMAND ${TOOLS_PREFIX}/rootls -1 test.root:tof
-                  OUTREF SimpleRootls3.ref)
+                  OUTREF SimpleRootls3.ref
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootls4
                   COMMAND ${TOOLS_PREFIX}/rootls -1 test.root:tof/*
-                  OUTREF SimpleRootls4.ref)
+                  OUTREF SimpleRootls4.ref
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(LongRootls1
                   COMMAND ${TOOLS_PREFIX}/rootls -l test.root
-                  OUTREF LongRootls.ref)
+                  OUTREF LongRootls.ref
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(LongRootls2
                   COMMAND ${TOOLS_PREFIX}/rootls -l test.root:*
-                  OUTREF LongRootls2.ref)
+                  OUTREF LongRootls2.ref
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(LongRootls3
                   COMMAND ${TOOLS_PREFIX}/rootls -l test.root:tof
-                  OUTREF LongRootls3.ref)
+                  OUTREF LongRootls3.ref
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(LongRootls4
                   COMMAND ${TOOLS_PREFIX}/rootls -l test.root:tof/*
-                  OUTREF LongRootls4.ref)
+                  OUTREF LongRootls4.ref
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(WebRootls1
                   COMMAND ${TOOLS_PREFIX}/rootls -1 http://root.cern.ch/files/pippa.root
-                  OUTREF WebRootls.ref)
+                  OUTREF WebRootls.ref
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(WebRootls2
                   COMMAND ${TOOLS_PREFIX}/rootls -1 http://root.cern.ch/files/pippa.root:LL
-                  OUTREF WebRootls2.ref)
+                  OUTREF WebRootls2.ref
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(TreeRootls1
                   COMMAND ${TOOLS_PREFIX}/rootls -t simpleTree.root
-                  OUTREF TreeRootls.ref)
+                  OUTREF TreeRootls.ref
+                  ${PYTESTS_WILLFAIL})
 
 #########################################################################
 
 
 ############################## ROORM TESTS ##############################
 ROOTTEST_ADD_TEST(SimpleRootrm1PrepareInput
-                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root victim1.root)
+                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root victim1.root
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootrm1
                   COMMAND ${TOOLS_PREFIX}/rootrm victim1.root:hpx
-                  DEPENDS SimpleRootrm1PrepareInput)
+                  DEPENDS SimpleRootrm1PrepareInput
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootrm1CheckOutput
                   COMMAND ${TOOLS_PREFIX}/rootls -1 victim1.root
                   OUTREF SimpleRootrm.ref
-                  DEPENDS SimpleRootrm1)
+                  DEPENDS SimpleRootrm1
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootrm1Clean
                   COMMAND ${TOOLS_PREFIX}/rootrm -r victim1.root
@@ -88,16 +104,19 @@ ROOTTEST_ADD_TEST(SimpleRootrm1Clean
 
 
 ROOTTEST_ADD_TEST(SimpleRootrm2PrepareInput
-                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root victim2.root)
+                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root victim2.root
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootrm2
                   COMMAND ${TOOLS_PREFIX}/rootrm victim2.root:hp*
-                  DEPENDS SimpleRootrm2PrepareInput)
+                  DEPENDS SimpleRootrm2PrepareInput
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootrm2CheckOutput
                   COMMAND ${TOOLS_PREFIX}/rootls -1 victim2.root
                   OUTREF SimpleRootrm2.ref
-                  DEPENDS SimpleRootrm2)
+                  DEPENDS SimpleRootrm2
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootrm2Clean
                   COMMAND ${TOOLS_PREFIX}/rootrm -r victim2.root
@@ -106,16 +125,19 @@ ROOTTEST_ADD_TEST(SimpleRootrm2Clean
 
 
 ROOTTEST_ADD_TEST(SimpleRootrm3PrepareInput
-                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root victim3.root)
+                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root victim3.root
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootrm3
                   COMMAND ${TOOLS_PREFIX}/rootrm -r victim3.root:tof/plane0
-                  DEPENDS SimpleRootrm3PrepareInput)
+                  DEPENDS SimpleRootrm3PrepareInput
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootrm3CheckOutput
                   COMMAND ${TOOLS_PREFIX}/rootls -1 victim3.root:tof
                   OUTREF SimpleRootrm3.ref
-                  DEPENDS SimpleRootrm3)
+                  DEPENDS SimpleRootrm3
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootrm3Clean
                   COMMAND ${TOOLS_PREFIX}/rootrm -r victim3.root
@@ -124,7 +146,8 @@ ROOTTEST_ADD_TEST(SimpleRootrm3Clean
 
 ############################# ROOMKDIR TESTS ############################
 ROOTTEST_ADD_TEST(SimpleRootmkdir1PrepareInput
-                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root target1.root)
+                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root target1.root
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootmkdir1
                   COMMAND ${TOOLS_PREFIX}/rootmkdir target1.root:new_directory
@@ -133,7 +156,8 @@ ROOTTEST_ADD_TEST(SimpleRootmkdir1
 ROOTTEST_ADD_TEST(SimpleRootmkdir1CheckOutput
                   COMMAND ${TOOLS_PREFIX}/rootls -1 target1.root
                   OUTREF SimpleRootmkdir.ref
-                  DEPENDS SimpleRootmkdir1)
+                  DEPENDS SimpleRootmkdir1
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootmkdir1Clean
                   COMMAND ${TOOLS_PREFIX}/rootrm -r target1.root
@@ -142,7 +166,8 @@ ROOTTEST_ADD_TEST(SimpleRootmkdir1Clean
 
 
 ROOTTEST_ADD_TEST(SimpleRootmkdir2PrepareInput
-                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root target2.root)
+                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root target2.root
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootmkdir2
                   COMMAND ${TOOLS_PREFIX}/rootmkdir target2.root:dir1 target2.root:dir2
@@ -151,7 +176,8 @@ ROOTTEST_ADD_TEST(SimpleRootmkdir2
 ROOTTEST_ADD_TEST(SimpleRootmkdir2CheckOutput
                   COMMAND ${TOOLS_PREFIX}/rootls -1 target2.root
                   OUTREF SimpleRootmkdir2.ref
-                  DEPENDS SimpleRootmkdir2)
+                  DEPENDS SimpleRootmkdir2
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootmkdir2Clean
                   COMMAND ${TOOLS_PREFIX}/rootrm -r target2.root
@@ -160,7 +186,8 @@ ROOTTEST_ADD_TEST(SimpleRootmkdir2Clean
 
 
 ROOTTEST_ADD_TEST(SimpleRootmkdir3PrepareInput
-                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root target3.root)
+                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root target3.root
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootmkdir3
                   COMMAND ${TOOLS_PREFIX}/rootmkdir -p target3.root:aa/bb/cc
@@ -169,7 +196,8 @@ ROOTTEST_ADD_TEST(SimpleRootmkdir3
 ROOTTEST_ADD_TEST(SimpleRootmkdir3CheckOutput
                   COMMAND ${TOOLS_PREFIX}/rootls -1 target3.root:aa/bb
                   OUTREF SimpleRootmkdir3.ref
-                  DEPENDS SimpleRootmkdir3)
+                  DEPENDS SimpleRootmkdir3
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootmkdir3Clean
                   COMMAND ${TOOLS_PREFIX}/rootrm -r target3.root
@@ -178,16 +206,19 @@ ROOTTEST_ADD_TEST(SimpleRootmkdir3Clean
 
 ############################# ROOCP TESTS ############################
 ROOTTEST_ADD_TEST(SimpleRootcp1PrepareInput
-                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root copy1.root)
+                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root copy1.root
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootcp1
                   COMMAND ${TOOLS_PREFIX}/rootcp copy1.root:hpx copy1.root:histo
-                  DEPENDS SimpleRootcp1PrepareInput)
+                  DEPENDS SimpleRootcp1PrepareInput
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootcp1CheckOutput
                   COMMAND ${TOOLS_PREFIX}/rootls -1 copy1.root
                   OUTREF SimpleRootcp.ref
-                  DEPENDS SimpleRootcp1)
+                  DEPENDS SimpleRootcp1
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootcp1Clean
                   COMMAND ${TOOLS_PREFIX}/rootrm -r copy1.root
@@ -196,16 +227,19 @@ ROOTTEST_ADD_TEST(SimpleRootcp1Clean
 
 
 ROOTTEST_ADD_TEST(SimpleRootcp2PrepareInput
-                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root copy2.root)
+                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root copy2.root
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootcp2
                   COMMAND ${TOOLS_PREFIX}/rootcp -r copy2.root:tof copy2.root:fot
-                  DEPENDS SimpleRootcp2PrepareInput)
+                  DEPENDS SimpleRootcp2PrepareInput
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootcp2CheckOutput
                   COMMAND ${TOOLS_PREFIX}/rootls -1 copy2.root
                   OUTREF SimpleRootcp2.ref
-                  DEPENDS SimpleRootcp2)
+                  DEPENDS SimpleRootcp2
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootcp2Clean
                   COMMAND ${TOOLS_PREFIX}/rootrm -r copy2.root
@@ -214,32 +248,38 @@ ROOTTEST_ADD_TEST(SimpleRootcp2Clean
 
 
 ROOTTEST_ADD_TEST(SimpleRootcp3PrepareInput
-                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root copy3.root)
+                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root copy3.root
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootcp3
                   COMMAND ${TOOLS_PREFIX}/rootcp --replace copy3.root:hpx copy3.root:hpxpy
-                  DEPENDS SimpleRootcp3PrepareInput)
+                  DEPENDS SimpleRootcp3PrepareInput
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootcp3CheckOutput
                   COMMAND ${TOOLS_PREFIX}/rootls -1 copy3.root
                   OUTREF SimpleRootcp3.ref
-                  DEPENDS SimpleRootcp3)
+                  DEPENDS SimpleRootcp3
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootcp3Clean
                   COMMAND ${TOOLS_PREFIX}/rootrm -r copy3.root
                   DEPENDS SimpleRootcp3CheckOutput)
 
 ROOTTEST_ADD_TEST(SimpleRootcp4PrepareInput
-                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root copy4.root)
+                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root copy4.root
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootcp4
                   COMMAND ${TOOLS_PREFIX}/rootcp copy4.root:hpx copy4.root:dir
-                  DEPENDS SimpleRootcp4PrepareInput)
+                  DEPENDS SimpleRootcp4PrepareInput
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootcp4CheckOutput
                   COMMAND ${TOOLS_PREFIX}/rootls -1 copy4.root:dir
                   OUTREF SimpleRootcp4.ref
-                  DEPENDS SimpleRootcp4)
+                  DEPENDS SimpleRootcp4
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootcp4Clean
                   COMMAND ${TOOLS_PREFIX}/rootrm -r copy4.root
@@ -248,16 +288,19 @@ ROOTTEST_ADD_TEST(SimpleRootcp4Clean
 
 
 ROOTTEST_ADD_TEST(SimpleRootcp5PrepareInput
-                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root copy5.root)
+                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root copy5.root
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootcp5
                   COMMAND ${TOOLS_PREFIX}/rootcp -r copy5.root:tof copy5.root:dir
-                  DEPENDS SimpleRootcp5PrepareInput)
+                  DEPENDS SimpleRootcp5PrepareInput
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootcp5CheckOutput
                   COMMAND ${TOOLS_PREFIX}/rootls -1 copy5.root:dir
                   OUTREF SimpleRootcp5.ref
-                  DEPENDS SimpleRootcp5)
+                  DEPENDS SimpleRootcp5
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootcp5Clean
                   COMMAND ${TOOLS_PREFIX}/rootrm -r copy5.root
@@ -266,16 +309,19 @@ ROOTTEST_ADD_TEST(SimpleRootcp5Clean
 
 ############################# ROOMV TESTS ############################
 ROOTTEST_ADD_TEST(SimpleRootmv1PrepareInput
-                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root move1.root)
+                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root move1.root
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootmv1
                   COMMAND ${TOOLS_PREFIX}/rootmv move1.root:hpx move1.root:histo
-                  DEPENDS SimpleRootmv1PrepareInput)
+                  DEPENDS SimpleRootmv1PrepareInput
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootmv1CheckOutput
                   COMMAND ${TOOLS_PREFIX}/rootls -1 move1.root
                   OUTREF SimpleRootmv.ref
-                  DEPENDS SimpleRootmv1)
+                  DEPENDS SimpleRootmv1
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootmv1Clean
                   COMMAND ${TOOLS_PREFIX}/rootrm -r move1.root
@@ -284,16 +330,19 @@ ROOTTEST_ADD_TEST(SimpleRootmv1Clean
 
 
 ROOTTEST_ADD_TEST(SimpleRootmv2PrepareInput
-                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root move2.root)
+                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root move2.root
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootmv2
                   COMMAND ${TOOLS_PREFIX}/rootmv move2.root:tof move2.root:fot
-                  DEPENDS SimpleRootmv2PrepareInput)
+                  DEPENDS SimpleRootmv2PrepareInput
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootmv2CheckOutput
                   COMMAND ${TOOLS_PREFIX}/rootls -1 move2.root
                   OUTREF SimpleRootmv2.ref
-                  DEPENDS SimpleRootmv2)
+                  DEPENDS SimpleRootmv2
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootmv2Clean
                   COMMAND ${TOOLS_PREFIX}/rootrm -r move2.root
@@ -302,48 +351,57 @@ ROOTTEST_ADD_TEST(SimpleRootmv2Clean
 
 
 ROOTTEST_ADD_TEST(SimpleRootmv3PrepareInput
-                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root move3.root)
+                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root move3.root
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootmv3
                   COMMAND ${TOOLS_PREFIX}/rootmv move3.root:hpx move3.root:hpxpy
-                  DEPENDS SimpleRootmv3PrepareInput)
+                  DEPENDS SimpleRootmv3PrepareInput
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootmv3CheckOutput
                   COMMAND ${TOOLS_PREFIX}/rootls -1 move3.root
                   OUTREF SimpleRootmv3.ref
-                  DEPENDS SimpleRootmv3)
+                  DEPENDS SimpleRootmv3
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootmv3Clean
                   COMMAND ${TOOLS_PREFIX}/rootrm -r move3.root
                   DEPENDS SimpleRootmv3CheckOutput)
 
 ROOTTEST_ADD_TEST(SimpleRootmv4PrepareInput
-                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root move4.root)
+                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root move4.root
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootmv4
                   COMMAND ${TOOLS_PREFIX}/rootmv move4.root:hpx move4.root:dir
-                  DEPENDS SimpleRootmv4PrepareInput)
+                  DEPENDS SimpleRootmv4PrepareInput
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootmv4CheckOutput
                   COMMAND ${TOOLS_PREFIX}/rootls -1 move4.root:*
                   OUTREF SimpleRootmv4.ref
-                  DEPENDS SimpleRootmv4)
+                  DEPENDS SimpleRootmv4
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootmv4Clean
                   COMMAND ${TOOLS_PREFIX}/rootrm -r move4.root
                   DEPENDS SimpleRootmv4CheckOutput)
 
 ROOTTEST_ADD_TEST(SimpleRootmv5PrepareInput
-                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root move5.root)
+                  COMMAND ${TOOLS_PREFIX}/rootcp -r test.root move5.root
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootmv5
                   COMMAND ${TOOLS_PREFIX}/rootmv move5.root:tof move5.root:dir
-                  DEPENDS SimpleRootmv5PrepareInput)
+                  DEPENDS SimpleRootmv5PrepareInput
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootmv5CheckOutput
                   COMMAND ${TOOLS_PREFIX}/rootls -1 move5.root:*
                   OUTREF SimpleRootmv5.ref
-                  DEPENDS SimpleRootmv5)
+                  DEPENDS SimpleRootmv5
+                  ${PYTESTS_WILLFAIL})
 
 ROOTTEST_ADD_TEST(SimpleRootmv5Clean
                   COMMAND ${TOOLS_PREFIX}/rootrm -r move5.root
@@ -352,6 +410,7 @@ ROOTTEST_ADD_TEST(SimpleRootmv5Clean
 
 ROOTTEST_ADD_TEST(ROOT_8197
                   MACRO ROOT_8197.C
-                  OUTREF ROOT_8197.ref)
+                  OUTREF ROOT_8197.ref
+                  ${PYTESTS_WILLFAIL})
 
 endif() # these tests are not run with the classic build

--- a/python/cpp/CMakeLists.txt
+++ b/python/cpp/CMakeLists.txt
@@ -4,17 +4,20 @@ if(ROOT_python_FOUND)
                     COPY_TO_BUILDDIR Namespace.C PointerPassing.C  Namespace2.C
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ Namespace.C+ 
                                          -e .L\ PointerPassing.C+ 
-                                         -e .L\ Namespace2.C+)
+                                         -e .L\ Namespace2.C+
+                    ${PYTESTS_WILLFAIL})
 
   ROOTTEST_ADD_TEST(advanced
                     MACRO PyROOT_advancedtests.py
                     COPY_TO_BUILDDIR AdvancedCpp.C Template.C
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ AdvancedCpp.C+
-                                                     -e .L\ Template.C+)
+                                                     -e .L\ Template.C+
+                    ${PYTESTS_WILLFAIL})
                                          
   ROOTTEST_ADD_TEST(cpp11
                     MACRO PyROOT_cpp11tests.py
                     COPY_TO_BUILDDIR Cpp11Features.C
-                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ Cpp11Features.C+)
+                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ Cpp11Features.C+
+                    ${PYTESTS_WILLFAIL})
                                          
 endif()

--- a/python/function/CMakeLists.txt
+++ b/python/function/CMakeLists.txt
@@ -4,5 +4,6 @@ if(ROOT_python_FOUND)
                     COPY_TO_BUILDDIR InstallableFunction.C GlobalFunction.C GlobalFunction2.C GlobalFunction3.C
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ InstallableFunction.C+
                                              -e .L\ GlobalFunction2.C+
-                                             -e .L\ GlobalFunction3.C+)
+                                             -e .L\ GlobalFunction3.C+
+                    ${PYTESTS_WILLFAIL})
 endif()

--- a/python/memory/CMakeLists.txt
+++ b/python/memory/CMakeLists.txt
@@ -2,5 +2,6 @@ if(ROOT_python_FOUND)
   ROOTTEST_ADD_TEST(memory
                     MACRO PyROOT_memorytests.py
                     COPY_TO_BUILDDIR MemTester.C
-                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ MemTester.C+)
+                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ MemTester.C+
+                    ${PYTESTS_WILLFAIL})
 endif()

--- a/python/pickle/CMakeLists.txt
+++ b/python/pickle/CMakeLists.txt
@@ -2,9 +2,11 @@ if(ROOT_python_FOUND)
   ROOTTEST_ADD_TEST(write
                     MACRO PyROOT_writetests.py
                     COPY_TO_BUILDDIR PickleTypes.C
-                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ PickleTypes.C+)
+                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ PickleTypes.C+
+                    ${PYTESTS_WILLFAIL})
 
   ROOTTEST_ADD_TEST(read
                     MACRO PyROOT_readtests.py
-                    DEPENDS write)
+                    DEPENDS write
+                    ${PYTESTS_WILLFAIL})
 endif()

--- a/python/pythonizations/CMakeLists.txt
+++ b/python/pythonizations/CMakeLists.txt
@@ -2,9 +2,12 @@ if(ROOT_python_FOUND)
   ROOTTEST_ADD_TEST(pythonizations
                     MACRO PyROOT_pythonizationtest.py
                     COPY_TO_BUILDDIR Pythonizables.C Pythonizables.h
-                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ Pythonizables.C+)
+                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ Pythonizables.C+
+                    ${PYTESTS_WILLFAIL})
+
   ROOTTEST_ADD_TEST(smartptr
                     MACRO PyROOT_smartptrtest.py
                     COPY_TO_BUILDDIR SmartPtr.C SmartPtr.h
-                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ SmartPtr.C+)
+                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ SmartPtr.C+
+                    ${PYTESTS_WILLFAIL})
 endif()

--- a/python/regression/CMakeLists.txt
+++ b/python/regression/CMakeLists.txt
@@ -13,12 +13,13 @@ if(ROOT_python_FOUND)
                                          -e .L\ ULongLong.C+
                                          -e .L\ Till.C+
                                          -e .L\ CoralAttributeList.C+
-                    )
+                    ${PYTESTS_WILLFAIL})
+
   ROOTTEST_ADD_TEST(root_6023
                     MACRO exec_root_6023.py OPTS -b
                     COPY_TO_BUILDDIR root_6023.h
                     PRECMD ${ROOT_root_CMD} -b -q -l -e gSystem->AddLinkedLibs\(\"${PYTHON_LIBRARY}\"\)
                                                      -e .L\ root_6023.h+
-                    )
+                    ${PYTESTS_WILLFAIL})
 
 endif()

--- a/python/stl/CMakeLists.txt
+++ b/python/stl/CMakeLists.txt
@@ -2,6 +2,7 @@ if(ROOT_python_FOUND)
   ROOTTEST_ADD_TEST(stl
                     MACRO PyROOT_stltests.py
                     COPY_TO_BUILDDIR StlTypes.C
-                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ StlTypes.C+)
+                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ StlTypes.C+
+                    ${PYTESTS_WILLFAIL})
 endif()
 

--- a/python/ttree/CMakeLists.txt
+++ b/python/ttree/CMakeLists.txt
@@ -2,5 +2,6 @@ if(ROOT_python_FOUND)
   ROOTTEST_ADD_TEST(ttree
                     MACRO PyROOT_ttreetests.py
                     COPY_TO_BUILDDIR TTreeTypes.C
-                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ TTreeTypes.C+)
+                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ TTreeTypes.C+
+                    ${PYTESTS_WILLFAIL})
 endif()

--- a/root/roofitstats/CMakeLists.txt
+++ b/root/roofitstats/CMakeLists.txt
@@ -2,7 +2,8 @@ if(ROOT_roofit_FOUND)
   ROOTTEST_ADD_TEST(read-scientificnotation
                     COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/read_scientific_notation.py
                     OUTCNVCMD grep -v -e "Wouter"
-                    OUTREF read_scientific_notation.ref)
+                    OUTREF read_scientific_notation.ref
+                    ${PYTESTS_WILLFAIL})
 
   ROOTTEST_ADD_TEST(RooDataSet_ASCII_in
                     MACRO ${CMAKE_CURRENT_SOURCE_DIR}/ASCII-in-out.C


### PR DESCRIPTION
A number of test failures have to be fixed in the experimental PyROOT builds:

https://epsft-jenkins.cern.ch/job/root-exp-pyroot/9/

This PR temporarily flags those tests as "will fail" for the experimental PyROOT builds, and they will be restored progressively as they are fixed.