### PR TITLE
[Exp PyROOT] Use ROOTSYS in case roottest is built separately

### DIFF
--- a/root/meta/tclass/regression/CMakeLists.txt
+++ b/root/meta/tclass/regression/CMakeLists.txt
@@ -9,8 +9,8 @@ ROOTTEST_ADD_TEST(execNormalizationInf
 ROOTTEST_ADD_TEST(execNormalizationInfPy
                   MACRO execNormalizationInf.py
                   OUTREF execNormalizationInf.py.ref
-		  ENVIRONMENT CLING_STANDARD_PCH=${CMAKE_BINARY_DIR}/etc/allDict.cxx.pch
-                              CPPYY_BACKEND_LIBRARY=${CMAKE_BINARY_DIR}/lib/libcppyy_backend.so)
+		  ENVIRONMENT CLING_STANDARD_PCH=${ROOTSYS}/etc/allDict.cxx.pch
+                              CPPYY_BACKEND_LIBRARY=${ROOTSYS}/lib/libcppyy_backend.so)
 
 ROOTTEST_ADD_TEST(execROOT_6038
                   MACRO execROOT_6038.C


### PR DESCRIPTION
Thank you @amadio for the suggestion!