### PR TITLE
[cxxmodules] Enable and disable the module.modulemap file.

### DIFF
--- a/root/meta/MakeProject/create_makeproject_examples.C
+++ b/root/meta/MakeProject/create_makeproject_examples.C
@@ -2,8 +2,14 @@ R__LOAD_LIBRARY(stl_makeproject_test)
 
 #include <stl_makeproject_test.h>
 
+bool file_exists (const std::string &file_name) {
+   return gSystem->AccessPathName(file_name.c_str(), kWritePermission);
+}
 int create_makeproject_examples()
 {
+   if (file_exists("./disabled.module.modulemap")) {
+      gSystem->Rename( "./disabled.module.modulemap" , "./module.modulemap");
+   }
    TFile _file0("stl_example.root", "RECREATE");
    SillyStlEvent *event = nullptr;
    TTree tree("T", "test tree");
@@ -14,6 +20,6 @@ int create_makeproject_examples()
    tree.Write();
    _file0.Close();
    gSystem->Unlink("./stl_makeproject_test.rootmap");
-   gSystem->Unlink("./module.modulemap");
+   gSystem->Rename( "./module.modulemap" , "./disabled.module.modulemap");
    return 0;
 }


### PR DESCRIPTION
The test has subtest which are testing the automatic loading and the project
generation in root. In the former case the module.modulemap file needs to be
present. In the latter case needs to be gone so that we can trigger the
generation of a new project.

The approach of this patch is not the best, however it is unclear if we can
split the logic into multiple tests without a slowdown or generating the same
input/output multiple times.