### PR TITLE
[Exp PyROOT] Adapt python-cpp-advanced to new Cppyy

### DIFF
--- a/python/cpp/CMakeLists.txt
+++ b/python/cpp/CMakeLists.txt
@@ -12,7 +12,8 @@ if(ROOT_python_FOUND)
                     COPY_TO_BUILDDIR AdvancedCpp.C Template.C
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ AdvancedCpp.C+
                                                      -e .L\ Template.C+
-                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
+                    ENVIRONMENT EXP_PYROOT=${exp_pyroot}
+                    ${PYTESTS_WILLFAIL})
                                          
   ROOTTEST_ADD_TEST(cpp11
                     MACRO PyROOT_cpp11tests.py

--- a/python/cpp/CMakeLists.txt
+++ b/python/cpp/CMakeLists.txt
@@ -12,7 +12,7 @@ if(ROOT_python_FOUND)
                     COPY_TO_BUILDDIR AdvancedCpp.C Template.C
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ AdvancedCpp.C+
                                                      -e .L\ Template.C+
-                    ${PYTESTS_WILLFAIL})
+                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
                                          
   ROOTTEST_ADD_TEST(cpp11
                     MACRO PyROOT_cpp11tests.py

--- a/python/cpp/PyROOT_advancedtests.py
+++ b/python/cpp/PyROOT_advancedtests.py
@@ -213,14 +213,34 @@ class Cpp02TemplateLookup( MyTestCase ):
          else:
             self.assert_( "must be explicit" in str(e) )
 
-      self.assertEqual( m.GetSize( 'char' )(),   m.GetCharSize() )
-      self.assertEqual( m.GetSize( int )(),      m.GetIntSize() )
-      self.assertEqual( m.GetSize( 'long' )(),   m.GetLongSize() )
-      self.assertEqual( m.GetSize( float )(),    m.GetFloatSize() )
-      self.assertEqual( m.GetSize( 'double' )(), m.GetDoubleSize() )
+      if self.exp_pyroot:
+         # New cppyy needs square brackets for explicit instantiation here,
+         # otherwise it tries to call the template proxy with the passed
+         # argument and it fails, since no instantiation is available. 
+         inst_char = m.GetSize['char']
+         inst_int = m.GetSize[int]
+         inst_long = m.GetSize['long']
+         inst_float = m.GetSize[float]
+         inst_double = m.GetSize['double']
+         inst_my_vec_double = m.GetSize['MyDoubleVector_t']
+         inst_vec_double = m.GetSize['vector<double>']
+      else:
+         inst_char = m.GetSize('char')
+         inst_int = m.GetSize(int)
+         inst_long = m.GetSize('long')
+         inst_float = m.GetSize(float)
+         inst_double = m.GetSize('double')
+         inst_my_vec_double = m.GetSize('MyDoubleVector_t')
+         inst_vec_double = m.GetSize('vector<double>')
 
-      self.assertEqual( m.GetSize( 'MyDoubleVector_t' )(), m.GetVectorOfDoubleSize() )
-      self.assertEqual( m.GetSize( 'vector<double>' )(), m.GetVectorOfDoubleSize() )
+      self.assertEqual( inst_char(),   m.GetCharSize() )
+      self.assertEqual( inst_int(),      m.GetIntSize() )
+      self.assertEqual( inst_long(),   m.GetLongSize() )
+      self.assertEqual( inst_float(),    m.GetFloatSize() )
+      self.assertEqual( inst_double(), m.GetDoubleSize() )
+
+      self.assertEqual( inst_my_vec_double(), m.GetVectorOfDoubleSize() )
+      self.assertEqual( inst_vec_double(), m.GetVectorOfDoubleSize() )
 
    def test05TemplateMemberFunctions( self ):
       """Test template member functions lookup and calls (set 2)"""

--- a/python/cpp/PyROOT_advancedtests.py
+++ b/python/cpp/PyROOT_advancedtests.py
@@ -207,7 +207,11 @@ class Cpp02TemplateLookup( MyTestCase ):
       try:
          m.GetSize()
       except TypeError as e:
-         self.assert_( "must be explicit" in str(e) )
+         if self.exp_pyroot:
+            # The error message has changed in new Cppyy
+            self.assert_( "cannot resolve method template call" in str(e) )
+         else:
+            self.assert_( "must be explicit" in str(e) )
 
       self.assertEqual( m.GetSize( 'char' )(),   m.GetCharSize() )
       self.assertEqual( m.GetSize( int )(),      m.GetIntSize() )
@@ -458,6 +462,10 @@ class Cpp04HandlingAbstractClasses( MyTestCase ):
 
 ### Return by reference should call assignment operator ======================
 class Cpp05AssignToRefArbitraryClass( MyTestCase ):
+   @classmethod
+   def setUpClass(cls):
+      cls.exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
+
    def test1AssignToReturnByRef( self ):
       """Test assignment to an instance returned by reference"""
       
@@ -485,7 +493,11 @@ class Cpp05AssignToRefArbitraryClass( MyTestCase ):
       try:
          a[0] = RefTesterNoAssign()
       except TypeError as e:
-         self.assert_( 'can not assign' in str(e) )
+         if self.exp_pyroot:
+            # Message has changed in new Cppyy
+            self.assert_( 'cannot assign' in str(e) )
+         else:
+            self.assert_( 'can not assign' in str(e) )
 
 
 ### Check availability of math conversions ===================================

--- a/python/cpp/PyROOT_advancedtests.py
+++ b/python/cpp/PyROOT_advancedtests.py
@@ -241,9 +241,10 @@ class Cpp02TemplateLookup( MyTestCase ):
          # Cppyy's Long will be deprecated in favour of ctypes.c_long
          # https://bitbucket.org/wlav/cppyy/issues/101
          long_par = ctypes.c_long(256).value
+         self.assertEqual( m.GetSize2(long_par, 1.), m.GetDoubleSize() - m.GetIntSize() )
       else:
          long_par = ROOT.Long(256)
-      self.assertEqual( m.GetSize2(long_par, 1.), m.GetFloatSize() - m.GetLongSize() )
+         self.assertEqual( m.GetSize2(long_par, 1.), m.GetDoubleSize() - m.GetLongSize() )
 
    def test06OverloadedTemplateMemberFunctions( self ):
       """Test overloaded template member functions lookup and calls"""

--- a/python/cpp/PyROOT_advancedtests.py
+++ b/python/cpp/PyROOT_advancedtests.py
@@ -265,7 +265,12 @@ class Cpp02TemplateLookup( MyTestCase ):
       self.assertEqual( len(dir(MyTemplatedMethodClass)), nd )
 
     # use existing explicit instantiations
-      self.assertEqual( m.GetSizeOL( float )( 3.14 ),  m.GetFloatSize() )
+      if self.exp_pyroot:
+         # New cppyy: use bracket syntax for explicit instantiation
+         inst = m.GetSizeOL[float]
+      else:
+         inst = m.GetSizeOL(float)
+      self.assertEqual( inst( 3.14 ),  m.GetFloatSize() )
       self.assertEqual( m.GetSizeOL( 3.14 ),           m.GetDoubleSize() )
       self.assertEqual( len(dir(MyTemplatedMethodClass)), nd + 2)
 
@@ -309,11 +314,14 @@ class Cpp02TemplateLookup( MyTestCase ):
          # the bindings to know we are explicitly instantiating for char.
          # Otherwise, the templated parameter is just (mis)interpreted as
          # string and a call to the string instantiation is made.
-         inst = m.GetSizeNEI['char']
+         inst_char = m.GetSizeNEI['char']
+         # This instantiation also needs square brackets in new Cppyy
+         inst_int = m.GetSizeNEI[int]
       else:
-         inst = m.GetSizeNEI('char')
-      self.assertEqual(inst('c'), m.GetCharSize())
-      self.assertEqual(m.GetSizeNEI(int)(1), m.GetIntSize())
+         inst_char = m.GetSizeNEI('char')
+         inst_int = m.GetSizeNEI(int)
+      self.assertEqual(inst_char('c'), m.GetCharSize())
+      self.assertEqual(inst_int(1), m.GetIntSize())
 
       # Test the non-templated overload (must have been added to
       # the template proxy too)

--- a/python/cpp/PyROOT_advancedtests.py
+++ b/python/cpp/PyROOT_advancedtests.py
@@ -12,6 +12,8 @@ import ROOT
 from ROOT import gROOT, Long, Double, std
 from common import *
 
+import ctypes
+
 __all__ = [
    'Cpp01VirtualInheritence',
    'Cpp02TemplateLookup',
@@ -235,7 +237,13 @@ class Cpp02TemplateLookup( MyTestCase ):
       else:
          inst = m.GetSize2('char', 'long')
       self.assertEqual(inst( 1, 'a' ), m.GetCharSize() - m.GetLongSize() )
-      self.assertEqual( m.GetSize2(ROOT.Long(256), 1.), m.GetDoubleSize() - m.GetLongSize() )
+      if self.exp_pyroot:
+         # Cppyy's Long will be deprecated in favour of ctypes.c_long
+         # https://bitbucket.org/wlav/cppyy/issues/101
+         long_par = ctypes.c_long(256).value
+      else:
+         long_par = ROOT.Long(256)
+      self.assertEqual( m.GetSize2(long_par, 1.), m.GetFloatSize() - m.GetLongSize() )
 
    def test06OverloadedTemplateMemberFunctions( self ):
       """Test overloaded template member functions lookup and calls"""


### PR DESCRIPTION
Note: the test `roottest-python-cpp-advanced` can't be fully re-enabled until the resolution of these two Cppyy issues:
- https://bitbucket.org/wlav/cppyy/issues/113/
- https://bitbucket.org/wlav/cppyy/issues/115/