### PR TITLE
[cxxmodules] Clean up the implicitly build module file.

### DIFF
--- a/root/meta/rootcling-modules/module-dep-order/CMakeLists.txt
+++ b/root/meta/rootcling-modules/module-dep-order/CMakeLists.txt
@@ -5,3 +5,5 @@ ROOTTEST_ADD_TEST(cxxmodules-implicit-build-error
                           implicit_build_linkdef.h
                   WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
                   PASSREGEX "Had to build non-system module A implicitly")
+# Remove the the implicitly built module to make the test work for incremental builds and testing.
+file(REMOVE out.pcm out_rdict.pcm A.pcm)


### PR DESCRIPTION
This fixes the test when run in incremental builds, where on a clean build the test passes but it fails on the next build because the files were already generated.