### PR TITLE
Exclude TLego from v6 types list

### DIFF
--- a/root/meta/execTypedefList.C
+++ b/root/meta/execTypedefList.C
@@ -134,7 +134,7 @@ int execTypedefList() {
    // res = check_target("std::list<std::string>::const_iterator","list<string>::const_iterator"); if (res) return res;
 
    res = check_file("typelist.v5.txt",349); if (res) return res;
-   res = check_file("typelist.v6.txt",1466); if (res) return res;
+   res = check_file("typelist.v6.txt",1465); if (res) return res;
 
    return 0;
 }

--- a/root/meta/typelist.v6.txt
+++ b/root/meta/typelist.v6.txt
@@ -1007,7 +1007,6 @@ Time_t
 TKDE::KernelFunction_Ptr
 TKDTreeID
 TKDTreeIF
-TLego
 TMatrix
 TMatrixD
 TMatrixDBase


### PR DESCRIPTION
TLego and TPainter3dAlgorithms were removed from public includes