### PR TITLE
[Exp PyROOT] Test fixed: pythonizations-pythonizations

### DIFF
--- a/python/pythonizations/CMakeLists.txt
+++ b/python/pythonizations/CMakeLists.txt
@@ -3,7 +3,7 @@ if(ROOT_python_FOUND)
                     MACRO PyROOT_pythonizationtest.py
                     COPY_TO_BUILDDIR Pythonizables.C Pythonizables.h
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ Pythonizables.C+
-                    ${PYTESTS_WILLFAIL})
+                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
 
   ROOTTEST_ADD_TEST(smartptr
                     MACRO PyROOT_smartptrtest.py

--- a/python/pythonizations/PyROOT_pythonizationtest.py
+++ b/python/pythonizations/PyROOT_pythonizationtest.py
@@ -64,7 +64,12 @@ class TestClassPYTHONIZATIONS:
         """Verify pinnability of returns"""
 
         import cppyy
-        cppyy.gbl.pythonizables.GimeDerived._creates = True
+        exp_pyroot = self.exp_pyroot
+
+        if exp_pyroot:
+            cppyy.gbl.pythonizables.GimeDerived.__creates__ = True
+        else:
+            cppyy.gbl.pythonizables.GimeDerived._creates = True
 
         result = cppyy.gbl.pythonizables.GimeDerived()
         assert type(result) == cppyy.gbl.pythonizables.MyDerived

--- a/python/pythonizations/PyROOT_pythonizationtest.py
+++ b/python/pythonizations/PyROOT_pythonizationtest.py
@@ -40,8 +40,14 @@ class TestClassPYTHONIZATIONS:
                 buf.SetSize(self.GetN())
             return buf
 
-        cppyy.add_pythonization(
-            cppyy.compose_method("pythonizables::MyBufferReturner$", "Get[XY]$", set_size))
+        if exp_pyroot:
+            cppyy.py.add_pythonization(
+                cppyy.py.compose_method("pythonizables::MyBufferReturner$", "Get[XY]$", set_size)
+                )
+        else:
+            cppyy.add_pythonization(
+                cppyy.compose_method("pythonizables::MyBufferReturner$", "Get[XY]$", set_size)
+                )
 
         bsize, xval, yval = 3, 2, 5
         m = cppyy.gbl.pythonizables.MyBufferReturner(bsize, xval, yval)

--- a/python/pythonizations/PyROOT_pythonizationtest.py
+++ b/python/pythonizations/PyROOT_pythonizationtest.py
@@ -32,8 +32,12 @@ class TestClassPYTHONIZATIONS:
 
         import cppyy
 
+        exp_pyroot = self.exp_pyroot
         def set_size(self, buf):
-            buf.SetSize(self.GetN())
+            if exp_pyroot:
+                buf.reshape((self.GetN(),))
+            else:
+                buf.SetSize(self.GetN())
             return buf
 
         cppyy.add_pythonization(

--- a/python/pythonizations/PyROOT_pythonizationtest.py
+++ b/python/pythonizations/PyROOT_pythonizationtest.py
@@ -74,7 +74,10 @@ class TestClassPYTHONIZATIONS:
         result = cppyy.gbl.pythonizables.GimeDerived()
         assert type(result) == cppyy.gbl.pythonizables.MyDerived
 
-        cppyy.make_interface(cppyy.gbl.pythonizables.MyBase)
+        if exp_pyroot:
+            cppyy.py.pin_type(cppyy.gbl.pythonizables.MyBase)
+        else:
+            cppyy.make_interface(cppyy.gbl.pythonizables.MyBase)
         assert type(result) == cppyy.gbl.pythonizables.MyDerived
 
 

--- a/python/pythonizations/PyROOT_pythonizationtest.py
+++ b/python/pythonizations/PyROOT_pythonizationtest.py
@@ -25,6 +25,7 @@ class TestClassPYTHONIZATIONS:
         import cppyy
         cls.test_dct = "Pythonizables_C"
         cls.pythonizables = cppyy.load_reflection_info(cls.test_dct)
+        cls.exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
 
     def test01_size_mapping(self):
         """Use composites to map GetSize() onto buffer returns"""


### PR DESCRIPTION
The test mentioned in the title was fixed thanks to commit e2c3fd4 in the ROOT repository and to some changes in the syntax in order to match the new Cppyy names of some variables and methods.