### PR TITLE
Narrow excluded tests

### DIFF
--- a/cling/CMakeLists.txt
+++ b/cling/CMakeLists.txt
@@ -1,1 +1,5 @@
-ROOTTEST_ADD_TESTDIRS()
+if(ROOT_runtime_cxxmodules_FOUND)
+  ROOTTEST_ADD_TESTDIRS(EXCLUDED_DIRS typedef_global)
+else()
+  ROOTTEST_ADD_TESTDIRS()
+endif()


### PR DESCRIPTION
roottest/cling/typedef_global tests fail