### PR TITLE
[PyROOT] Use new square bracket syntax to prevent deprecation warning

### DIFF
--- a/cling/functionTemplate/CMakeLists.txt
+++ b/cling/functionTemplate/CMakeLists.txt
@@ -16,8 +16,7 @@ ROOTTEST_ADD_TEST(testcint
                   OUTREF pythoncintrun.ref
                   OUTCNVCMD grep -v "just a comment"
                   WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-                  LABELS roottest regression cling
-                  ${PYTESTS_WILLFAIL})
+                  LABELS roottest regression cling)
 
 if(ROOT_cintex_FOUND)
   ROOTTEST_ADD_TEST(testreflex

--- a/cling/functionTemplate/testcint.py
+++ b/cling/functionTemplate/testcint.py
@@ -3,7 +3,7 @@ import ROOT
 from sys import stdout
 
 def printme(o):
-    print("t now %g %d %d" % (o.get("double")(), o.get("int")(), o.get("float")()))
+    print("t now %g %d %d" % (o.get["double"](), o.get["int"](), o.get["float"]()))
     stdout.flush()
 
 ROOT.gROOT.ProcessLine(".L t.h+")


### PR DESCRIPTION
Goes together with:
https://github.com/root-project/root/pull/4733

and prevents this test failure caused by the newly introduced deprecation warning:
https://epsft-jenkins.cern.ch/job/root-pullrequests-build/74251/testReport/projectroot.roottest.cling/functionTemplate/roottest_cling_functionTemplate_testcint/