### PR TITLE
[cxxmodules] Filter out source locations.

### DIFF
--- a/cling/operator/EqualTest.ref-cling
+++ b/cling/operator/EqualTest.ref-cling
@@ -2,7 +2,7 @@
 Processing runEqualTest.C...
 ===========================================================================
 class privateOp2
-SIZE: 4 FILE: equal.C LINE: 29
+SIZE: 4 FILE: equal.C LINE: N/A
 List of member variables --------------------------------------------------
 List of member functions :---------------------------------------------------
 filename     line:size busy function type and name

--- a/cling/operator/EqualTest_convert.sh
+++ b/cling/operator/EqualTest_convert.sh
@@ -1,2 +1,2 @@
-sed -e 's?FILE:.*[/\]?FILE:?' -e 's/.dll/.so/g' \
+sed -e 's?FILE:.*[/\]?FILE:?' -e 's/.dll/.so/g' | sed -E "s,(: )-?[0-9]+$,\1N/A," \
 | grep -v -e tagnum -e 'int c' -e '~privateOp2'


### PR DESCRIPTION
If the declaration comes from an AST file no source locations are printed.

This patch is in the same direction as we took in root-project/roottest@3a8dfca4

This is part of root-project/root#3850