### PR TITLE
[Exp PyROOT] For MacOs, tell Cppyy location of libcppyy_backend

### DIFF
--- a/python/basic/CMakeLists.txt
+++ b/python/basic/CMakeLists.txt
@@ -21,5 +21,7 @@ if(ROOT_python_FOUND)
                     MACRO PyROOT_overloadtests.py
                     COPY_TO_BUILDDIR Overloads.C Overloads.h
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ Overloads.C+
-                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
+                    ENVIRONMENT CLING_STANDARD_PCH=none
+                                CPPYY_BACKEND_LIBRARY=${CMAKE_BINARY_DIR}/lib/libcppyy_backend.so
+                                ENVIRONMENT EXP_PYROOT=${exp_pyroot})
 endif()


### PR DESCRIPTION
Fix nightly test failure in MacOS:
https://epsft-jenkins.cern.ch/job/root-exp-pyroot/LABEL=mac1014,SPEC=default/235/testReport/projectroot.roottest.python/basic/roottest_python_basic_overload/