### PR TITLE
[Exp PyROOT] No need to specify URL of PCH to Cppyy

### DIFF
--- a/python/regression/CMakeLists.txt
+++ b/python/regression/CMakeLists.txt
@@ -20,7 +20,7 @@ if(ROOT_python_FOUND)
                     COPY_TO_BUILDDIR root_6023.h
                     PRECMD ${ROOT_root_CMD} -b -q -l -e gSystem->AddLinkedLibs\(\"${PYTHON_LIBRARY}\"\)
                                                      -e .L\ root_6023.h+
-                    ENVIRONMENT CLING_STANDARD_PCH=${CMAKE_BINARY_DIR}/etc/allDict.cxx.pch
+                    ENVIRONMENT CLING_STANDARD_PCH=none
                                 CPPYY_BACKEND_LIBRARY=${CMAKE_BINARY_DIR}/lib/libcppyy_backend.so)
 
 endif()

--- a/root/meta/tclass/regression/CMakeLists.txt
+++ b/root/meta/tclass/regression/CMakeLists.txt
@@ -9,7 +9,7 @@ ROOTTEST_ADD_TEST(execNormalizationInf
 ROOTTEST_ADD_TEST(execNormalizationInfPy
                   MACRO execNormalizationInf.py
                   OUTREF execNormalizationInf.py.ref
-		  ENVIRONMENT CLING_STANDARD_PCH=${CMAKE_BINARY_DIR}/etc/allDict.cxx.pch
+		  ENVIRONMENT CLING_STANDARD_PCH=none
                               CPPYY_BACKEND_LIBRARY=${CMAKE_BINARY_DIR}/lib/libcppyy_backend.so)
 
 ROOTTEST_ADD_TEST(execROOT_6038


### PR DESCRIPTION
Just setting `CLING_STANDARD_PCH` to `none` will prevent Cppyy from checking the PCH.

This will fix the test failure from last night in PyROOT experimental:
https://epsft-jenkins.cern.ch/job/root-exp-pyroot/79/