### PR TITLE
changes after fixes of gcc9 warnings

### DIFF
--- a/root/meta/MemberComments.ref
+++ b/root/meta/MemberComments.ref
@@ -1,5 +1,5 @@
 
-Processing /Users/pcanal/root_working/roottest/root/meta/runMemberComments.C...
+Processing runMemberComments.C...
 
 TH1F::Class()->GetListOfAllPublicDataMembers():
 OBJ: TViewPubDataMembers	TViewPubDataMembers	 : 0
@@ -486,9 +486,9 @@ OBJ: TList	TList	Doubly linked list : 0
  OBJ: TMethod	TArrow	 : 0
       TArrow TArrow::TArrow(const TArrow& arrow)
  OBJ: TMethod	TAttBBox2D	 : 0
-      TAttBBox2D TAttBBox2D::TAttBBox2D(const TAttBBox2D&)
- OBJ: TMethod	TAttBBox2D	 : 0
       TAttBBox2D TAttBBox2D::TAttBBox2D()
+ OBJ: TMethod	TAttBBox2D	 : 0
+      TAttBBox2D TAttBBox2D::TAttBBox2D(const TAttBBox2D&)
  OBJ: TMethod	TAttFill	 : 0
       TAttFill TAttFill::TAttFill()
  OBJ: TMethod	TAttFill	 : 0
@@ -546,7 +546,7 @@ OBJ: TList	TList	Doubly linked list : 0
  OBJ: TMethod	operator=	 : 0
       TArrow& TArrow::operator=(const TArrow&)
  OBJ: TMethod	operator=	 : 0
-      TLine& TLine::operator=(const TLine&)
+      TLine& TLine::operator=(const TLine& src)
  OBJ: TMethod	operator=	 : 0
       TObject& TObject::operator=(const TObject& rhs)
  OBJ: TMethod	operator=	 : 0


### PR DESCRIPTION
Fix error appeared in https://github.com/root-project/root/pull/3876

In principle, one could restore original order of methods again. 