### PR TITLE
Add missing TList.h in hist/operator/runcopy.C macro

### DIFF
--- a/root/hist/operator/runcopy.C
+++ b/root/hist/operator/runcopy.C
@@ -1,5 +1,6 @@
 #include "TH1.h"
 #include "TDirectory.h"
+#include "TList.h"
 
 TH1F *h=0;
 TH1F *h2=0;
@@ -11,13 +12,13 @@ void runcopy()
    if (h2) delete h2;
    if (h3) delete h3;
    fprintf(stdout,"List has %d elements!\n",gDirectory->GetList()->GetSize());
-   
+
    h = new TH1F("h", "", 100, 0, 100);
    h2 = (TH1F *) h->Clone("h2");
    h3 = (TH1F *) h->Clone("h3");
 
    // do something
-   
+
    //h3->SetDirectory(0);
    *h3 = *h + *h2;
    //h3->SetName("h3");


### PR DESCRIPTION
Appears when ROOT build with "less_includes" option