### PR TITLE
Add hsimple copying test rule in file merger

### DIFF
--- a/cmake/modules/RoottestMacros.cmake
+++ b/cmake/modules/RoottestMacros.cmake
@@ -350,7 +350,7 @@ macro(ROOTTEST_GENERATE_REFLEX_DICTIONARY dictionary)
                              SELECTION ${ARG_SELECTION}
                              ${reflex_pass_options})
 
-  add_library(${targetname_libgen} EXCLUDE_FROM_ALL SHARED ${gensrcdict})
+  add_library(${targetname_libgen} EXCLUDE_FROM_ALL SHARED ${dictionary}.cxx)
   set_target_properties(${targetname_libgen} PROPERTIES  ${ROOT_LIBRARY_PROPERTIES} )
 
   if(ARG_LIBNAME)

--- a/cmake/modules/RoottestMacros.cmake
+++ b/cmake/modules/RoottestMacros.cmake
@@ -555,6 +555,7 @@ endmacro(ROOTTEST_SETUP_EXECTEST)
 #                            [OUTREF stdout_reference]
 #                            [ERRREF stderr_reference]
 #                            [WORKING_DIR dir]
+#                            [TIMEOUT tmout]
 #                            [COPY_TO_BUILDDIR file1 file2 ...])
 #
 # This function defines a roottest test. It adds a number of additional
@@ -563,8 +564,8 @@ endmacro(ROOTTEST_SETUP_EXECTEST)
 #-------------------------------------------------------------------------------
 function(ROOTTEST_ADD_TEST testname)
   CMAKE_PARSE_ARGUMENTS(ARG "WILLFAIL;RUN_SERIAL"
-                            "OUTREF;ERRREF;OUTREF_CINTSPECIFIC;OUTCNV;PASSRC;MACROARG;WORKING_DIR;INPUT;ENABLE_IF;DISABLE_IF;"
-                            "TESTOWNER;COPY_TO_BUILDDIR;MACRO;EXEC;COMMAND;PRECMD;POSTCMD;OUTCNVCMD;FAILREGEX;PASSREGEX;DEPENDS;OPTS;TIMEOUT;LABELS;ENVIRONMENT" ${ARGN})
+                            "OUTREF;ERRREF;OUTREF_CINTSPECIFIC;OUTCNV;PASSRC;MACROARG;WORKING_DIR;INPUT;ENABLE_IF;DISABLE_IF;TIMEOUT"
+                            "TESTOWNER;COPY_TO_BUILDDIR;MACRO;EXEC;COMMAND;PRECMD;POSTCMD;OUTCNVCMD;FAILREGEX;PASSREGEX;DEPENDS;OPTS;LABELS;ENVIRONMENT" ${ARGN})
 
   # Test name
   ROOTTEST_TARGETNAME_FROM_FILE(testprefix .)

--- a/root/io/filemerger/CMakeLists.txt
+++ b/root/io/filemerger/CMakeLists.txt
@@ -107,7 +107,7 @@ if(CMAKE_SIZEOF_VOID_P EQUAL 4)
             PRECMD ${ROOT_hadd_CMD} -f505 mzstdfile1-4.root mzstdfile1-2.root mzstdfile3-4.root
             COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testMergedFile.C(\"mzstdfile1-4.root\",505,4456,20)"
             DEPENDS datagen-hadd-mzstdfile12
-            DEPENDS datagen-hadd-mzstdfile34)   
+            DEPENDS datagen-hadd-mzstdfile34)
    endif()
 else()
    if(${ZSTD_VERSION} VERSION_LESS_EQUAL "1.3.3")
@@ -121,31 +121,21 @@ else()
                   PRECMD ${ROOT_hadd_CMD} -f505 mzstdfile1-4.root mzstdfile1-2.root mzstdfile3-4.root
                   COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testMergedFile.C(\"mzstdfile1-4.root\",505,4454,20)"
                   DEPENDS datagen-hadd-mzstdfile12
-                  DEPENDS datagen-hadd-mzstdfile34)   
+                  DEPENDS datagen-hadd-mzstdfile34)
    endif()
 endif()
 
 #TBD: add file generation as test fixture
 if(NOT TARGET hsimple)
-      add_custom_target(hsimple-filemergerfile ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/hsimple.root)
-      add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/hsimple.root
-                  COMMAND ${ROOT_root_CMD} -q -l -b ${ROOTSYS}/tutorials/hsimple.C -e "{ TFile f(\"hsimple.root\"); TTree *ntuple; f.GetObject(\"ntuple\",ntuple); return ntuple ? 0 : 1; }" > hsimple.log
-                  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-                  DEPENDS ${HSimpleDependencies}
-                  VERBATIM)
-      add_custom_command(
-        TARGET  hsimple-filemergerfile
-        COMMAND ${CMAKE_COMMAND} -E copy
-                ${CMAKE_CURRENT_BINARY_DIR}/hsimple.root
-                hsimple.root)
+      add_test(NAME roottest-root-io-filemerger-hsimple-create
+               COMMAND ${ROOT_root_CMD} -q -l -b ${ROOTSYS}/tutorials/hsimple.C -e "{ TFile f(\"hsimple.root\"); TTree *ntuple; f.GetObject(\"ntuple\",ntuple); return ntuple ? 0 : 1; }"
+               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+      add_test(NAME roottest-root-io-filemerger-hsimple
+               COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/hsimple.root hsimple.root)
+      set_property(TEST roottest-root-io-filemerger-hsimple PROPERTY DEPENDS roottest-root-io-filemerger-hsimple-create)
 else()
-      add_custom_target(hsimple-filemergerfile ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/hsimple.root)
-      set(HSimpleDependencies "hsimple")
-      add_dependencies(hsimple-filemergerfile ${HSimpleDependencies})
-      add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/hsimple.root
-        COMMAND ${CMAKE_COMMAND} -E copy
-                ${CMAKE_BINARY_DIR}/tutorials/hsimple.root
-                hsimple.root)
+      add_test(NAME roottest-root-io-filemerger-hsimple
+               COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tutorials/hsimple.root hsimple.root)
 endif()
 
 if(${compression_default} STREQUAL "zlib")
@@ -153,34 +143,34 @@ if(${compression_default} STREQUAL "zlib")
       ROOTTEST_ADD_TEST(simple-default-compr-level9
                   PRECMD ${ROOT_hadd_CMD} -f9 hsimple9.root hsimple.root
                   COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple9.root\",25000,9,441439,25)"
-                  DEPENDS hsimple-filemergerfile)
+                  DEPENDS roottest-root-io-filemerger-hsimple)
 
       ROOTTEST_ADD_TEST(simple-zlib-compr-level1
                   PRECMD ${ROOT_hadd_CMD} -f101 hsimple101.root hsimple.root
                   COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple101.root\",25000,101,442963,25)"
-                  DEPENDS hsimple-filemergerfile)
+                  DEPENDS roottest-root-io-filemerger-hsimple)
 
       ROOTTEST_ADD_TEST(simple-zlib-compr-level6
                   PRECMD ${ROOT_hadd_CMD} -f106 hsimple106.root hsimple.root
                   COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple106.root\",25000,106,441545,25)"
-                  DEPENDS hsimple-filemergerfile)
+                  DEPENDS roottest-root-io-filemerger-hsimple)
 
       ROOTTEST_ADD_TEST(simple-zlib-compr-level9
                   PRECMD ${ROOT_hadd_CMD} -f109 hsimple109.root hsimple.root
                   COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple109.root\",25000,109,441449,25)"
-                  DEPENDS hsimple-filemergerfile)
+                  DEPENDS roottest-root-io-filemerger-hsimple)
 
       ROOTTEST_ADD_TEST(simple-default-compr-level9-datageneration
                   PRECMD  ${ROOT_hadd_CMD} -f9 hsimple9x2.root hsimple.root
                   COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple9x2.root\",25000,9,441449,25)"
                   POSTCMD ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/hsimple9x2.root ${CMAKE_CURRENT_BINARY_DIR}/hsimple92.root
-                  DEPENDS hsimple-filemergerfile)
+                  DEPENDS roottest-root-io-filemerger-hsimple)
 
       ROOTTEST_ADD_TEST(simple-zlib-compr-level9-datageneration
                   PRECMD  ${ROOT_hadd_CMD} -f109 hsimple109x2.root hsimple.root
                   COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple109x2.root\",25000,109,441456,25)"
                   POSTCMD ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/hsimple109x2.root ${CMAKE_CURRENT_BINARY_DIR}/hsimple1092.root
-                  DEPENDS hsimple-filemergerfile)
+                  DEPENDS roottest-root-io-filemerger-hsimple)
 
       ROOTTEST_ADD_TEST(simplex2-default-compr-level9
                   PRECMD  ${ROOT_hadd_CMD} -f9 -a hsimple9x2.root hsimple.root
@@ -197,7 +187,7 @@ if(${compression_default} STREQUAL "zlib")
       ROOTTEST_ADD_TEST(simplek-default-compr-deflevel
                   PRECMD ${ROOT_hadd_CMD} -fk hsimpleK.root hsimple209.root hsimple409.root hsimple.root hsimple9.root hsimple92.root
                   COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimpleK.root\",6*25000,209,2297560,30)"
-                  DEPENDS hsimple-filemergerfile
+                  DEPENDS roottest-root-io-filemerger-hsimple
                   DEPENDS simple-lz4-compr-level9
                   DEPENDS simple-lzma-compr-level9
                   DEPENDS simplex2-default-compr-level9
@@ -206,7 +196,7 @@ if(${compression_default} STREQUAL "zlib")
       ROOTTEST_ADD_TEST(simplek-lzma-compr-level9
                   PRECMD ${ROOT_hadd_CMD} -fk209 hsimpleK209.root hsimpleK.root hsimple209.root hsimple409.root hsimple.root hsimple9.root hsimple92.root
                   COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimpleK209.root\",12*25000,209,4583784,30)"
-                  DEPENDS hsimple-filemergerfile
+                  DEPENDS roottest-root-io-filemerger-hsimple
                   DEPENDS simple-lz4-compr-level9
                   DEPENDS simple-lzma-compr-level9
                   DEPENDS simplex2-default-compr-level9
@@ -216,7 +206,7 @@ if(${compression_default} STREQUAL "zlib")
       ROOTTEST_ADD_TEST(simplef-default-compr-level9
                   PRECMD ${ROOT_hadd_CMD} -ff hsimpleF.root hsimple9.root hsimple209.root hsimple409.root hsimpleK404.root hsimple.root hsimple92.root
                   COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimpleF.root\",30*25000,9,12889766,30)"
-                  DEPENDS hsimple-filemergerfile
+                  DEPENDS roottest-root-io-filemerger-hsimple
                   DEPENDS simple-lz4-compr-level9
                   DEPENDS simple-lzma-compr-level9
                   DEPENDS simplex2-default-compr-level9
@@ -227,7 +217,7 @@ if(${compression_default} STREQUAL "zlib")
             ROOTTEST_ADD_TEST(simplek-lz4-compr-level4
                            PRECMD ${ROOT_hadd_CMD} -fk404 hsimpleK404.root hsimpleK209.root hsimpleK.root hsimple.root hsimple9.root hsimple209.root hsimple409.root hsimple92.root
                            COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimpleK404.root\",24*25000,404,12047466,30)"
-                           DEPENDS hsimple-filemergerfile
+                           DEPENDS roottest-root-io-filemerger-hsimple
                            DEPENDS simple-lz4-compr-level9
                            DEPENDS simple-lzma-compr-level9
                            DEPENDS simplex2-default-compr-level9
@@ -237,22 +227,22 @@ if(${compression_default} STREQUAL "zlib")
             ROOTTEST_ADD_TEST(simple-lz4-compr-level4
                            PRECMD ${ROOT_hadd_CMD} -f404 hsimple404.root hsimple.root
                            COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple404.root\",25000,404,517232,15)"
-                           DEPENDS hsimple-filemergerfile)
+                           DEPENDS roottest-root-io-filemerger-hsimple)
 
             ROOTTEST_ADD_TEST(simple-lz4-compr-level9
                            PRECMD ${ROOT_hadd_CMD} -f409 hsimple409.root hsimple.root
                            COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple409.root\",25000,409,516961,5)"
-                           DEPENDS hsimple-filemergerfile)
+                           DEPENDS roottest-root-io-filemerger-hsimple)
 
             ROOTTEST_ADD_TEST(simple-lz4-compr-level1
                            PRECMD ${ROOT_hadd_CMD} -f401 hsimple401.root hsimple.root
                            COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple401.root\",25000,401,447579,5)"
-                           DEPENDS hsimple-filemergerfile)
+                           DEPENDS roottest-root-io-filemerger-hsimple)
       elseif(${LZ4_VERSION} VERSION_GREATER_EQUAL "1.7.5")
             ROOTTEST_ADD_TEST(simplek-lz4-compr-level4
                            PRECMD ${ROOT_hadd_CMD} -fk404 hsimpleK404.root hsimpleK209.root hsimpleK.root hsimple.root hsimple9.root hsimple209.root hsimple409.root hsimple92.root
                            COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimpleK404.root\",24*25000,404,12047466,30)"
-                           DEPENDS hsimple-filemergerfile
+                           DEPENDS roottest-root-io-filemerger-hsimple
                            DEPENDS simple-lz4-compr-level9
                            DEPENDS simple-lzma-compr-level9
                            DEPENDS simplex2-default-compr-level9
@@ -262,50 +252,50 @@ if(${compression_default} STREQUAL "zlib")
             ROOTTEST_ADD_TEST(simple-lz4-compr-level4
                            PRECMD ${ROOT_hadd_CMD} -f404 hsimple404.root hsimple.root
                            COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple404.root\",25000,404,517232,15)"
-                           DEPENDS hsimple-filemergerfile)
+                           DEPENDS roottest-root-io-filemerger-hsimple)
 
             ROOTTEST_ADD_TEST(simple-lz4-compr-level9
                            PRECMD ${ROOT_hadd_CMD} -f409 hsimple409.root hsimple.root
                            COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple409.root\",25000,409, 516961,5)"
-                           DEPENDS hsimple-filemergerfile)
+                           DEPENDS roottest-root-io-filemerger-hsimple)
 
             ROOTTEST_ADD_TEST(simple-lz4-compr-level1
                            PRECMD ${ROOT_hadd_CMD} -f401 hsimple401.root hsimple.root
                            COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple401.root\",25000,401,447579,5)"
-                           DEPENDS hsimple-filemergerfile)
+                           DEPENDS roottest-root-io-filemerger-hsimple)
       endif()
    else()
       ROOTTEST_ADD_TEST(simple-default-compr-level9
                   PRECMD ${ROOT_hadd_CMD} -f9 hsimple9.root hsimple.root
                   COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple9.root\",25000,9,430953,25)"
-                  DEPENDS hsimple-filemergerfile)
+                  DEPENDS roottest-root-io-filemerger-hsimple)
 
       ROOTTEST_ADD_TEST(simple-zlib-compr-level1
                   PRECMD ${ROOT_hadd_CMD} -f101 hsimple101.root hsimple.root
                   COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple101.root\",25000,101,414948,25)"
-                  DEPENDS hsimple-filemergerfile)
+                  DEPENDS roottest-root-io-filemerger-hsimple)
 
       ROOTTEST_ADD_TEST(simple-zlib-compr-level6
                   PRECMD ${ROOT_hadd_CMD} -f106 hsimple106.root hsimple.root
                   COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple106.root\",25000,106,431240,25)"
-                  DEPENDS hsimple-filemergerfile)
+                  DEPENDS roottest-root-io-filemerger-hsimple)
 
       ROOTTEST_ADD_TEST(simple-zlib-compr-level9
                   PRECMD ${ROOT_hadd_CMD} -f109 hsimple109.root hsimple.root
                   COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple109.root\",25000,109,430962,25)"
-                  DEPENDS hsimple-filemergerfile)
+                  DEPENDS roottest-root-io-filemerger-hsimple)
 
       ROOTTEST_ADD_TEST(simple-default-compr-level9-datageneration
                   PRECMD  ${ROOT_hadd_CMD} -f9 hsimple9x2.root hsimple.root
                   COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple9x2.root\",25000,9,430961,25)"
                   POSTCMD ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/hsimple9x2.root ${CMAKE_CURRENT_BINARY_DIR}/hsimple92.root
-                  DEPENDS hsimple-filemergerfile)
+                  DEPENDS roottest-root-io-filemerger-hsimple)
 
       ROOTTEST_ADD_TEST(simple-zlib-compr-level9-datageneration
                   PRECMD  ${ROOT_hadd_CMD} -f109 hsimple109x2.root hsimple.root
                   COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple109x2.root\",25000,109,430970,25)"
                   POSTCMD ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/hsimple109x2.root ${CMAKE_CURRENT_BINARY_DIR}/hsimple1092.root
-                  DEPENDS hsimple-filemergerfile)
+                  DEPENDS roottest-root-io-filemerger-hsimple)
 
       ROOTTEST_ADD_TEST(simplex2-default-compr-level9
                   PRECMD  ${ROOT_hadd_CMD} -f9 -a hsimple9x2.root hsimple.root
@@ -322,7 +312,7 @@ if(${compression_default} STREQUAL "zlib")
       ROOTTEST_ADD_TEST(simplek-default-compr-deflevel
                   PRECMD ${ROOT_hadd_CMD} -fk hsimpleK.root hsimple209.root hsimple409.root hsimple.root hsimple9.root hsimple92.root
                   COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimpleK.root\",6*25000,209,2297560,30)"
-                  DEPENDS hsimple-filemergerfile
+                  DEPENDS roottest-root-io-filemerger-hsimple
                   DEPENDS simple-lz4-compr-level9
                   DEPENDS simple-lzma-compr-level9
                   DEPENDS simplex2-default-compr-level9
@@ -331,7 +321,7 @@ if(${compression_default} STREQUAL "zlib")
       ROOTTEST_ADD_TEST(simplek-lzma-compr-level9
                   PRECMD ${ROOT_hadd_CMD} -fk209 hsimpleK209.root hsimpleK.root hsimple209.root hsimple409.root hsimple.root hsimple9.root hsimple92.root
                   COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimpleK209.root\",12*25000,209,4583784,30)"
-                  DEPENDS hsimple-filemergerfile
+                  DEPENDS roottest-root-io-filemerger-hsimple
                   DEPENDS filemerger-simple-lz4-compr-level9
                   DEPENDS filemerger-simple-lzma-compr-level9
                   DEPENDS simplex2-default-compr-level9
@@ -341,7 +331,7 @@ if(${compression_default} STREQUAL "zlib")
          ROOTTEST_ADD_TEST(simplek-lz4-compr-level4
                      PRECMD ${ROOT_hadd_CMD} -fk404 hsimpleK404.root hsimpleK209.root hsimpleK.root hsimple.root hsimple9.root hsimple209.root hsimple409.root hsimple92.root
                      COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimpleK404.root\",24*25000,404,12047489,30)"
-                     DEPENDS hsimple-filemergerfile
+                     DEPENDS roottest-root-io-filemerger-hsimple
                      DEPENDS simple-lz4-compr-level9
                      DEPENDS simple-lzma-compr-level9
                      DEPENDS simplex2-default-compr-level9
@@ -351,22 +341,22 @@ if(${compression_default} STREQUAL "zlib")
          ROOTTEST_ADD_TEST(simple-lz4-compr-level4
                         PRECMD ${ROOT_hadd_CMD} -f404 hsimple404.root hsimple.root
                         COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple404.root\",25000,404,517275,15)"
-                        DEPENDS hsimple-filemergerfile)
+                        DEPENDS roottest-root-io-filemerger-hsimple)
          ROOTTEST_ADD_TEST(simple-lz4-compr-level9
                         PRECMD ${ROOT_hadd_CMD} -f409 hsimple409.root hsimple.root
                         COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple409.root\",25000,409,516893,5)"
-                        DEPENDS hsimple-filemergerfile)
+                        DEPENDS roottest-root-io-filemerger-hsimple)
 
          ROOTTEST_ADD_TEST(simple-lz4-compr-level1
                         PRECMD ${ROOT_hadd_CMD} -f401 hsimple401.root hsimple.root
                         COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple401.root\",25000,401,418044,5)"
-                        DEPENDS hsimple-filemergerfile)
+                        DEPENDS roottest-root-io-filemerger-hsimple)
 
       elseif(${LZ4_VERSION} VERSION_GREATER_EQUAL "1.7.5")
          ROOTTEST_ADD_TEST(simplek-lz4-compr-level4
                      PRECMD ${ROOT_hadd_CMD} -fk404 hsimpleK404.root hsimpleK209.root hsimpleK.root hsimple.root hsimple9.root hsimple209.root hsimple409.root hsimple92.root
                      COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimpleK404.root\",24*25000,404,12047466,30)"
-                     DEPENDS hsimple-filemergerfile
+                     DEPENDS roottest-root-io-filemerger-hsimple
                      DEPENDS simple-lz4-compr-level9
                      DEPENDS simple-lzma-compr-level9
                      DEPENDS simplex2-default-compr-level9
@@ -376,28 +366,28 @@ if(${compression_default} STREQUAL "zlib")
          ROOTTEST_ADD_TEST(simple-lz4-compr-level4
                         PRECMD ${ROOT_hadd_CMD} -f404 hsimple404.root hsimple.root
                         COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple404.root\",25000,404,517232,15)"
-                        DEPENDS hsimple-filemergerfile)
+                        DEPENDS roottest-root-io-filemerger-hsimple)
          if(CMAKE_SYSTEM_PROCESSOR MATCHES aarch64)
             ROOTTEST_ADD_TEST(simple-lz4-compr-level9
                           PRECMD ${ROOT_hadd_CMD} -f409 hsimple409.root hsimple.root
                           COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple409.root\",25000,409,516975,5)"
-                          DEPENDS hsimple-filemergerfile)
+                          DEPENDS roottest-root-io-filemerger-hsimple)
          else()
             ROOTTEST_ADD_TEST(simple-lz4-compr-level9
                           PRECMD ${ROOT_hadd_CMD} -f409 hsimple409.root hsimple.root
                           COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple409.root\",25000,409,516961,5)"
-                          DEPENDS hsimple-filemergerfile)
+                          DEPENDS roottest-root-io-filemerger-hsimple)
          endif()
          ROOTTEST_ADD_TEST(simple-lz4-compr-level1
                         PRECMD ${ROOT_hadd_CMD} -f401 hsimple401.root hsimple.root
                         COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple401.root\",25000,401,418887,5)"
-                        DEPENDS hsimple-filemergerfile)
+                        DEPENDS roottest-root-io-filemerger-hsimple)
       endif()
 
       ROOTTEST_ADD_TEST(simplef-default-compr-level9
                   PRECMD ${ROOT_hadd_CMD} -ff hsimpleF.root hsimple9.root hsimple209.root hsimple409.root hsimpleK404.root hsimple.root hsimple92.root
                   COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimpleF.root\",30*25000,9,12581392,30)"
-                  DEPENDS hsimple-filemergerfile
+                  DEPENDS roottest-root-io-filemerger-hsimple
                   DEPENDS simple-lz4-compr-level9
                   DEPENDS simple-lzma-compr-level9
                   DEPENDS simplex2-default-compr-level9
@@ -409,4 +399,4 @@ endif()
 ROOTTEST_ADD_TEST(simple-lzma-compr-level9
                   PRECMD ${ROOT_hadd_CMD} -f209 hsimple209.root hsimple.root
                   COMMAND ${ROOT_root_CMD} -q -l -b "${CMAKE_CURRENT_SOURCE_DIR}/testSimpleFile.C(\"hsimple209.root\",25000,209,392673,12)"
-                  DEPENDS hsimple-filemergerfile)
+                  DEPENDS roottest-root-io-filemerger-hsimple)


### PR DESCRIPTION
1. When running tests, one cannot use dependency from normal targets. 
Therefore, in `filemerger` create/copy hsimple.root file using extra tests targets and assign dependency from them

2. `TIMEOUT` parameter in ROOTTEST_ADD_TEST can only have single value

3. When generate dictionary, use name of dictionary directly - not a global variable which may change in the future