### PR TITLE
[cxxmodules] Narrow the excluded tests.

### DIFF
--- a/root/io/CMakeLists.txt
+++ b/root/io/CMakeLists.txt
@@ -1,4 +1,5 @@
 # FIXME: Temporary workaround for runtime_cxxmodules
-if(NOT ROOT_runtime_cxxmodules_FOUND)
-ROOTTEST_ADD_TESTDIRS()
+if(ROOT_runtime_cxxmodules_FOUND)
+  set(excluded tuple)
 endif()
+ROOTTEST_ADD_TESTDIRS(EXCLUDED_DIRS ${excluded})


### PR DESCRIPTION
We fail only when running roottest/root/io/tuple tests.