### PR TITLE
[Exp PyROOT] Adapt python-memory test to new Cppyy

### DIFF
--- a/python/memory/CMakeLists.txt
+++ b/python/memory/CMakeLists.txt
@@ -3,5 +3,6 @@ if(ROOT_python_FOUND)
                     MACRO PyROOT_memorytests.py
                     COPY_TO_BUILDDIR MemTester.C
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ MemTester.C+
+                    ENVIRONMENT EXP_PYROOT=${exp_pyroot}
                     ${PYTESTS_WILLFAIL})
 endif()

--- a/python/memory/CMakeLists.txt
+++ b/python/memory/CMakeLists.txt
@@ -3,6 +3,5 @@ if(ROOT_python_FOUND)
                     MACRO PyROOT_memorytests.py
                     COPY_TO_BUILDDIR MemTester.C
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ MemTester.C+
-                    ENVIRONMENT EXP_PYROOT=${exp_pyroot}
-                    ${PYTESTS_WILLFAIL})
+                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
 endif()

--- a/python/memory/PyROOT_memorytests.py
+++ b/python/memory/PyROOT_memorytests.py
@@ -37,6 +37,10 @@ else:
 
 ### Memory management test cases =============================================
 class Memory1TestCase( MyTestCase ):
+   @classmethod
+   def setUpClass(cls):
+      cls.exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
+
    def test1ObjectCreationDestruction( self ):
       """Test object creation and destruction"""
 

--- a/python/memory/PyROOT_memorytests.py
+++ b/python/memory/PyROOT_memorytests.py
@@ -134,40 +134,50 @@ class Memory1TestCase( MyTestCase ):
       MemTester.CallPtr( b1 );
       self.assertEqual( MemTester.counter, 1 )
       del b1
-      self.assertEqual( MemTester.counter, 1 )
+      if self.exp_pyroot:
+         counter = 0
+      else:
+         counter = 1
+      self.assertEqual( MemTester.counter, counter )
 
       b2 = MemTester()
-      self.assertEqual( MemTester.counter, 2 )
+      counter += 1
+      self.assertEqual( MemTester.counter, counter )
       SetMemoryPolicy( kMemoryStrict )
       MemTester.CallPtr( b2 );
-      self.assertEqual( MemTester.counter, 2 )
+      self.assertEqual( MemTester.counter, counter )
       del b2
-      self.assertEqual( MemTester.counter, 1 )
+      counter -= 1
+      self.assertEqual( MemTester.counter, counter )
 
       b3 = MemTester()
-      self.assertEqual( MemTester.counter, 2 )
+      counter += 1
+      self.assertEqual( MemTester.counter, counter )
       SetMemoryPolicy( kMemoryHeuristics )
       MemTester.CallPtr( b3 );
-      self.assertEqual( MemTester.counter, 2 )
+      self.assertEqual( MemTester.counter, counter )
       del b3
-      self.assertEqual( MemTester.counter, 2 )
+      self.assertEqual( MemTester.counter, counter )
 
       b4 = MemTester()
-      self.assertEqual( MemTester.counter, 3 )
+      counter += 1
+      self.assertEqual( MemTester.counter, counter )
       self.set_mem_policy(MemTester.CallPtr, kMemoryStrict)
       MemTester.CallPtr( b4 );
-      self.assertEqual( MemTester.counter, 3 )
+      self.assertEqual( MemTester.counter, counter )
       del b4
-      self.assertEqual( MemTester.counter, 2 )
+      counter -= 1
+      self.assertEqual( MemTester.counter, counter )
 
       b5 = MemTester()
-      self.assertEqual( MemTester.counter, 3 )
+      counter += 1
+      self.assertEqual( MemTester.counter, counter )
       SetMemoryPolicy( kMemoryStrict )
       self.set_mem_policy(MemTester.CallPtr, kMemoryHeuristics)
       MemTester.CallPtr( b5 );
-      self.assertEqual( MemTester.counter, 3 )
+      self.assertEqual( MemTester.counter, counter )
       del b5
-      self.assertEqual( MemTester.counter, 3 )
+      self.assertEqual( MemTester.counter, counter )
 
     # test explicit destruction
       SetMemoryPolicy( kMemoryHeuristics )

--- a/python/memory/PyROOT_memorytests.py
+++ b/python/memory/PyROOT_memorytests.py
@@ -83,6 +83,13 @@ class Memory1TestCase( MyTestCase ):
     # should no longer be accessible
       self.assert_( not gROOT.FindObject( 'memtest_th1f' ) )
 
+   def set_mem_policy(self, callable_obj, pol):
+      # Set the memory policy of the callable object received
+      if self.exp_pyroot:
+         callable_obj.__mempolicy__ = pol
+      else:
+         callable_obj._mempolicy = pol
+
    def test3ObjectCallHeuristics( self ):
       """Test memory mgmt heuristics for object calls"""
       
@@ -96,11 +103,11 @@ class Memory1TestCase( MyTestCase ):
       MemTester.CallRef( a );
       self.assertEqual( MemTester.counter, 1 )
 
-      MemTester.CallRef._mempolicy = kMemoryStrict
+      self.set_mem_policy(MemTester.CallRef, kMemoryStrict)
       MemTester.CallRef( a );
       self.assertEqual( MemTester.counter, 1 )
 
-      MemTester.CallRef._mempolicy = kMemoryHeuristics
+      self.set_mem_policy(MemTester.CallRef, kMemoryHeuristics)
       MemTester.CallRef( a );
       self.assertEqual( MemTester.counter, 1 )
 
@@ -114,11 +121,11 @@ class Memory1TestCase( MyTestCase ):
       MemTester.CallConstPtr( MemTester() )
       self.assertEqual( MemTester.counter, 0 )
 
-      MemTester.CallConstPtr._mempolicy = kMemoryStrict
+      self.set_mem_policy(MemTester.CallConstPtr, kMemoryStrict)
       MemTester.CallConstPtr( MemTester() )
       self.assertEqual( MemTester.counter, 0 )
 
-      MemTester.CallConstPtr._mempolicy = kMemoryHeuristics
+      self.set_mem_policy(MemTester.CallConstPtr, kMemoryHeuristics)
       MemTester.CallConstPtr( MemTester() )
       self.assertEqual( MemTester.counter, 0 )
 
@@ -147,7 +154,7 @@ class Memory1TestCase( MyTestCase ):
 
       b4 = MemTester()
       self.assertEqual( MemTester.counter, 3 )
-      MemTester.CallPtr._mempolicy = kMemoryStrict
+      self.set_mem_policy(MemTester.CallPtr, kMemoryStrict)
       MemTester.CallPtr( b4 );
       self.assertEqual( MemTester.counter, 3 )
       del b4
@@ -156,7 +163,7 @@ class Memory1TestCase( MyTestCase ):
       b5 = MemTester()
       self.assertEqual( MemTester.counter, 3 )
       SetMemoryPolicy( kMemoryStrict )
-      MemTester.CallPtr._mempolicy = kMemoryHeuristics
+      self.set_mem_policy(MemTester.CallPtr, kMemoryHeuristics)
       MemTester.CallPtr( b5 );
       self.assertEqual( MemTester.counter, 3 )
       del b5
@@ -165,7 +172,7 @@ class Memory1TestCase( MyTestCase ):
     # test explicit destruction
       SetMemoryPolicy( kMemoryHeuristics )
       MemTester().counter = 1      # silly way of setting it to 0
-      MemTester.CallPtr._mempolicy = kMemoryHeuristics
+      self.set_mem_policy(MemTester.CallPtr, kMemoryHeuristics)
       self.assertEqual( MemTester.counter, 0 )
       c = MemTester()
       self.assertEqual( MemTester.counter, 1 )


### PR DESCRIPTION
Changes are mainly motivated by the change in the default memory policy (now is `kUseStrict`, used to be `kUseHeuristics`).