### PR TITLE
Define CMAKE_MODULE_PATH for roottest.git too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,8 @@ else()# testing using an installation
   enable_testing()
 endif()
 
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
+
 # Synchronizing default compression algorithm used for ROOT.
 # We need to have it for CMake settings for switching tests references.
 set(compression_default "zlib" CACHE STRING "" FORCE)


### PR DESCRIPTION
Fix problem visible on macosx1014:
CMake Error at /build/jenkins/workspace/root-pullrequests-build/roottest/CMakeLists.txt:142 (ROOTTEST_ADD_TESTDIRS):
17:47:23   Unknown CMake command "ROOTTEST_ADD_TESTDIRS".