### PR TITLE
Do not leave "#define private public" in interpreter!

### DIFF
--- a/root/io/newClassDef/featuretest/ClassTrick.C
+++ b/root/io/newClassDef/featuretest/ClassTrick.C
@@ -12,3 +12,8 @@ bool ClassTrick() {
   return false;
 #endif
 }
+
+// This file gets included in the dictionary and the interpreter,
+// make sure we clean up behind us!
+#undef private
+#undef protected


### PR DESCRIPTION
This is suppopsed to fix the test issue with clangHEAD:
Info in <TUnixSystem::ACLiC>: creating shared library /mnt/build/wsincrmaster/LABEL/ROOT-ubuntu1804-clangHEAD/SPEC/noimt/roottest/root/io/newClassDef/featuretest/ClassTrick_C.so
In file included from input_line_14:18:
In file included from /mnt/build/wsincrmaster/LABEL/ROOT-ubuntu1804-clangHEAD/SPEC/noimt/build/include/root_std_complex.h:13:
In file included from /usr/lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/complex:45:
/usr/lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/sstream:301:14: error: '__xfer_bufptrs' redeclared with 'public' access
      struct __xfer_bufptrs
             ^
/usr/lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/sstream:67:14: note: previously declared 'private' here
      struct __xfer_bufptrs;
             ^
Error in <ACLiC>: Dictionary generation failed!