### PR TITLE
add potentially missing include in execMissingCheckSum.cxx [skip-ci]

### DIFF
--- a/root/meta/evolution/execMissingCheckSum.cxx
+++ b/root/meta/evolution/execMissingCheckSum.cxx
@@ -1,5 +1,7 @@
 #include "TFile.h"
 #include "TClass.h"
+#include "TObjArray.h"
+
 
 class MyClass {
 public:


### PR DESCRIPTION
May appear after optimizing ROOT includes