### PR TITLE
No longer strip/ignore std in ResolveTypedef.  Adapt reference file.

### DIFF
--- a/root/meta/naming/execCheckNaming.ref
+++ b/root/meta/naming/execCheckNaming.ref
@@ -1,7 +1,7 @@
 
 Processing execCheckNaming.C...
 Check TClassEdit::ResolveTypedef
-@const Something_t&@ --> @const Something&@
+@const Something_t&@ --> @const std::Something&@
 @const std::Something&@ --> @const std::Something&@
 @const string&@ --> @const string&@
 @A<B>[2]@ --> @A<B>[2]@

--- a/root/meta/naming/execResolveTypedef.cxx
+++ b/root/meta/naming/execResolveTypedef.cxx
@@ -136,7 +136,7 @@ int execResolveTypedef()
    // Known failure: the Long64_t is not yet propagated to the template's typedef :(
    // testing("NS::Inner<Long64_t,Object>",TClassEdit::ResolveTypedef("Wrapper<Long64_t>::Point_t"));
 
-   testing(                           "!=<const Roo*,const Roo*,vector<RooFunction> >",
+   testing(                           "!=<const Roo*,const Roo*,std::vector<RooFunction> >",
            TClassEdit::ResolveTypedef("!=<const Roo*, const Roo*, std::vector<RooFunction> >"));
 
    // TClassEdit::ResolveTypedef's job is *not* (yet?) to clean up the spaces.

--- a/root/meta/naming/execResolveTypedef.ref
+++ b/root/meta/naming/execResolveTypedef.ref
@@ -1,5 +1,5 @@
 
-Processing execResolveTypedef.cxx+...
+Processing execResolveTypedef.cxx...
 Test 1 The result is correct: const int
 Test 2 The result is correct: const int
 Test 3 The result is correct: const Long64_t
@@ -53,7 +53,7 @@ Test 50 The result is correct: Long64_t
 Test 51 The result is correct: Long64_t
 Test 52 The result is correct: testing_iterator<pair<const unsigned int,TGLPhysicalShape*> >::_Base_ptr*
 Test 53 The result is correct: testing_iterator<pair<const unsigned int,TGLPhysicalShape*> >::_Base_ptr*
-Test 54 The result is correct: !=<const Roo*,const Roo*,vector<RooFunction> >
+Test 54 The result is correct: !=<const Roo*,const Roo*,std::vector<RooFunction> >
 Test 55 The result is correct: vec<const int>
 Test 56 The result is correct: vec<const int>
 Test 57 The result is correct: vec<const int>


### PR DESCRIPTION
This is needed to solve ROOT-10337.

```
root [0] struct Complex {};
root [1] auto v = std::vector<Complex>{};
root [2] TClassEdit::ResolveTypedef("std::vector<Complex>::value_type")
(std::string) "std::Complex"
```