### PR TITLE
[DF] Adapt tests now that RDF throws if there is an error during the event loop

### DIFF
--- a/root/dataframe/test_typeguessing.cxx
+++ b/root/dataframe/test_typeguessing.cxx
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <stdexcept>
+#include <cassert>
 
 auto fileName("testtypeguessing.root");
 auto treeName("myTree");
@@ -22,12 +23,21 @@ int main() {
 
    TFile f(fileName);
    ROOT::RDataFrame d(treeName, fileName);
+
    // TTreeReader should cause a runtime error (type mismatch) when the event-loop is run
    auto hb = d.Histo1D<double>("b");
+
    // Histo1D("s") should compile and execute (jitting recognizes the std::string type)
    // although the histogram will be filled with meaningless values
    auto hs = d.Histo1D("s");
-   *hb;
+
+   bool exception_caught = false;
+   try {
+      *hb;
+   } catch (const std::runtime_error &) {
+      exception_caught = true;
+   }
+   assert(exception_caught);
 
    return 0;
 }


### PR DESCRIPTION
Fixes test failures seen in `chainZombieFIle` and `typeguessing` tests at https://github.com/root-project/root/pull/5207