### PR TITLE
multicore: read ttree_read_imt.root from http://root.cern:

### DIFF
--- a/root/multicore/CMakeLists.txt
+++ b/root/multicore/CMakeLists.txt
@@ -181,16 +181,13 @@ ROOTTEST_ADD_TEST(fork
                   DEPENDS ${GENERATE_EXECUTABLE_TEST} tsenums tclass_methods)
 
 if(ROOT_imt_FOUND)
-   ROOTTEST_ADD_TEST(generate_imt_tree
-                     MACRO generate_imt_tree.C+)
-
    ROOTTEST_GENERATE_EXECUTABLE(ttree_read_imt ttree_read_imt.cpp LIBRARIES Core Thread Tree RIO Imt)
 
    ROOTTEST_ADD_TEST(ttree_read_imt
                      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/ttree_read_imt.sh
                      FAILREGEX "ERROR"
                      OUTREF ttree_read_imt.ref
-                     DEPENDS generate_imt_tree ${GENERATE_EXECUTABLE_TEST})
+                     DEPENDS ${GENERATE_EXECUTABLE_TEST})
 
 ### Keep this test for debugging purposes: even if ttree_read_imt makes it redundant, it can be useful to
 ### debug issues that are hard to reproduce locally but can eventually be observed on the test machines.
@@ -200,7 +197,7 @@ if(ROOT_imt_FOUND)
 #                     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/ttree_read_imt_allpar.sh
 #                     FAILREGEX "ERROR"
 #                     OUTREF ttree_read_imt_allpar.ref
-#                     DEPENDS generate_imt_tree ${GENERATE_EXECUTABLE_TEST})
+#                     DEPENDS ${GENERATE_EXECUTABLE_TEST})
 
    ROOTTEST_GENERATE_EXECUTABLE(ttree_write_imt ttree_write_imt.cpp LIBRARIES Core Thread Tree Hist RIO Imt)
 

--- a/root/multicore/generate_imt_tree.C
+++ b/root/multicore/generate_imt_tree.C
@@ -1,3 +1,5 @@
+///
+/// Used to generate http://root.cern/files/ttree_read_imt.root
 #include "TFile.h"
 #include "TRandom.h"
 #include "TTree.h"

--- a/root/multicore/ttree_read_imt.cpp
+++ b/root/multicore/ttree_read_imt.cpp
@@ -69,8 +69,6 @@ int main(int argc, char** argv) {
   const int nentries  = std::get<1>(options);
   auto const filename = std::get<2>(options);
 
-  gSystem->Load("generate_imt_tree_C.so");
-
   TFile *file = TFile::Open(filename.c_str());
   
   Int_t nbreadseq, nbreadseq2, nbreadpar, nbreadpar2;

--- a/root/multicore/ttree_read_imt.cpp
+++ b/root/multicore/ttree_read_imt.cpp
@@ -17,7 +17,7 @@ void printHelp(const char* iName, int nThreads, int nEntries)
             << "If no arguments are given " << nThreads << " threads, " << nEntries << " entries will be used." << std::endl;
 }
 
-const std::string kDefaultFileName("ttree_read_imt.root");
+const std::string kDefaultFileName("http://root.cern/files/ttree_read_imt.root");
 
 std::tuple<int,int,std::string> parseOptions(int argc, char** argv)
 {

--- a/root/multicore/ttree_read_imt.ref
+++ b/root/multicore/ttree_read_imt.ref
@@ -1,4 +1,6 @@
 SUCCESS [IMT] - Bytes sequential1: 232750000 - parallel1: 232750000
 SUCCESS [IMT] - Checked state of global IMT
 SUCCESS [IMT] - Bytes sequential2: 232750000 - parallel2: 232750000
+Warning in <TClass::Init>: no dictionary for class A is available
+Warning in <TClass::Init>: no dictionary for class B is available
 NUM TASKS: 100000

--- a/root/multicore/ttree_read_imt.sh
+++ b/root/multicore/ttree_read_imt.sh
@@ -3,7 +3,7 @@
 TESTNAME=ttree_read_imt
 NTHREADS=4
 NENTRIES=500
-INPUTFILE=ttree_read_imt.root
+INPUTFILE=http://root.cern/files/ttree_read_imt.root
 
 #ROOTDEBUG=1 ./$TESTNAME $NTHREADS $NENTRIES $INPUTFILE 1>${TESTNAME}.out 2>${TESTNAME}.err
 

--- a/root/multicore/ttree_read_imt_allpar.cpp
+++ b/root/multicore/ttree_read_imt_allpar.cpp
@@ -69,8 +69,6 @@ int main(int argc, char** argv) {
   const int nentries  = std::get<1>(options);
   auto const filename = std::get<2>(options);
 
-  gSystem->Load("generate_imt_tree_C.so");
-
   TFile *file = TFile::Open(filename.c_str());
   
   Int_t nbreadpar, nbreadpar2;

--- a/root/multicore/ttree_read_imt_allpar.cpp
+++ b/root/multicore/ttree_read_imt_allpar.cpp
@@ -17,7 +17,7 @@ void printHelp(const char* iName, int nThreads, int nEntries)
             << "If no arguments are given " << nThreads << " threads, " << nEntries << " entries will be used." << std::endl;
 }
 
-const std::string kDefaultFileName("ttree_read_imt.root");
+const std::string kDefaultFileName("http://root.cern/files/ttree_read_imt.root");
 
 std::tuple<int,int,std::string> parseOptions(int argc, char** argv)
 {

--- a/root/multicore/ttree_read_imt_allpar.sh
+++ b/root/multicore/ttree_read_imt_allpar.sh
@@ -3,7 +3,7 @@
 TESTNAME=ttree_read_imt_allpar
 NTHREADS=4
 NENTRIES=500
-INPUTFILE=ttree_read_imt.root
+INPUTFILE=http://root.cern/files/ttree_read_imt.root
 
 if ROOTDEBUG=1 ./$TESTNAME $NTHREADS $NENTRIES $INPUTFILE 1>${TESTNAME}.out 2>${TESTNAME}.err ; then
    :


### PR DESCRIPTION
On 32bit, generating that file takes > 5 minutes. It is also a nice
exercise to do IMT reads across the network!