### PR TITLE
[DF] Add TreePlayer as an explicit dependency for tests

### DIFF
--- a/root/dataframe/CMakeLists.txt
+++ b/root/dataframe/CMakeLists.txt
@@ -7,7 +7,7 @@ if(ROOTTEST_OS_ID MATCHES Ubuntu)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-as-needed")
 endif()
 
-set(DFLIBRARIES Core ROOTDataFrame Hist Tree RIO MathCore)
+set(DFLIBRARIES Core RIO Hist Tree MathCore TreePlayer ROOTDataFrame)
 
 # Linked to ROOT-9773: train cache with TTreeReader
 ROOTTEST_ADD_TEST(test_trainCache


### PR DESCRIPTION
Otherwise, when building roottest against a pre-existing ROOT
installation, libTreePlayer is not linked.
This explicit dependency on libTreePlayer can be removed once the
ROOTDataFrame target transitively brings in its dependencies also
when building roottest against a pre-existing ROOT installation.

@amadio how do we test that this resolves the failures you were seeing?