### PR TITLE
[Exp PyROOT] Test fixed: pythonizations-smartptr

### DIFF
--- a/python/pythonizations/CMakeLists.txt
+++ b/python/pythonizations/CMakeLists.txt
@@ -9,5 +9,5 @@ if(ROOT_python_FOUND)
                     MACRO PyROOT_smartptrtest.py
                     COPY_TO_BUILDDIR SmartPtr.C SmartPtr.h
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ SmartPtr.C+
-                    ${PYTESTS_WILLFAIL})
+                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
 endif()

--- a/python/pythonizations/PyROOT_smartptrtest.py
+++ b/python/pythonizations/PyROOT_smartptrtest.py
@@ -27,6 +27,10 @@ class TestClassSMARTPTRS:
         cls.test_dct = "SmartPtr_C"
         cls.smartptr = cppyy.load_reflection_info(cls.test_dct)
 
+        # We need to introduce it in order to distinguish between
+        # _get_smart_ptr in old Cppyy and __smartptr__ in new Cppyy
+        cls.exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
+
     def test01_transparency(self):
         import cppyy
 
@@ -34,7 +38,11 @@ class TestClassSMARTPTRS:
         mine = cppyy.gbl.mine
 
         assert type(mine) == MyShareable
-        assert type(mine._get_smart_ptr()) == cppyy.gbl.std.shared_ptr(MyShareable)
+        if self.exp_pyroot:
+            assert type(mine.__smartptr__()) == cppyy.gbl.std.shared_ptr(MyShareable)
+        else:
+            assert type(mine._get_smart_ptr()) == cppyy.gbl.std.shared_ptr(MyShareable)
+
         assert mine.say_hi() == "Hi!"
 
     def test02_converters(self):
@@ -49,11 +57,18 @@ class TestClassSMARTPTRS:
         cppyy.gbl.pass_mine_sp_ptr(mine)
         cppyy.gbl.pass_mine_sp_ref(mine)
 
-        cppyy.gbl.pass_mine_sp_ptr(mine._get_smart_ptr())
-        cppyy.gbl.pass_mine_sp_ref(mine._get_smart_ptr())
+        if self.exp_pyroot:
+            cppyy.gbl.pass_mine_sp_ptr(mine.__smartptr__())
+            cppyy.gbl.pass_mine_sp_ref(mine.__smartptr__())
+        else:
+            cppyy.gbl.pass_mine_sp_ptr(mine._get_smart_ptr())
+            cppyy.gbl.pass_mine_sp_ref(mine._get_smart_ptr())
 
         cppyy.gbl.pass_mine_sp(mine)
-        cppyy.gbl.pass_mine_sp(mine._get_smart_ptr())
+        if self.exp_pyroot:
+            cppyy.gbl.pass_mine_sp(mine.__smartptr__())
+        else:
+            cppyy.gbl.pass_mine_sp(mine._get_smart_ptr())
 
         # TODO:
         # cppyy.gbl.mine = mine
@@ -61,22 +76,31 @@ class TestClassSMARTPTRS:
 
     def test03_executors(self):
         import cppyy
-        
+
         MyShareable = cppyy.gbl.MyShareable
 
         mine = cppyy.gbl.gime_mine_ptr()
         assert type(mine) == MyShareable
-        assert type(mine._get_smart_ptr()) == cppyy.gbl.std.shared_ptr(MyShareable)
+        if self.exp_pyroot:
+            assert type(mine.__smartptr__()) == cppyy.gbl.std.shared_ptr(MyShareable)
+        else:
+            assert type(mine._get_smart_ptr()) == cppyy.gbl.std.shared_ptr(MyShareable)
         assert mine.say_hi() == "Hi!"
 
         mine = cppyy.gbl.gime_mine_ref()
         assert type(mine) == MyShareable
-        assert type(mine._get_smart_ptr()) == cppyy.gbl.std.shared_ptr(MyShareable)
+        if self.exp_pyroot:
+            assert type(mine.__smartptr__()) == cppyy.gbl.std.shared_ptr(MyShareable)
+        else:
+            assert type(mine._get_smart_ptr()) == cppyy.gbl.std.shared_ptr(MyShareable)
         assert mine.say_hi() == "Hi!"
 
         mine = cppyy.gbl.gime_mine()
         assert type(mine) == MyShareable
-        assert type(mine._get_smart_ptr()) == cppyy.gbl.std.shared_ptr(MyShareable)
+        if self.exp_pyroot:
+            assert type(mine.__smartptr__()) == cppyy.gbl.std.shared_ptr(MyShareable)
+        else:
+            assert type(mine._get_smart_ptr()) == cppyy.gbl.std.shared_ptr(MyShareable)
         assert mine.say_hi() == "Hi!"
 
 


### PR DESCRIPTION
The test mentioned in the title was fixed. The problem was simply that the attribute `_get_smart_ptr` became `__smartptr__` in new Cppyy.