### PR TITLE
[multicore] Test move-only types support in TExecutor::Map

### DIFF
--- a/root/multicore/tExecutor.h
+++ b/root/multicore/tExecutor.h
@@ -2,6 +2,7 @@
 #include "TRandom.h"
 #include <functional>
 #include <vector>
+#include <memory>
 #include <numeric> //accumulate
 
 int f(int a)
@@ -29,6 +30,9 @@ int TExecutorPoolTest(T &pool) {
    auto res = pool.Map([](int a) -> int { return a+1; }, {0,0,0,0});
    if( res != truth)
       return 1;
+
+   // ... and move-only types
+   pool.Map([](int) { return std::make_unique<TList>(); }, { 1, 2, 3 });
 
    // vector and C++ function
    std::vector<int> vargs = {0,0,0,0};


### PR DESCRIPTION
Rebased https://github.com/root-project/roottest/pull/302 - does that fix the errors?