### PR TITLE
Add "OPTIONS" flag to ROOTTEST_GENERATE_DICTIONARY:

### DIFF
--- a/cling/dict/ROOT-9110/CMakeLists.txt
+++ b/cling/dict/ROOT-9110/CMakeLists.txt
@@ -1,2 +1,3 @@
-ROOTTEST_GENERATE_DICTIONARY(NoPPDict -DNoPP=:.:.: NoPP.h
+ROOTTEST_GENERATE_DICTIONARY(NoPPDict NoPP.h
+                             OPTIONS -DNoPP=:.:.:
                              LINKDEF NoPPLinkdef.h)

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -231,6 +231,7 @@ endmacro(ROOTTEST_COMPILE_MACRO)
 # macro ROOTTEST_GENERATE_DICTIONARY(<dictname>
 #                                    [LINKDEF linkdef]
 #                                    [DEPENDS deps]
+#                                    [OPTIONS opts]
 #                                    [files ...]      )
 #
 # This macro generates a dictionary <dictname> from the provided <files>.
@@ -240,7 +241,7 @@ endmacro(ROOTTEST_COMPILE_MACRO)
 #
 #-------------------------------------------------------------------------------
 macro(ROOTTEST_GENERATE_DICTIONARY dictname)
-  CMAKE_PARSE_ARGUMENTS(ARG "NO_ROOTMAP" "" "LINKDEF;DEPENDS" ${ARGN})
+  CMAKE_PARSE_ARGUMENTS(ARG "NO_ROOTMAP" "" "LINKDEF;DEPENDS;OPTIONS" ${ARGN})
 
   set(CMAKE_ROOTTEST_DICT ON)
 
@@ -251,6 +252,7 @@ macro(ROOTTEST_GENERATE_DICTIONARY dictname)
   ROOT_GENERATE_DICTIONARY(${dictname} ${ARG_UNPARSED_ARGUMENTS}
                            MODULE ${dictname}
                            LINKDEF ${ARG_LINKDEF}
+                           OPTIONS ${ARG_OPTIONS}
                            DEPENDENCIES ${ARG_DEPENDS})
   
   ROOTTEST_TARGETNAME_FROM_FILE(GENERATE_DICTIONARY_TEST ${dictname})


### PR DESCRIPTION
Does the same as for ROOT_GENERATE_DICTIONARY (just forwards).
Otherwise, flags will be misinterpreted as header files.