### PR TITLE
[Exp PyROOT] More modifications for python-cpp-advanced

### DIFF
--- a/python/cpp/PyROOT_advancedtests.py
+++ b/python/cpp/PyROOT_advancedtests.py
@@ -295,7 +295,16 @@ class Cpp02TemplateLookup( MyTestCase ):
       else:
          inst = m.GetSizeOL(float)
       self.assertEqual( inst( 3.14 ),  m.GetFloatSize() )
-      self.assertEqual( m.GetSizeOL( 3.14 ),           m.GetDoubleSize() )
+
+      if self.exp_pyroot:
+         # In new cppyy, since an instantiation of GetSizeOL for
+         # float already exists, that instantiation will be picked
+         # instead of creating a new instantiation for double.
+         # https://bitbucket.org/wlav/cppyy/issues/115
+         self.assertEqual( m.GetSizeOL( 3.14 ), m.GetFloatSize() )
+      else:
+         self.assertEqual( m.GetSizeOL( 3.14 ), m.GetDoubleSize() )
+      
       self.assertEqual( len(dir(MyTemplatedMethodClass)), nd + 2)
 
     # explicit forced instantiation

--- a/python/cpp/PyROOT_advancedtests.py
+++ b/python/cpp/PyROOT_advancedtests.py
@@ -294,6 +294,7 @@ class Cpp02TemplateLookup( MyTestCase ):
          inst = m.GetSizeOL[float]
       else:
          inst = m.GetSizeOL(float)
+      num_new_inst = 1
       self.assertEqual( inst( 3.14 ),  m.GetFloatSize() )
 
       if self.exp_pyroot:
@@ -304,8 +305,10 @@ class Cpp02TemplateLookup( MyTestCase ):
          self.assertEqual( m.GetSizeOL( 3.14 ), m.GetFloatSize() )
       else:
          self.assertEqual( m.GetSizeOL( 3.14 ), m.GetDoubleSize() )
-      
-      self.assertEqual( len(dir(MyTemplatedMethodClass)), nd + 2)
+         # GetSizeOL<double> is only instantiated here
+         num_new_inst += 1
+
+      self.assertEqual( len(dir(MyTemplatedMethodClass)), nd + num_new_inst)
 
     # explicit forced instantiation
       self.assertEqual( m.GetSizeOL( int )( 1 ),       m.GetIntSize() )

--- a/python/cpp/PyROOT_advancedtests.py
+++ b/python/cpp/PyROOT_advancedtests.py
@@ -311,13 +311,18 @@ class Cpp02TemplateLookup( MyTestCase ):
       self.assertEqual( len(dir(MyTemplatedMethodClass)), nd + num_new_inst)
 
     # explicit forced instantiation
-      self.assertEqual( m.GetSizeOL( int )( 1 ),       m.GetIntSize() )
+      if self.exp_pyroot:
+         # New cppyy: use bracket syntax for explicit instantiation
+         inst = m.GetSizeOL[int]
+      else:
+         inst = m.GetSizeOL(int)
+      self.assertEqual( inst( 1 ),       m.GetIntSize() )
       self.assertEqual( len(dir(MyTemplatedMethodClass)), nd + 3 )
       self.assert_( 'GetSizeOL<int>' in dir(MyTemplatedMethodClass) )
       gzoi_id = id( MyTemplatedMethodClass.__dict__[ 'GetSizeOL<int>' ] )
 
     # second call should make no changes, but re-use
-      self.assertEqual( m.GetSizeOL( int )( 1 ),       m.GetIntSize() )
+      self.assertEqual( inst( 1 ),       m.GetIntSize() )
       self.assertEqual( len(dir(MyTemplatedMethodClass)), nd + 3 )
       self.assertEqual( gzoi_id, id( MyTemplatedMethodClass.__dict__[ 'GetSizeOL<int>' ] ) )
 

--- a/python/cpp/PyROOT_advancedtests.py
+++ b/python/cpp/PyROOT_advancedtests.py
@@ -316,19 +316,21 @@ class Cpp02TemplateLookup( MyTestCase ):
          inst = m.GetSizeOL[int]
       else:
          inst = m.GetSizeOL(int)
+      num_new_inst += 1
       self.assertEqual( inst( 1 ),       m.GetIntSize() )
-      self.assertEqual( len(dir(MyTemplatedMethodClass)), nd + 3 )
+      self.assertEqual( len(dir(MyTemplatedMethodClass)), nd + num_new_inst )
       self.assert_( 'GetSizeOL<int>' in dir(MyTemplatedMethodClass) )
       gzoi_id = id( MyTemplatedMethodClass.__dict__[ 'GetSizeOL<int>' ] )
 
     # second call should make no changes, but re-use
       self.assertEqual( inst( 1 ),       m.GetIntSize() )
-      self.assertEqual( len(dir(MyTemplatedMethodClass)), nd + 3 )
+      self.assertEqual( len(dir(MyTemplatedMethodClass)), nd + num_new_inst )
       self.assertEqual( gzoi_id, id( MyTemplatedMethodClass.__dict__[ 'GetSizeOL<int>' ] ) )
 
     # implicitly forced instantiation
       self.assertEqual( m.GetSizeOL( MyDoubleVector_t() ), m.GetVectorOfDoubleSize() )
-      self.assertEqual( len(dir(MyTemplatedMethodClass)), nd + 4 )
+      num_new_inst += 1
+      self.assertEqual( len(dir(MyTemplatedMethodClass)), nd + num_new_inst )
       for key in MyTemplatedMethodClass.__dict__.keys():
        # the actual method name is implementation dependent (due to the
        # default vars, and vector could live in a versioned namespace),
@@ -340,7 +342,7 @@ class Cpp02TemplateLookup( MyTestCase ):
 
     # as above, no changes on 2nd call
       self.assertEqual( m.GetSizeOL( MyDoubleVector_t() ), m.GetVectorOfDoubleSize() )
-      self.assertEqual( len(dir(MyTemplatedMethodClass)), nd + 4 )
+      self.assertEqual( len(dir(MyTemplatedMethodClass)), nd + num_new_inst )
       self.assertEqual( gzoi_id, id( MyTemplatedMethodClass.__dict__[ mname ] ) )
 
    def test07TemplateMemberFunctionsNotInstantiated(self):


### PR DESCRIPTION
This is a new round of modifications for `roottest-python-cpp-advanced` to work with PyROOT experimental. The test is not fully working yet because of two pending issues:
- https://bitbucket.org/wlav/cppyy/issues/113 : fixed in CPyCppyy's repo, an update of the PyROOT's copy of Cppyy is needed to incorporate it. Trying to cherry pick only the related changes results in new crashes in the same test that might be caused by missing previous changes in Cppyy. To be checked.
- https://bitbucket.org/wlav/cppyy/issues/121