### PR TITLE
[Exp PyROOT] Set environment to find libcppyy_backend on MacOS

### DIFF
--- a/python/regression/CMakeLists.txt
+++ b/python/regression/CMakeLists.txt
@@ -19,6 +19,8 @@ if(ROOT_python_FOUND)
                     MACRO exec_root_6023.py OPTS -b
                     COPY_TO_BUILDDIR root_6023.h
                     PRECMD ${ROOT_root_CMD} -b -q -l -e gSystem->AddLinkedLibs\(\"${PYTHON_LIBRARY}\"\)
-                                                     -e .L\ root_6023.h+)
+                                                     -e .L\ root_6023.h+
+                    ENVIRONMENT CLING_STANDARD_PCH=${CMAKE_BINARY_DIR}/etc/allDict.cxx.pch
+                                CPPYY_BACKEND_LIBRARY=${CMAKE_BINARY_DIR}/lib/libcppyy_backend.so)
 
 endif()


### PR DESCRIPTION
After re-enabling `root_6023`, which uses Cppyy directly, an equivalent fix to the one of:

https://github.com/root-project/roottest/commit/82d1ac9264d731e173a13629d8483674875299b9

is needed for the test to find the location of the `libcppyy_backend` library on MacOS.