### PR TITLE
[Exp PyROOT] Fix roottest-python-cling tests

### DIFF
--- a/python/cling/CMakeLists.txt
+++ b/python/cling/CMakeLists.txt
@@ -1,11 +1,15 @@
 if(ROOT_python_FOUND)
+  if (ROOT_pyroot_experimental_FOUND)
+    set(api_macro_file runPyAPITestCppyy.C) # Uses new Cppyy API
+  else()
+    set(api_macro_file runPyAPITest.C)
+  endif()
   ROOTTEST_ADD_TEST(api
-                    MACRO runPyAPITest.C
+                    MACRO ${api_macro_file}
                     WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
                     OUTREF PyAPITest.ref
                     ENVIRONMENT CLING_STANDARD_PCH=none
-                                CPPYY_BACKEND_LIBRARY=${CMAKE_BINARY_DIR}/lib/libcppyy_backend.so
-                    ${PYTESTS_WILLFAIL})
+                                CPPYY_BACKEND_LIBRARY=${CMAKE_BINARY_DIR}/lib/libcppyy_backend.so)
 
   ROOTTEST_ADD_TEST(class MACRO
                     runPyClassTest.C

--- a/python/cling/CMakeLists.txt
+++ b/python/cling/CMakeLists.txt
@@ -3,12 +3,16 @@ if(ROOT_python_FOUND)
                     MACRO runPyAPITest.C
                     WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
                     OUTREF PyAPITest.ref
+                    ENVIRONMENT CLING_STANDARD_PCH=none
+                                CPPYY_BACKEND_LIBRARY=${CMAKE_BINARY_DIR}/lib/libcppyy_backend.so
                     ${PYTESTS_WILLFAIL})
 
   ROOTTEST_ADD_TEST(class MACRO
                     runPyClassTest.C
                     WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
                     OUTREF PyClassTest.ref
+                    ENVIRONMENT CLING_STANDARD_PCH=none
+                    CPPYY_BACKEND_LIBRARY=${CMAKE_BINARY_DIR}/lib/libcppyy_backend.so
                     ${PYTESTS_WILLFAIL})
 
   ROOTTEST_ADD_TEST(cling

--- a/python/cling/CMakeLists.txt
+++ b/python/cling/CMakeLists.txt
@@ -24,6 +24,5 @@ if(ROOT_python_FOUND)
   ROOTTEST_ADD_TEST(cling
                     MACRO PyROOT_clingtests.py
                     WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-                    OUTREF PyROOT_clingtests.ref
-                    ${PYTESTS_WILLFAIL})
+                    OUTREF PyROOT_clingtests.ref)
 endif()

--- a/python/cling/CMakeLists.txt
+++ b/python/cling/CMakeLists.txt
@@ -11,6 +11,8 @@ if(ROOT_python_FOUND)
                     ENVIRONMENT CLING_STANDARD_PCH=none
                                 CPPYY_BACKEND_LIBRARY=${CMAKE_BINARY_DIR}/lib/libcppyy_backend.so)
 
+  # TPython::LoadMacro and TPython::Import are broken in the new Cppyy
+  # https://bitbucket.org/wlav/cppyy/issues/65 
   ROOTTEST_ADD_TEST(class MACRO
                     runPyClassTest.C
                     WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}

--- a/python/cling/runPyAPITestCppyy.C
+++ b/python/cling/runPyAPITestCppyy.C
@@ -1,0 +1,17 @@
+#include "CPyCppyy/TPython.h"
+#include "TError.h"
+
+void runPyAPITestCppyy() {
+// The higher warning ignore level is to suppress warnings about
+// classes already being in the class table (on Mac).
+   int eil = gErrorIgnoreLevel;
+   gErrorIgnoreLevel = kError;
+
+   TObject* o = new TObject;
+   PyObject* a = TPython::CPPInstance_FromVoidPtr( o, "TObject" );
+   printf( "OBC:  should be true:  %d\n", TPython::CPPInstance_Check( a ) );
+   printf( "OBCE: should be false: %d\n", TPython::CPPInstance_CheckExact( a ) );
+
+   Bool_t match = ( o == TPython::CPPInstance_AsVoidPtr( a ) );
+   printf( "VPC:  should be true:  %d\n", match );
+}


### PR DESCRIPTION
This PR needs to be merged after https://github.com/root-project/root/pull/3731, since it needs the `RPyROOTApplication` functionality for wrapping ROOT warnings into Python warnings.