### PR TITLE
[JupyROOT] Replace CMake checks by runtime checks for test dependencies

### DIFF
--- a/python/JupyROOT/CMakeLists.txt
+++ b/python/JupyROOT/CMakeLists.txt
@@ -2,49 +2,38 @@ if (ROOT_pyroot_FOUND AND NOT ROOT_CLASSIC_BUILD) # Do not run with classic buil
 
 set(MODULES_LOCATION ${ROOTSYS}/lib/JupyROOT/helpers)
 set(NBDIFFUTIL ${CMAKE_CURRENT_SOURCE_DIR}/nbdiff.py )
+set(DOCTEST_LAUNCHER ${CMAKE_CURRENT_SOURCE_DIR}/doctest_launcher.py)
 
 # List of notebook files
 # TODO: To be extended with the list of downloaded notebooks used in the
 # documentation and as tutorials.
 set(NOTEBOOKS ${CMAKE_CURRENT_SOURCE_DIR}/importROOT.ipynb
-              ${CMAKE_CURRENT_SOURCE_DIR}/simpleCppMagic.ipynb)
+              ${CMAKE_CURRENT_SOURCE_DIR}/simpleCppMagic.ipynb
+              ${CMAKE_CURRENT_SOURCE_DIR}/thread_local.ipynb
+              ${CMAKE_CURRENT_SOURCE_DIR}/ROOT_kernel.ipynb
+              ${CMAKE_CURRENT_SOURCE_DIR}/tpython.ipynb)
 
-# Include cpp notebooks if metakernel is present
-execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c" "import metakernel" RESULT_VARIABLE FoundMetakernel ERROR_QUIET)
-if(FoundMetakernel EQUAL 0)
-  set(NOTEBOOKS ${NOTEBOOKS}
-                ${CMAKE_CURRENT_SOURCE_DIR}/thread_local.ipynb
-                ${CMAKE_CURRENT_SOURCE_DIR}/ROOT_kernel.ipynb
-                ${CMAKE_CURRENT_SOURCE_DIR}/tpython.ipynb)
-endif()
-
-find_python_module(IPython QUIET)
-
-if(PY_IPYTHON_FOUND)
 # Test all modules with doctest. All new tests will be automatically picked up
-  file(GLOB pyfiles ${MODULES_LOCATION}/*.py)
-  foreach(pyfile ${pyfiles})
-    get_filename_component(SHORTPYFILE ${pyfile} NAME_WE)
-    if (NOT ${SHORTPYFILE} STREQUAL "__init__")
-      ROOTTEST_ADD_TEST(${SHORTPYFILE}_doctest
-                        COMMAND ${PYTHON_EXECUTABLE} -m doctest ${pyfile})
-    endif()
-  endforeach()
+file(GLOB pyfiles ${MODULES_LOCATION}/*.py)
+foreach(pyfile ${pyfiles})
+  get_filename_component(SHORTPYFILE ${pyfile} NAME_WE)
+  if (NOT ${SHORTPYFILE} STREQUAL "__init__")
+    ROOTTEST_ADD_TEST(${SHORTPYFILE}_doctest
+                      COMMAND ${PYTHON_EXECUTABLE} ${DOCTEST_LAUNCHER} ${pyfile})
+  endif()
+endforeach()
 
 # Test all notebooks available
-  foreach(NOTEBOOK ${NOTEBOOKS})
-    get_filename_component(NOTEBOOKBASE ${NOTEBOOK} NAME_WE)
-    ROOTTEST_ADD_TEST(${NOTEBOOKBASE}_notebook
-                      COMMAND ${PYTHON_EXECUTABLE} ${NBDIFFUTIL} ${NOTEBOOK})
-  endforeach()
+foreach(NOTEBOOK ${NOTEBOOKS})
+  get_filename_component(NOTEBOOKBASE ${NOTEBOOK} NAME_WE)
+  ROOTTEST_ADD_TEST(${NOTEBOOKBASE}_notebook
+                    COMMAND ${PYTHON_EXECUTABLE} ${NBDIFFUTIL} ${NOTEBOOK})
+endforeach()
 
-  if(FoundMetakernel EQUAL 0 AND ROOT_imt_FOUND)
-    # No need to compare output here, just check it runs with no error
-    ROOTTEST_ADD_TEST(Cpp_IMT_Canvas_notebook
-                      COMMAND ${PYTHON_EXECUTABLE} ${NBDIFFUTIL} ${CMAKE_CURRENT_SOURCE_DIR}/Cpp_IMT_Canvas.ipynb "OFF")
-  endif()
+if(ROOT_imt_FOUND)
+  # No need to compare output here, just check it runs with no error
+  ROOTTEST_ADD_TEST(Cpp_IMT_Canvas_notebook
+                    COMMAND ${PYTHON_EXECUTABLE} ${NBDIFFUTIL} ${CMAKE_CURRENT_SOURCE_DIR}/Cpp_IMT_Canvas.ipynb "OFF")
 endif()
-
-
 
 endif()

--- a/python/JupyROOT/doctest_launcher.py
+++ b/python/JupyROOT/doctest_launcher.py
@@ -1,0 +1,24 @@
+import sys, os
+from doctest import testmod
+
+try:
+   import IPython
+except:
+   raise ImportError("Cannot import IPython")
+
+if len(sys.argv) < 2:
+    raise RuntimeError('Please specify tutorial file path as only argument of this script')
+
+filename = sys.argv[1]
+
+# Replicate what doctest does: insert the module's
+# dir into sys.path and try to import it
+dirname, filename = os.path.split(filename)
+sys.path.insert(0, dirname)
+m = __import__(filename[:-3])
+del sys.path[0]
+failures, _ = testmod(m)
+if failures:
+    sys.exit(1)
+else:
+    sys.exit(0)

--- a/python/JupyROOT/nbdiff.py
+++ b/python/JupyROOT/nbdiff.py
@@ -103,8 +103,7 @@ def getKernelName(inNBName):
         return 'root'
 
 
-def canReproduceNotebook(inNBName, needsCompare):
-    kernelName = getKernelName(inNBName)
+def canReproduceNotebook(inNBName, kernelName, needsCompare):
     tmpDir = addEtcToEnvironment(os.path.dirname(inNBName))
     outNBName = inNBName.replace(nbExtension,"_out"+nbExtension)
     interpName = getInterpreterName()
@@ -134,5 +133,20 @@ if __name__ == "__main__":
     nbFileName = sys.argv[1]
     if not isInputNotebookFileName(nbFileName):
         sys.exit(1)
-    retCode = canReproduceNotebook(nbFileName, needsCompare)
+
+    try:
+        # If jupyter is there, ipython is too
+        import jupyter
+    except:
+        raise ImportError("Cannot import jupyter")
+
+    kernelName = getKernelName(nbFileName)
+    if kernelName == 'root':
+        try:
+            # We need metakernel for ROOT C++ notebooks
+            import metakernel
+        except:
+            raise ImportError("Cannot import metakernel")
+
+    retCode = canReproduceNotebook(nbFileName, kernelName, needsCompare)
     sys.exit(retCode)


### PR DESCRIPTION
The JupyROOT tests have several dependencies:
1. Doctests: IPython
2. Python kernel tests: jupyter (for nbconvert), which also pulls IPython
3. C++ kernel tests: jupyter and metakernel

This PR moves the check for these test dependencies at runtime instead of at build time.