### PR TITLE
Follow fix needed for ROOT-10648.

### DIFF
--- a/root/io/filemerger/CMakeLists.txt
+++ b/root/io/filemerger/CMakeLists.txt
@@ -241,7 +241,7 @@ if(${compression_default} STREQUAL "zlib")
 
             ROOTTEST_ADD_TEST(simple-lz4-compr-level9
                            PRECMD ${ROOT_hadd_CMD} -f409 hsimple409.root hsimple.root
-                           COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple409.root\",25000,409,516957,5)"
+                           COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple409.root\",25000,409,516961,5)"
                            DEPENDS hsimple-filemergerfile)
 
             ROOTTEST_ADD_TEST(simple-lz4-compr-level1
@@ -266,7 +266,7 @@ if(${compression_default} STREQUAL "zlib")
 
             ROOTTEST_ADD_TEST(simple-lz4-compr-level9
                            PRECMD ${ROOT_hadd_CMD} -f409 hsimple409.root hsimple.root
-                           COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple409.root\",25000,409, 516957,5)"
+                           COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple409.root\",25000,409, 516961,5)"
                            DEPENDS hsimple-filemergerfile)
 
             ROOTTEST_ADD_TEST(simple-lz4-compr-level1
@@ -385,7 +385,7 @@ if(${compression_default} STREQUAL "zlib")
          else()
             ROOTTEST_ADD_TEST(simple-lz4-compr-level9
                           PRECMD ${ROOT_hadd_CMD} -f409 hsimple409.root hsimple.root
-                          COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple409.root\",25000,409,516957,5)"
+                          COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple409.root\",25000,409,516961,5)"
                           DEPENDS hsimple-filemergerfile)
          endif()
          ROOTTEST_ADD_TEST(simple-lz4-compr-level1

--- a/root/io/filemerger/CMakeLists.txt
+++ b/root/io/filemerger/CMakeLists.txt
@@ -246,7 +246,7 @@ if(${compression_default} STREQUAL "zlib")
 
             ROOTTEST_ADD_TEST(simple-lz4-compr-level1
                            PRECMD ${ROOT_hadd_CMD} -f401 hsimple401.root hsimple.root
-                           COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple401.root\",25000,401,447572,5)"
+                           COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple401.root\",25000,401,447579,5)"
                            DEPENDS hsimple-filemergerfile)
       elseif(${LZ4_VERSION} VERSION_GREATER_EQUAL "1.7.5")
             ROOTTEST_ADD_TEST(simplek-lz4-compr-level4
@@ -271,7 +271,7 @@ if(${compression_default} STREQUAL "zlib")
 
             ROOTTEST_ADD_TEST(simple-lz4-compr-level1
                            PRECMD ${ROOT_hadd_CMD} -f401 hsimple401.root hsimple.root
-                           COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple401.root\",25000,401,447572,5)"
+                           COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple401.root\",25000,401,447579,5)"
                            DEPENDS hsimple-filemergerfile)
       endif()
    else()
@@ -390,7 +390,7 @@ if(${compression_default} STREQUAL "zlib")
          endif()
          ROOTTEST_ADD_TEST(simple-lz4-compr-level1
                         PRECMD ${ROOT_hadd_CMD} -f401 hsimple401.root hsimple.root
-                        COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple401.root\",25000,401,418880,5)"
+                        COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple401.root\",25000,401,418887,5)"
                         DEPENDS hsimple-filemergerfile)
       endif()
 

--- a/root/tree/fastcloning/references/execCheckClusterRange.ref32
+++ b/root/tree/fastcloning/references/execCheckClusterRange.ref32
@@ -142,7 +142,7 @@ Cluster #47 starts at 1740 and ends at 1769
 Cluster #48 starts at 1770 and ends at 1799
 ******************************************************************************
 *Tree    :t1        :                                                        *
-*Entries :     1800 : Total =           29346 bytes  File  Size =      17990 *
+*Entries :     1800 : Total =           29346 bytes  File  Size =      17988 *
 *        :          : Tree compression factor =   1.59                       *
 ******************************************************************************
 Cluster Range #  Entry Start      Last Entry           Size   Number of clusters
@@ -222,7 +222,7 @@ Cluster #67 starts at 2340 and ends at 2369
 Cluster #68 starts at 2370 and ends at 2399
 ******************************************************************************
 *Tree    :t1        :                                                        *
-*Entries :     2400 : Total =           33566 bytes  File  Size =      20857 *
+*Entries :     2400 : Total =           33566 bytes  File  Size =      20847 *
 *        :          : Tree compression factor =   1.56                       *
 ******************************************************************************
 Cluster Range #  Entry Start      Last Entry           Size   Number of clusters

--- a/root/tree/fastcloning/references/execCheckClusterRange_builtinzlib.ref
+++ b/root/tree/fastcloning/references/execCheckClusterRange_builtinzlib.ref
@@ -142,7 +142,7 @@ Cluster #47 starts at 1740 and ends at 1769
 Cluster #48 starts at 1770 and ends at 1799
 ******************************************************************************
 *Tree    :t1        :                                                        *
-*Entries :     1800 : Total =           29346 bytes  File  Size =      17981 *
+*Entries :     1800 : Total =           29346 bytes  File  Size =      17984 *
 *        :          : Tree compression factor =   1.59                       *
 ******************************************************************************
 Cluster Range #  Entry Start      Last Entry           Size   Number of clusters
@@ -222,7 +222,7 @@ Cluster #67 starts at 2340 and ends at 2369
 Cluster #68 starts at 2370 and ends at 2399
 ******************************************************************************
 *Tree    :t1        :                                                        *
-*Entries :     2400 : Total =           33566 bytes  File  Size =      20853 *
+*Entries :     2400 : Total =           33566 bytes  File  Size =      20856 *
 *        :          : Tree compression factor =   1.56                       *
 ******************************************************************************
 Cluster Range #  Entry Start      Last Entry           Size   Number of clusters

--- a/root/tree/fastcloning/references/execCheckClusterRange_zlib.ref
+++ b/root/tree/fastcloning/references/execCheckClusterRange_zlib.ref
@@ -142,7 +142,7 @@ Cluster #47 starts at 1740 and ends at 1769
 Cluster #48 starts at 1770 and ends at 1799
 ******************************************************************************
 *Tree    :t1        :                                                        *
-*Entries :     1800 : Total =           29346 bytes  File  Size =      17989 *
+*Entries :     1800 : Total =           29346 bytes  File  Size =      17992 *
 *        :          : Tree compression factor =   1.59                       *
 ******************************************************************************
 Cluster Range #  Entry Start      Last Entry           Size   Number of clusters
@@ -222,7 +222,7 @@ Cluster #67 starts at 2340 and ends at 2369
 Cluster #68 starts at 2370 and ends at 2399
 ******************************************************************************
 *Tree    :t1        :                                                        *
-*Entries :     2400 : Total =           33566 bytes  File  Size =      20848 *
+*Entries :     2400 : Total =           33566 bytes  File  Size =      20851 *
 *        :          : Tree compression factor =   1.56                       *
 ******************************************************************************
 Cluster Range #  Entry Start      Last Entry           Size   Number of clusters


### PR DESCRIPTION
By switching the TStreamerSTL from being modified then stored to
storing a copy created on the stack, the kIsOnHeap bit is change and since
that information is store, the onfile representation (and thus after compression
size) change a bit.