### PR TITLE
[Exp PyROOT] Test copy construction from nullptr and __assign__

### DIFF
--- a/python/cpp/PyROOT_cpptests.py
+++ b/python/cpp/PyROOT_cpptests.py
@@ -110,19 +110,37 @@ class Cpp1LanguageFeatureTestCase( MyTestCase ):
       t2 = TLorentzVector( 0., 0., 0.,  0. )
       t3 = TLorentzVector( t1 )
 
-      t4 = TLorentzVector(0, 0, 0, 0)
-      t4.__init__(TLorentzVector(0, 1, 2, 3))
-      # the following should work exactly as above, but no longer does on some version of ROOT 6
-      t5 = TLorentzVector(0, 0, 0, 0)
-      TLorentzVector.__init__(t5, TLorentzVector(0, 1, 2, 3))
-
       self.assertEqual( t1, t3 )
       self.assertNotEqual( t1, t2 )
-      #self.assertNotEqual( t4, t5 )
 
       for i in range(4):
          self.assertEqual( t1[i], t3[i] )
-         self.assertEqual( t4[i], t5[i] )
+
+      if self.exp_pyroot:
+         # Test copy constructor with null pointer
+         t4 = MakeNullPointer(TLorentzVector)
+         t4.__init__(TLorentzVector(0, 1, 2, 3))
+         t5 = MakeNullPointer(TLorentzVector)
+         TLorentzVector.__init__(t5, TLorentzVector(0, 1, 2, 3))
+
+         # Test __assign__ if the object already exists
+         t6 = TLorentzVector(0, 0, 0, 0)
+         t6.__assign__(TLorentzVector(0, 1, 2, 3))
+         t7 = TLorentzVector(0, 0, 0, 0)
+         TLorentzVector.__assign__(t7, TLorentzVector(0, 1, 2, 3))
+
+         for i in range(4):
+            self.assertEqual( t4[i], t5[i] )
+            self.assertEqual( t6[i], t7[i] )
+      else:
+         t4 = TLorentzVector(0, 0, 0, 0)
+         t4.__init__(TLorentzVector(0, 1, 2, 3))
+         # the following should work exactly as above, but no longer does on some version of ROOT 6
+         t5 = TLorentzVector(0, 0, 0, 0)
+         TLorentzVector.__init__(t5, TLorentzVector(0, 1, 2, 3))
+
+         for i in range(4):
+            self.assertEqual( t4[i], t5[i] )
 
    def test08ObjectValidity( self ):
       """Test object validity checking"""


### PR DESCRIPTION
Goes together with: https://github.com/root-project/root/pull/4753

Both in old PyROOT and in new Cppyy, when copy constructing a
pre-existing object, i.e. with the syntax `x.__init__(y)`,
the Python proxy for x is reassigned to the new value of C++ x
after the copy construction, and both the proxy and the new
C++ object are registered as a new pair in the memory regulator.
However, the old C++ object still exists (although it is not
pointed by any Python proxy anymore), which can cause a memory
leak if the Proxy owned the C++ object; furthermore, the old
C++ object is still registered in the memory regulator with
its old proxy.

Consequently, `x.__init__(y)` should be discouraged if x already
points to a C++ object. Instead, we change this test to:
1. Use `x.__init__(y)` when x is a proxy to a null pointer.
2. Use `x.__assign__(y)` when x is a proxy to C++ object.

In addition, for experimental PyROOT, using `x.__init__(y)` when
x points to a C++ object does not interplay well with
ClearPythonProxies, since there are two C++ objects in the
map registered with the same proxy, but the proxy only points
to one of them (the new one). When clearing the objects,
UnregisterPyObject will not be able to remove the old C++
object from the map, since the proxy does not point to it anymore.

Relevant cppyy ticket:
https://bitbucket.org/wlav/cppyy/issues/187/calling-the-copy-constructor-of-an-already