### PR TITLE
[Notebooks] Increase kernel timeout to 3 minutes

### DIFF
--- a/python/JupyROOT/nbdiff.py
+++ b/python/JupyROOT/nbdiff.py
@@ -7,7 +7,14 @@ import sys
 import tempfile
 
 nbExtension=".ipynb"
-convCmdTmpl = "%s nbconvert  --to notebook --ExecutePreprocessor.kernel_name=%s --ExecutePreprocessor.enabled=True --ExecutePreprocessor.timeout=3600 %s --output %s"
+convCmdTmpl = "%s nbconvert " \
+"--to notebook " \
+"--ExecutePreprocessor.kernel_name=%s " \
+"--ExecutePreprocessor.enabled=True " \
+"--ExecutePreprocessor.timeout=3600 " \
+"--ExecutePreprocessor.startup_timeout=180 " \
+"%s " \
+"--output %s"
 pythonInterpName = 'python3' if sys.version_info >= (3, 0) else 'python2'
 
 rootKernelFileContent = '''{


### PR DESCRIPTION
In case a test machine is overloaded and the default 1-minute
timeout fires up, but there is no real error.

To check if this intermittent failure ("kernel didn't respond...") observed on root-fedora29-3:

http://cdash.cern.ch/testDetails.php?test=83240520&build=852667

is due to eventual high load on the node. When running the test alone on the same node 100 times, not a single failure happens.
