### PR TITLE
[PyROOT][ROOT-7983] Test injection of overloads for createHistogram

### DIFF
--- a/python/pythonizations/PyROOT_pythonizationtest.py
+++ b/python/pythonizations/PyROOT_pythonizationtest.py
@@ -142,6 +142,20 @@ class TestClassROOT_PYTHONIZATIONS:
         assert h.GetBinErrorUp(1)  == 0.
         assert h.GetBinErrorLow(1) == 0.
 
+    def test04_roodataset(self):
+        """createHistogram overloads obtained with using decls"""
+
+        # ROOT-7983
+        import ROOT
+
+        x = ROOT.RooRealVar("x", "x", -10, 10)
+        mean = ROOT.RooRealVar("mean", "mean of gaussian", 1, -10, 10)
+        sigma = ROOT.RooRealVar("sigma", "width of gaussian", 1, 0.1, 10)
+        gauss = ROOT.RooGaussian("gauss", "gaussian PDF", x, mean, sigma)
+
+        data = gauss.generate(ROOT.RooArgSet(x), 10000)  # ROOT.RooDataSet
+        h1d = data.createHistogram("myname", x)
+
 
 ## actual test run
 if __name__ == '__main__':


### PR DESCRIPTION
Now this is done with a pythonization, until the bindings handle
the injection of the using overloads.

Goes together with https://github.com/root-project/root/pull/4916