### PR TITLE
[Exp PyROOT] Make tests compliant with new Cppyy

### DIFF
--- a/python/basic/PyROOT_basictests.py
+++ b/python/basic/PyROOT_basictests.py
@@ -127,7 +127,12 @@ class Basic3PythonLanguageTestCase( MyTestCase ):
    def test3ThreadingSupport( self ):
       """Test whether the GIL can be properly released"""
 
-      gROOT.GetVersion._threaded = 1
+      try:
+         gROOT.GetVersion._threaded = 1
+      except AttributeError:
+         # Attribute name change in new Cppyy
+         gROOT.GetVersion.__release_gil__ = 1
+
       gROOT.GetVersion()
 
    def test4ClassAndTypedefEquality( self ):

--- a/python/basic/PyROOT_basictests.py
+++ b/python/basic/PyROOT_basictests.py
@@ -66,7 +66,20 @@ class Basic2SetupTestCase( MyTestCase ):
       ROOT.gMyOwnGlobal = 3.1415
 
       proxy = gROOT.GetGlobal( 'gMyOwnGlobal', 1 )
-      self.assertEqual( proxy.__get__( proxy ), 3.1415 )
+      try:
+         self.assertEqual( proxy.__get__( proxy ), 3.1415 )
+      except AttributeError:
+         # In the old PyROOT, if we try to bind a new global,
+         # such global is defined on the C++ side too, but
+         # only if its type is basic or string (see ROOT.py).
+         # The new PyROOT will discontinue this feature.
+
+         # Note that in the new PyROOT we can still define a
+         # global in C++ and access/modify it from Python
+         ROOT.gInterpreter.Declare("int gMyOwnGlobal2 = 1;")
+         self.assertEqual(ROOT.gMyOwnGlobal2, 1)
+         ROOT.gMyOwnGlobal2 = -1
+         self.assert_(gROOT.ProcessLine('gMyOwnGlobal2 == -1'))
 
    def test4AutoLoading( self ):
       """Test auto-loading by retrieving a non-preloaded class"""

--- a/python/basic/PyROOT_basictests.py
+++ b/python/basic/PyROOT_basictests.py
@@ -54,11 +54,8 @@ class Basic2SetupTestCase( MyTestCase ):
       import ROOT
       oldval = ROOT.gDebug
 
-    # get proxy before setting, otherwise the AutoLoader will have printout
-      proxy = gROOT.GetGlobal( 'gDebug', 1 )
-
       ROOT.gDebug = -1
-      self.assertEqual( proxy.__get__( proxy ), -1 )
+      self.assert_(gROOT.ProcessLine('gDebug == -1'))
 
       ROOT.gDebug = oldval
 

--- a/python/function/PyROOT_functiontests.py
+++ b/python/function/PyROOT_functiontests.py
@@ -29,7 +29,7 @@ gROOT.LoadMacro( "InstallableFunction.C+" )
 
 
 ### helpers for general test cases -------------------------------------------
-def identity( x ):
+def identity( x, par = None ):
    return x[0]
 
 class Linear:

--- a/python/function/PyROOT_functiontests.py
+++ b/python/function/PyROOT_functiontests.py
@@ -103,7 +103,8 @@ class Func1CallFunctionTestCase( MyTestCase ):
    def test2CallableObject( self ):
       """Test calling of a python callable object"""
 
-      f = TF1( "pyf2", Linear(), -1., 1., 2 )
+      pycal = Linear()
+      f = TF1( "pyf2", pycal, -1., 1., 2 )
       f.SetParameters( 5., 2. )
 
       self.assertEqual( f.Eval( -0.1 ), 4.8 )


### PR DESCRIPTION
This PR modifies `roottest-python-basic-basic` and `roottest-python-function-function` to adapt them to the new experimental PyROOT and its new Cppyy. Every commit explains the reason for the corresponding changes.

It is expected that, after these modifications, both tests will still fail. In the case of  `roottest-python-basic-basic`, there is still this issue:
https://sft.its.cern.ch/jira/browse/ROOT-10041

As for `roottest-python-function-function`, there is this remaining issue:
https://sft.its.cern.ch/jira/browse/ROOT-10029

Both issues have already been fixed in the Cppyy repos and will be incorporated in the next Cppyy update for PyROOT experimental.
