### PR TITLE
json: test writing and reading std::map as JSON object

### DIFF
--- a/root/io/json/Makefile
+++ b/root/io/json/Makefile
@@ -7,7 +7,7 @@ CLEAN_TARGETS += $(ALL_LIBRARIES) *.log *.clog
 # only target added.  If the name of the target is changed in the rules then
 # the name should be changed accordingly in this list.
 
-TEST_TARGETS += PolyMarker ArrayCompress BasicTypes String Objects STL STL1 STL0 StreamerLoop RootClasses mytest
+TEST_TARGETS += PolyMarker ArrayCompress BasicTypes String Objects STL STL1 STL0 StreamerLoop RootClasses Map mytest
 
 # Search for Rules.mk in roottest/scripts
 # Algorithm:  Find the current working directory and remove everything after
@@ -91,6 +91,9 @@ STL0: STL0.log
 	$(TestDiff)
 
 StreamerLoop: StreamerLoop.log
+	$(TestDiff)
+
+Map: Map.log
 	$(TestDiff)
 
 StreamerLoop.log STL.log STL1.log STL0.log Objects.log String.log BasicTypes.log RootClasses.log: test_classes_h.$(DllSuf)

--- a/root/io/json/Map.ref
+++ b/root/io/json/Map.ref
@@ -1,0 +1,8 @@
+
+Processing runMap.C...
+DEFAULT: [{"$pair" : "pair<string,int>", "first" : "field0", "second" : 0}, {"$pair" : "pair<string,int>", "first" : "field1", "second" : 7}, {"$pair" : "pair<string,int>", "first" : "field2", "second" : 14}, {"$pair" : "pair<string,int>", "first" : "field3", "second" : 21}, {"$pair" : "pair<string,int>", "first" : "field4", "second" : 28}, {"$pair" : "pair<string,int>", "first" : "field5", "second" : 35}, {"$pair" : "pair<string,int>", "first" : "field6", "second" : 42}, {"$pair" : "pair<string,int>", "first" : "field7", "second" : 49}, {"$pair" : "pair<string,int>", "first" : "field8", "second" : 56}, {"$pair" : "pair<string,int>", "first" : "field9", "second" : 63}]
+Data matches
+OBJECT: {"_typename": "map<string,int>", "field0": 0, "field1": 7, "field2": 14, "field3": 21, "field4": 28, "field5": 35, "field6": 42, "field7": 49, "field8": 56, "field9": 63}
+Data matches
+MINIMAL: {"field0":0,"field1":7,"field2":14,"field3":21,"field4":28,"field5":35,"field6":42,"field7":49,"field8":56,"field9":63}
+Data matches

--- a/root/io/json/runMap.C
+++ b/root/io/json/runMap.C
@@ -37,10 +37,10 @@ void runMap()
       data[key] = n*7;
    }
 
-   testJson(data, 0, "DEFAULT: ");
+   testJson(data, TBufferJSON::kNoCompress, "DEFAULT: ");
 
-   testJson(data, 5, "OBJECT: ");
+   testJson(data, TBufferJSON::kMapAsObject, "OBJECT: ");
 
-   testJson(data, 108, "MINIMAL: ");
+   testJson(data, TBufferJSON::kSkipTypeInfo + TBufferJSON::kMapAsObject + TBufferJSON::kNoSpaces, "MINIMAL: ");
 
 }

--- a/root/io/json/runMap.C
+++ b/root/io/json/runMap.C
@@ -1,0 +1,46 @@
+#include "TBufferJSON.h"
+#include <map>
+#include <string>
+
+void testJson(std::map<std::string,int> &data, int compact, const char *name)
+{
+   auto json = TBufferJSON::ToJSON(&data, compact);
+
+   std::cout << name << json << std::endl;
+
+   auto mread = TBufferJSON::FromJSON<std::map<std::string,int>>(json.Data());
+   if (!mread) {
+      std::cout << "Fail to read map from JSON" << std::endl;
+   } else if (data.size() != mread->size()) {
+      std::cout << "Mismatch in maps size " << data.size() << "  " << mread->size() << std::endl;
+   } else {
+      bool isok = true;
+      for (auto &item : data) {
+         if (mread->at(item.first) != item.second) {
+            std::cout << "Failure with field " << item.first << std::endl;
+            isok = false;
+         }
+      }
+      if (isok)
+         std::cout << "Data matches" << std::endl;
+   }
+
+}
+
+void runMap()
+{
+   std::map<std::string,int> data;
+
+   for (int n=0;n<10;++n) {
+      std::string key = "field";
+      key.append(std::to_string(n));
+      data[key] = n*7;
+   }
+
+   testJson(data, 0, "DEFAULT: ");
+
+   testJson(data, 5, "OBJECT: ");
+
+   testJson(data, 108, "MINIMAL: ");
+
+}


### PR DESCRIPTION
Testing new funcitonlaity to store special kinds of map as JSON object.
Such representation is much more compact than default one.
But works only for limited usecases, therefore cannot be used by
default.