### PR TITLE
[cxxmodules] Avoid name clashes which are already defined by MacTypes.h

### DIFF
--- a/python/regression/PyROOT_regressiontests.py
+++ b/python/regression/PyROOT_regressiontests.py
@@ -248,16 +248,16 @@ class Regression05LoKiNamespace( MyTestCase ):
       struct TriggerResults {};
       struct Tag {};
 
-      template <typename T> struct Handle {};
+      template <typename T> struct HandleT {};
 
       struct Event {
-         template <typename T> int getByLabel(const Tag&, Handle<T>&) { return 0; }
+         template <typename T> int getByLabel(const Tag&, HandleT<T>&) { return 0; }
       };
       """)
 
       ev = ROOT.Event()
       tag = ROOT.Tag()
-      result = ROOT.Handle(ROOT.TriggerResults)()
+      result = ROOT.HandleT(ROOT.TriggerResults)()
 
       self.assertEqual(ev.getByLabel(tag, result), 0)
 

--- a/root/io/const/constTest.C
+++ b/root/io/const/constTest.C
@@ -4,14 +4,14 @@
 using namespace std;
 
 class Reconstructor {};
-class normal {};
+class Normal {};
 
 class Holder : public TObject {
 public:
-   vector<const normal*> v1;
+   vector<const Normal*> v1;
    vector<Reconstructor> v2;
-   //vector<normal *const> v3;
-   //vector<normal const*> v3;
+   //vector<Normal *const> v3;
+   //vector<Normal const*> v3;
 
    Holder() {};
    ~Holder() {};   


### PR DESCRIPTION
The Darwin module exposes more names when enabled. Thus we get a diagnostic that `normal` and `Handle` are being redefined.

This patch should fix 2 failing tests on OSX when runtime_cxxmodules=On

Patch by Alexander Penev(@alexander-penev)!