### PR TITLE
[Exp PyROOT] Fixes for tests in roottest-python

### DIFF
--- a/python/regression/CMakeLists.txt
+++ b/python/regression/CMakeLists.txt
@@ -19,8 +19,7 @@ if(ROOT_python_FOUND)
                                          -e .L\ ULongLong.C+
                                          -e .L\ Till.C+
                                          -e .L\ CoralAttributeList.C+
-                    ENVIRONMENT EXP_PYROOT=${exp_pyroot}
-                    ${PYTESTS_WILLFAIL})
+                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
 
   ROOTTEST_ADD_TEST(root_6023
                     MACRO exec_root_6023.py OPTS -b

--- a/python/regression/PyROOT_regressiontests.py
+++ b/python/regression/PyROOT_regressiontests.py
@@ -50,6 +50,9 @@ __all__ = [
 ### "from ROOT import *" done in import-*-ed module ==========================
 from Amir import *
 
+exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
+
+
 class Regression01TwiceImportStar( MyTestCase ):
    def test1FromROOTImportStarInModule( self ):
       """Test handling of twice 'from ROOT import*'"""
@@ -353,15 +356,11 @@ class Regression10CoralAttributeListIterators( MyTestCase ):
 
 ### importing cout should not result in printed errors =======================
 class Regression11GlobalsLookup( MyTestCase ):
-   @classmethod
-   def setUpClass(cls):
-      cls.exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
-
    def test1GetCout( self ):
       """Test that ROOT.cout does not cause error messages"""
 
       import ROOT
-      if self.exp_pyroot:
+      if exp_pyroot:
          # Look for cout in std
          c = ROOT.std.cout
       else:
@@ -382,8 +381,15 @@ class Regression12WriteTGraph( MyTestCase ):
       gr = TGraph()
       ff = TFile( "test.root", "RECREATE" )
       ff.WriteObject( gr, "grname", "" )
-      gr2 = TGraph()
-      ff.GetObject( "grname", gr2 )
+      if exp_pyroot:
+         # In new PyROOT, use a nicer way to get objects in files:
+         # (1) getattr syntax
+         ff.grname
+         # (2) Get pythonisation
+         ff.Get("grname")
+      else:  
+         gr2 = TGraph()
+         ff.GetObject( "grname", gr2 )
       os.remove( "test.root" )
 
 
@@ -404,7 +410,6 @@ class Regression14TPyException( MyTestCase ):
    def test1PythonAccessToTPyException( self ):
       """Load TPyException into python and make sure its usable"""
 
-      exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
       if exp_pyroot:
          # In exp PyROOT, TPyException belongs to the CPyCppyy namespace.
          # Also, it is not included in the PCH, so we need to include the

--- a/python/regression/PyROOT_regressiontests.py
+++ b/python/regression/PyROOT_regressiontests.py
@@ -353,11 +353,19 @@ class Regression10CoralAttributeListIterators( MyTestCase ):
 
 ### importing cout should not result in printed errors =======================
 class Regression11GlobalsLookup( MyTestCase ):
+   @classmethod
+   def setUpClass(cls):
+      cls.exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
+
    def test1GetCout( self ):
       """Test that ROOT.cout does not cause error messages"""
 
       import ROOT
-      c = ROOT.cout
+      if self.exp_pyroot:
+         # Look for cout in std
+         c = ROOT.std.cout
+      else:
+         c = ROOT.cout
 
    def test2GlobalFromROOTNamespace( self ):
       """Entities in 'ROOT::' need no explicit 'ROOT.'"""

--- a/python/stl/CMakeLists.txt
+++ b/python/stl/CMakeLists.txt
@@ -3,7 +3,6 @@ if(ROOT_python_FOUND)
                     MACRO PyROOT_stltests.py
                     COPY_TO_BUILDDIR StlTypes.C
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ StlTypes.C+
-                    ENVIRONMENT EXP_PYROOT=${exp_pyroot}
-                    ${PYTESTS_WILLFAIL})
+                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
 endif()
 

--- a/python/stl/CMakeLists.txt
+++ b/python/stl/CMakeLists.txt
@@ -3,6 +3,7 @@ if(ROOT_python_FOUND)
                     MACRO PyROOT_stltests.py
                     COPY_TO_BUILDDIR StlTypes.C
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ StlTypes.C+
+                    ENVIRONMENT EXP_PYROOT=${exp_pyroot}
                     ${PYTESTS_WILLFAIL})
 endif()
 

--- a/python/stl/PyROOT_stltests.py
+++ b/python/stl/PyROOT_stltests.py
@@ -297,6 +297,7 @@ class TestClasSTLSTRINGHANDLING:
         import cppyy
         cls.test_dct = "StlTypes_C"
         cls.datatypes = cppyy.load_reflection_info(cls.test_dct)
+        cls.exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
 
     def test01_string_argument_passing(self):
         """Test mapping of python strings and std::string"""
@@ -351,7 +352,10 @@ class TestClasSTLSTRINGHANDLING:
         t0 = "aap\0noot"
         assert t0 == "aap\0noot"
 
-        c, s = StringyClass(), std.string(t0, len(t0))
+        if self.exp_pyroot:
+           c, s = StringyClass(), std.string(t0, 0, len(t0))
+        else:
+           c, s = StringyClass(), std.string(t0, len(t0))
 
         c.SetString1( s )
         assert t0 == c.GetString1()


### PR DESCRIPTION
This contributes to fix:
- roottest-python-stl-stl
- roottest-python-regression-regression

Goes together with: https://github.com/root-project/root/pull/4334

A relevant cppyy ticket is:
https://bitbucket.org/wlav/cppyy/issues/157