### PR TITLE
[cxxmodules] Fix tests for cxxmodules build on MacOSX

### DIFF
--- a/cling/exception/CMakeLists.txt
+++ b/cling/exception/CMakeLists.txt
@@ -1,4 +1,5 @@
-if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64.*|x86.*|amd64.*|AMD64.*|i686.*|i386.*")
+  # All platforms except of ARM/AARCH64
   ROOTTEST_ADD_TEST(nullderef-macro
                     MACRO nullderef.C
                     PASSRC 1
@@ -6,6 +7,6 @@ if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
 endif()
 
 ROOTTEST_ADD_TEST(nullderef-e
-                  COMMAND root -l -b -q -e 'int*p=nullptr;*p'
+                  COMMAND ${ROOT_root_CMD} -l -b -q -e "int*p=nullptr" -e "*p"
                   PASSRC 1
                   LABELS roottest regression cling)

--- a/cling/functionTemplate/CMakeLists.txt
+++ b/cling/functionTemplate/CMakeLists.txt
@@ -12,7 +12,7 @@ ROOTTEST_ADD_TEST(runreferenceuse
 
 ROOTTEST_ADD_TEST(testcint
                   MACRO testcint.py
-                  PRECMD root -b -q -l -e .L\ t.h+
+                  PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ t.h+
                   OUTREF pythoncintrun.ref
                   OUTCNVCMD grep -v "just a comment"
                   WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}

--- a/cling/specialobj/CMakeLists.txt
+++ b/cling/specialobj/CMakeLists.txt
@@ -17,7 +17,8 @@ ROOTTEST_ADD_TEST(stlProxies
                   DEPENDS stlwrite
                   LABELS roottest regression cling)
 
-if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64.*|x86.*|amd64.*|AMD64.*|i686.*|i386.*")
+  # All platforms except of ARM/AARCH64
   ROOTTEST_ADD_TEST(runf02
                     MACRO runf02.C
                     OUTCNVCMD sed -e s,input_line_[0-9]*,input_line_FILTERED,g

--- a/cling/specialobj/f02.ref
+++ b/cling/specialobj/f02.ref
@@ -10,7 +10,7 @@ input_line_FILTERED:2:3: error: use of undeclared identifier 'ThisReallyDoesNotE
   ^
 Error in <HandleInterpreterException>: Error evaluating expression (ThisReallyDoesNotExist[42]).
 Execution of your code was aborted.
-input_line_17:2:7: error: use of undeclared identifier 'WhyAmI'
+input_line_FILTERED:2:7: error: use of undeclared identifier 'WhyAmI'
 (1 ? WhyAmI : 0)
 ^
 Error in <HandleInterpreterException>: Error evaluating expression (1 ? WhyAmI : 0).

--- a/root/rint/CMakeLists.txt
+++ b/root/rint/CMakeLists.txt
@@ -1,4 +1,5 @@
-if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64.*|x86.*|amd64.*|AMD64.*|i686.*|i386.*")
+  # All platforms except of ARM/AARCH64
   ROOTTEST_ADD_TEST(TabCom
                     COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/driveTabCom.py
                     INPUT TabCom_input.txt


### PR DESCRIPTION
Fixes 2 tests for cxxmodules MacOSX builds http://cdash.cern.ch/testDetails.php?test=67555125&build=685983 && http://cdash.cern.ch/testDetails.php?test=67555125&build=685983

Originally test gives incorrect results also on non-cxxmodules build (ubuntu), but it is always green because expected output is test failure:
```
-- TEST COMMAND -- 
cd /mnt/build/night/LABEL/ROOT-ubuntu1804-clangHEAD/SPEC/cxxmod-noimt/V/6-18/build/roottest/cling/exception
/usr/bin/timeout -s USR2 270s root -l -b -q -e ''int*p=nullptr' *p'
-- BEGIN TEST OUTPUT --
-- END TEST OUTPUT --
-- BEGIN TEST ERROR --
Warning in <TApplication::GetOptions>: macro *p' not found
ROOT_cli_0:1:1: warning: missing terminating ' character [-Winvalid-pp-token]
'int*p=nullptr
^
ROOT_cli_0:1:1: error: expected expression

-- END TEST ERROR
```

If you will call directly from command line: `root -l -b -q -e "int*p=nullptr; *p"` you suppose to get next: https://gist.github.com/oshadura/1ee9cf4daf8cc4201d5ee63a164dbdda , giving exception about trying to dereference null pointer or trying to call routine taking non-null arguments.

Failure was noticeable in Mac OS X in cxxmodules builds, maybe due different way how bash works.

```
/build/jenkins/night/LABEL/mac1014/SPEC/cxxmod-noimt/build/roottest/cling/exception/root -l -b -q -e ''int*p=nullptr' *p'
-- BEGIN TEST OUTPUT --
-- END TEST OUTPUT --
CMake Error at /build/jenkins/night/LABEL/mac1014/SPEC/cxxmod-noimt/root/cmake/modules/RootTestDriver.cmake:190 (message):
  got exit code No such file or directory but expected 1
```
The original problem is in RootTestDriver.cmake, which removes all ";" and make some transformations on a COMMAND input string. Fixing/expanding RootTestDriver.cmake will take significant time (I already tried to fix it, but it takes longer time). So my proposal is to move from direct root invocation to use ROOT macro for this test.

Also in test directory, there is other macro used only for arm, which is testing the same functionality and for me it looks like it should be part of `if(arm).. else()`.
