### PR TITLE
[Exp PyROOT] Use correct Python type in test python-function

### DIFF
--- a/python/function/CMakeLists.txt
+++ b/python/function/CMakeLists.txt
@@ -1,9 +1,14 @@
 if(ROOT_python_FOUND)
+  if (ROOT_pyroot_experimental_FOUND)
+    set(exp_pyroot True)
+  else()
+    set(exp_pyroot False)
+  endif()
   ROOTTEST_ADD_TEST(function
                     MACRO PyROOT_functiontests.py
                     COPY_TO_BUILDDIR InstallableFunction.C GlobalFunction.C GlobalFunction2.C GlobalFunction3.C
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ InstallableFunction.C+
                                              -e .L\ GlobalFunction2.C+
                                              -e .L\ GlobalFunction3.C+
-                    ${PYTESTS_WILLFAIL})
+                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
 endif()

--- a/python/function/PyROOT_functiontests.py
+++ b/python/function/PyROOT_functiontests.py
@@ -63,7 +63,12 @@ def fcn( npar, gin, f, par, iflag ):
       delta  = (z[i]-func(x[i],y[i],par))/errorz[i]
       chisq += delta*delta
 
-   f[0] = chisq
+   if os.environ.get('EXP_PYROOT') == 'True':
+      # In the new Cppyy, f is a ctypes.c_double (see ROOT-10029).
+      # Thus, the assignment needs to be done to its value attribute
+      f.value = chisq
+   else:
+      f[0] = chisq
    ncount += 1
 
 def func( x, y, par ):


### PR DESCRIPTION
In the new Cppyy, `double&` is `ctypes.c_double` in Python and therefore the assignment needs to be done to its value attribute, see:
https://sft.its.cern.ch/jira/browse/ROOT-10029