### PR TITLE
[JupyROOT] Backport 6.18: Run tests in build directory

### DIFF
--- a/python/JupyROOT/CMakeLists.txt
+++ b/python/JupyROOT/CMakeLists.txt
@@ -6,15 +6,15 @@ set(NBDIFFUTIL ${CMAKE_CURRENT_SOURCE_DIR}/nbdiff.py )
 # List of notebook files
 # TODO: To be extended with the list of downloaded notebooks used in the
 # documentation and as tutorials.
-set(NOTEBOOKS ${CMAKE_CURRENT_SOURCE_DIR}/importROOT.ipynb
-              ${CMAKE_CURRENT_SOURCE_DIR}/simpleCppMagic.ipynb)
+set(NOTEBOOKS importROOT.ipynb
+              simpleCppMagic.ipynb)
 
 # Include cpp notebooks if metakernel is present
 execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c" "import metakernel" RESULT_VARIABLE FoundMetakernel ERROR_QUIET)
 if(FoundMetakernel EQUAL 0)
 set(NOTEBOOKS ${NOTEBOOKS}
-              ${CMAKE_CURRENT_SOURCE_DIR}/thread_local.ipynb
-              ${CMAKE_CURRENT_SOURCE_DIR}/ROOT_kernel.ipynb)
+              thread_local.ipynb
+              ROOT_kernel.ipynb)
 endif()
 
 find_python_module(IPython QUIET)
@@ -34,6 +34,7 @@ if(PY_IPYTHON_FOUND)
   foreach(NOTEBOOK ${NOTEBOOKS})
     get_filename_component(NOTEBOOKBASE ${NOTEBOOK} NAME_WE)
     ROOTTEST_ADD_TEST(${NOTEBOOKBASE}_notebook
+                      COPY_TO_BUILDDIR ${NOTEBOOK}
                       COMMAND ${PYTHON_EXECUTABLE} ${NBDIFFUTIL} ${NOTEBOOK}
                       ${PYTESTS_WILLFAIL})
   endforeach()


### PR DESCRIPTION
Prevent the creation of .ipynb, .C, .pcm, .d and .so temporary
files in the source directory. Such remnants can cause
failures in the JupyROOT tests.