### PR TITLE
Change test to check when new lines of CSV file are read

### DIFF
--- a/root/dataframe/CMakeLists.txt
+++ b/root/dataframe/CMakeLists.txt
@@ -201,8 +201,9 @@ ROOTTEST_ADD_TEST(test_readTotemNtuple
 
 ROOTTEST_GENERATE_EXECUTABLE(test_progressiveCSV test_progressiveCSV.cxx LIBRARIES ${DFLIBRARIES})
 ROOTTEST_ADD_TEST(test_progressiveCSV
-                  EXEC ./test_progressiveCSV
+                  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_progressiveCSV.sh
                   COPY_TO_BUILDDIR test_progressiveCSV.csv
+                  OUTREF test_progressiveCSV.ref
                   DEPENDS ${GENERATE_EXECUTABLE_TEST})
 
 endif() # CMAKE_SIZEOF_VOID_P EQUAL 4

--- a/root/dataframe/test_progressiveCSV.cxx
+++ b/root/dataframe/test_progressiveCSV.cxx
@@ -1,47 +1,25 @@
 
-#include "TSystem.h"
 #include "ROOT/RDataFrame.hxx"
 #include "ROOT/RCsvDS.hxx"
 #include <iostream>
-#include <cassert>
 
 int test_progressiveCSV()
 {
-   // Input file: 5000 rows (> 700 KB)
+   // Input file: 5000 lines
    auto fileName = "test_progressiveCSV.csv";
-   const auto numRows = 5000U;
-   const auto sizeInKB = 700.;
 
-   // Create a CSV data source that reads in chunks of 10 rows 
-   const auto chunkSize = 10LL;
-   auto tdf = ROOT::RDF::MakeCsvDataFrame(fileName, true, ',', chunkSize);
-   
-   ProcInfo_t info;
-   gSystem->GetProcInfo(&info);
-   auto memBefore = info.fMemResident; // KB
+   // Create a CSV data source that reads in chunks of 2000 lines
+   const auto chunkSize = 2000LL;
+   auto rdf = ROOT::RDF::MakeCsvDataFrame(fileName, true, ',', chunkSize);
 
-   assert(*tdf.Count() == numRows);
-
-   gSystem->GetProcInfo(&info);
-   auto memAfter = info.fMemResident;
-
-   // Check that indeed we read in chunks (consumed memory should be much less than 700 KB)
-   assert(memAfter - memBefore < sizeInKB);
-
+   auto rdflines = *rdf.Count();
+   std::cout << "Total num lines: " << rdflines << std::endl;
 
    // Now create a CSV data source that reads the entire file into memory at once
-   auto tdf2 = ROOT::RDF::MakeCsvDataFrame(fileName);
+   auto rdf2 = ROOT::RDF::MakeCsvDataFrame(fileName);
 
-   gSystem->GetProcInfo(&info);
-   memBefore = info.fMemResident;
-
-   assert(*tdf2.Count() == numRows);
-
-   gSystem->GetProcInfo(&info);
-   memAfter = info.fMemResident;
-
-   // Check that this time we allocated memory for all the rows 
-   assert(memAfter - memBefore > sizeInKB);   
+   rdflines = *rdf2.Count();
+   std::cout << "Total num lines: " << rdflines << std::endl;
 
    return 0; 
 }

--- a/root/dataframe/test_progressiveCSV.ref
+++ b/root/dataframe/test_progressiveCSV.ref
@@ -1,0 +1,8 @@
+Total num lines: 5000
+Total num lines: 5000
+Info in <GetEntryRanges>: Attempted to read chunk of 2000 lines of CSV file into memory, 2000 lines read
+Info in <GetEntryRanges>: Attempted to read chunk of 2000 lines of CSV file into memory, 2000 lines read
+Info in <GetEntryRanges>: Attempted to read chunk of 2000 lines of CSV file into memory, 1000 lines read
+Info in <GetEntryRanges>: Attempted to read chunk of 2000 lines of CSV file into memory, 0 lines read
+Info in <GetEntryRanges>: Attempted to read entire CSV file into memory, 5000 lines read
+Info in <GetEntryRanges>: Attempted to read entire CSV file into memory, 0 lines read

--- a/root/dataframe/test_progressiveCSV.sh
+++ b/root/dataframe/test_progressiveCSV.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+TESTNAME=test_progressiveCSV
+
+# Run test
+ROOTDEBUG=1 ./$TESTNAME 1>${TESTNAME}.out 2>${TESTNAME}.err
+
+# Print only messages about lines being read from CSV file
+cat ${TESTNAME}.out | grep "Total num lines"
+cat ${TESTNAME}.err | grep "GetEntryRanges"
+


### PR DESCRIPTION
Change test to check when new lines of CSV file are read. The previous strategy, which consisted in checking the resident memory of the process before and after running the RDF computation, was not reliable and made the test fail intermittently.