### PR TITLE
[cxxmodules] Rename the modulemap file before the test starts.

### DIFF
--- a/root/meta/MakeProject/CMakeLists.txt
+++ b/root/meta/MakeProject/CMakeLists.txt
@@ -20,12 +20,31 @@ ROOTTEST_ADD_TEST(runaliceesd
 
 ROOTTEST_GENERATE_DICTIONARY(stl_makeproject_test stl_makeproject_test.h LINKDEF stl_makeproject_test_linkdef.h)
 
-ROOTTEST_ADD_TEST(examples
+if(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/module.modulemap")
+  # For C++ modules builds, module.modulemap is generated during configuration time.
+  ROOTTEST_ADD_TEST(examples
+                   COPY_TO_BUILDDIR stl_makeproject_test.h
+                   MACRO create_makeproject_examples.C
+                   POSTCMD ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/module.modulemap ${CMAKE_CURRENT_BINARY_DIR}/disabled.module.modulemap
+                   OUTREF create_makeproject_examples.ref
+                   DEPENDS ${GENERATE_DICTIONARY_TEST} stl_makeproject_test-build)
+elseif(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/disabled.module.modulemap")
+  # For C++ modules incremental builds.
+  ROOTTEST_ADD_TEST(examples
                   COPY_TO_BUILDDIR stl_makeproject_test.h
+                  PRECMD ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/disabled.module.modulemap ${CMAKE_CURRENT_BINARY_DIR}/module.modulemap
                   MACRO create_makeproject_examples.C
-                  PRECMD ${CMAKE_COMMAND} -E remove stl_example.root || :
+                  POSTCMD ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/module.modulemap ${CMAKE_CURRENT_BINARY_DIR}/disabled.module.modulemap
                   OUTREF create_makeproject_examples.ref
                   DEPENDS ${GENERATE_DICTIONARY_TEST} stl_makeproject_test-build)
+elseif(NOT ROOT_runtime_cxxmodules_FOUND)
+  ROOTTEST_ADD_TEST(examples
+                    COPY_TO_BUILDDIR stl_makeproject_test.h
+                    MACRO create_makeproject_examples.C
+                    OUTREF create_makeproject_examples.ref
+                    DEPENDS ${GENERATE_DICTIONARY_TEST} stl_makeproject_test-build)
+endif()
+
 
 ROOTTEST_ADD_TEST(stltest
                   MACRO runstltest.C

--- a/root/meta/MakeProject/create_makeproject_examples.C
+++ b/root/meta/MakeProject/create_makeproject_examples.C
@@ -2,14 +2,9 @@ R__LOAD_LIBRARY(stl_makeproject_test)
 
 #include <stl_makeproject_test.h>
 
-bool file_exists (const std::string &file_name) {
-   return gSystem->AccessPathName(file_name.c_str(), kWritePermission);
-}
 int create_makeproject_examples()
 {
-   if (file_exists("./disabled.module.modulemap")) {
-      gSystem->Rename( "./disabled.module.modulemap" , "./module.modulemap");
-   }
+   gSystem->Unlink("./stl_example.root");
    TFile _file0("stl_example.root", "RECREATE");
    SillyStlEvent *event = nullptr;
    TTree tree("T", "test tree");
@@ -20,6 +15,5 @@ int create_makeproject_examples()
    tree.Write();
    _file0.Close();
    gSystem->Unlink("./stl_makeproject_test.rootmap");
-   gSystem->Rename( "./module.modulemap" , "./disabled.module.modulemap");
    return 0;
 }


### PR DESCRIPTION
This patch moves the deletion of the stl_example.root in the test so that
we could use the POSTCMD and PRECMD to rename the modulemap file, activating it
before the particular test and deactivating it for the next tests.