### PR TITLE
[cxxmodules] Remove workaround due to root-project/root#3990.

### DIFF
--- a/root/io/CMakeLists.txt
+++ b/root/io/CMakeLists.txt
@@ -1,5 +1,1 @@
-# FIXME: Temporary workaround for runtime_cxxmodules
-if(ROOT_runtime_cxxmodules_FOUND)
-  set(excluded tuple)
-endif()
-ROOTTEST_ADD_TESTDIRS(EXCLUDED_DIRS ${excluded})
+ROOTTEST_ADD_TESTDIRS()


### PR DESCRIPTION
As per root-project/root#3990