### PR TITLE
[Notebooks] Don't compare output, just check it runs successfully

### DIFF
--- a/python/JupyROOT/CMakeLists.txt
+++ b/python/JupyROOT/CMakeLists.txt
@@ -15,11 +15,6 @@ if(FoundMetakernel EQUAL 0)
   set(NOTEBOOKS ${NOTEBOOKS}
                 ${CMAKE_CURRENT_SOURCE_DIR}/thread_local.ipynb
                 ${CMAKE_CURRENT_SOURCE_DIR}/ROOT_kernel.ipynb)
-
-  if(ROOT_imt_FOUND)
-    set(NOTEBOOKS ${NOTEBOOKS}
-                  ${CMAKE_CURRENT_SOURCE_DIR}/Cpp_IMT_Canvas.ipynb)
-  endif()
 endif()
 
 find_python_module(IPython QUIET)
@@ -41,6 +36,12 @@ if(PY_IPYTHON_FOUND)
     ROOTTEST_ADD_TEST(${NOTEBOOKBASE}_notebook
                       COMMAND ${PYTHON_EXECUTABLE} ${NBDIFFUTIL} ${NOTEBOOK})
   endforeach()
+
+  if(FoundMetakernel EQUAL 0 AND ROOT_imt_FOUND)
+    # No need to compare output here, just check it runs with no error
+    ROOTTEST_ADD_TEST(Cpp_IMT_Canvas_notebook
+                      COMMAND ${PYTHON_EXECUTABLE} ${NBDIFFUTIL} ${CMAKE_CURRENT_SOURCE_DIR}/Cpp_IMT_Canvas.ipynb "OFF")
+  endif()
 endif()
 
 

--- a/python/JupyROOT/nbdiff.py
+++ b/python/JupyROOT/nbdiff.py
@@ -96,15 +96,18 @@ def getKernelName(inNBName):
         return 'root'
 
 
-def canReproduceNotebook(inNBName):
+def canReproduceNotebook(inNBName, needsCompare):
     kernelName = getKernelName(inNBName)
     tmpDir = addEtcToEnvironment(os.path.dirname(inNBName))
     outNBName = inNBName.replace(nbExtension,"_out"+nbExtension)
     interpName = getInterpreterName()
     convCmd = convCmdTmpl %(interpName, kernelName, inNBName, outNBName)
-    os.system(convCmd) # we use system to inherit the environment in os.environ
+    exitStatus = os.system(convCmd) # we use system to inherit the environment in os.environ
     shutil.rmtree(tmpDir)
-    return compareNotebooks(inNBName,outNBName)
+    if needsCompare:
+        return compareNotebooks(inNBName,outNBName)
+    else:
+        return exitStatus
 
 def isInputNotebookFileName(filename):
     if not filename.endswith(".ipynb"):
@@ -114,11 +117,15 @@ def isInputNotebookFileName(filename):
 
 if __name__ == "__main__":
     import sys
-    if len(sys.argv) != 2:
-        print("Usage: nbdiff.py myNotebook.ipynb")
+    needsCompare = True
+    if len(sys.argv) < 2:
+        print("Usage: nbdiff.py myNotebook.ipynb [compare_output]")
         sys.exit(1)
+    elif len(sys.argv) == 3 and sys.argv[2] == "OFF":
+        needsCompare = False
+
     nbFileName = sys.argv[1]
     if not isInputNotebookFileName(nbFileName):
         sys.exit(1)
-    retCode = canReproduceNotebook(nbFileName)
+    retCode = canReproduceNotebook(nbFileName, needsCompare)
     sys.exit(retCode)


### PR DESCRIPTION
This test failure was observed:
http://cdash.cern.ch/testDetails.php?test=81587595&build=834646

because in the Cpp_IMT_Canvas notebook test, the output notebook
notebook is compared with the input notebook to decide if the
test succeeded. It seems that the text representation of the
image encoded in the notebook can be different depending on
the platform, making the diff fail and the test too, whereas
the test actually succeeded.

Since the aim of the test is just to check if drawing an (empty)
canvas runs without error in implicit MT mode, it is enough to check
that the exit status of the process that runs the notebook is zero.