### PR TITLE
[Exp PyROOT] Added 'import ROOT' in smartptr test

### DIFF
--- a/python/pythonizations/PyROOT_smartptrtest.py
+++ b/python/pythonizations/PyROOT_smartptrtest.py
@@ -23,6 +23,9 @@ def setup_module(mod):
 
 class TestClassSMARTPTRS:
     def setup_class(cls):
+        # we need to import ROOT because in macOS if a cppyy env
+        # variable is not set libcppyy_backend cannot be found
+        import ROOT
         import cppyy
         cls.test_dct = "SmartPtr_C"
         cls.smartptr = cppyy.load_reflection_info(cls.test_dct)


### PR DESCRIPTION
In smartptr test, ROOT needed to be imported because in MacOs if a cppyy environment variable is not set, libcppyy_backend is not found.