### PR TITLE
Cmake: tighten ROOTTEST_GENERATE_EXECUTABLE

### DIFF
--- a/cmake/modules/RoottestMacros.cmake
+++ b/cmake/modules/RoottestMacros.cmake
@@ -399,15 +399,14 @@ endmacro(ROOTTEST_GENERATE_REFLEX_DICTIONARY)
 macro(ROOTTEST_GENERATE_EXECUTABLE executable)
   CMAKE_PARSE_ARGUMENTS(ARG "" "" "LIBRARIES;COMPILE_FLAGS;DEPENDS" ${ARGN})
 
-  set(exec_sources)
-  foreach(exec_src_file ${ARGN})
-    get_filename_component(exec_src_file ${exec_src_file} ABSOLUTE)
-    if(EXISTS ${exec_src_file})
-      list(APPEND exec_sources ${exec_src_file})
+  add_executable(${executable} EXCLUDE_FROM_ALL)
+  foreach(exec_src_file ${ARG_UNPARSED_ARGUMENTS})
+    if(NOT IS_ABSOLUTE ${exec_src_file})
+      get_filename_component(exec_src_file ${exec_src_file} ABSOLUTE)
     endif()
+    target_sources(${executable} PRIVATE ${exec_src_file})
   endforeach()
 
-  add_executable(${executable} EXCLUDE_FROM_ALL ${exec_sources})
   set_target_properties(${executable} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
   set_property(TARGET ${executable}

--- a/root/math/vdt/CMakeLists.txt
+++ b/root/math/vdt/CMakeLists.txt
@@ -7,7 +7,7 @@ include_directories(${VDT_INCLUDE_DIRS})
 
 ROOTTEST_GENERATE_EXECUTABLE(${testname}
                              ${testname}.cxx
-                             ADDITIONAL_COMPILE_FLAGS ${additional_compile_flags}
+                             COMPILE_FLAGS ${additional_compile_flags}
                              LIBRARIES Core Hist Gpad MathCore ${VDT_LIBRARIES})
 
 ROOTTEST_ADD_TEST(${testname}


### PR DESCRIPTION
Before, also already parsed arguments were potentially added as sources. "Potentially", because files that were not found were silently not added (like `LIBRARIES`, `Core` etc...)

Now, files that don't exist at configuration time *are* added (because they might be generated later, during build!). That now causes nice errors when an argument is misinterpreted as source file (e.g. misspelled parameter name).