### PR TITLE
[RF] Add missing library to roofit's stability tests.

### DIFF
--- a/root/roofitstats/CMakeLists.txt
+++ b/root/roofitstats/CMakeLists.txt
@@ -14,7 +14,7 @@ if(ROOT_roofit_FOUND)
                     MACROARG "true, \"./ASCII-in-out_result.txt\""
                     POSTCMD diff ${CMAKE_CURRENT_SOURCE_DIR}/ASCII-in-out_data.txt ./ASCII-in-out_result.txt)
 
-  ROOT_ADD_GTEST(stabilityTests stabilityTests.cxx LIBRARIES Core Tree RooFitCore RooFit
+  ROOT_ADD_GTEST(stabilityTests stabilityTests.cxx LIBRARIES Core Tree RIO RooFitCore RooFit
                  COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/stabilityTests_data_1.root)
 
   add_subdirectory(vectorisedPDFs) 


### PR DESCRIPTION
This only shows when roottest is built outside of ROOT.