### PR TITLE
[PyROOT] 6.22 Backport: Adapt tests to removal of pyroot_experimental flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,8 +146,8 @@ if(ROOT_pyroot_FOUND)
   endif()
 endif()
 
-#---Set flag for PyROOT tests that are expected to fail in experimental
-if(ROOT_pyroot_experimental_FOUND)
+#---Set flag for PyROOT tests that are expected to fail
+if(ROOT_pyroot_FOUND)
   set(PYTESTS_WILLFAIL WILLFAIL)
 endif()
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,8 +1,8 @@
 if(ROOT_pyroot_FOUND)
-  if (ROOT_pyroot_experimental_FOUND)
-    set(exp_pyroot True)
+  if (ROOT_pyroot_legacy_FOUND)
+    set(legacy_pyroot True)
   else()
-    set(exp_pyroot False)
+    set(legacy_pyroot False)
   endif()
 endif()
 

--- a/python/basic/CMakeLists.txt
+++ b/python/basic/CMakeLists.txt
@@ -3,7 +3,7 @@ if(ROOT_pyroot_FOUND)
                     MACRO PyROOT_basictests.py
                     COPY_TO_BUILDDIR ArgumentPassingCompiled.C ReturnValues.C SimpleClass.C ArgumentPassingInterpreted.C
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ ArgumentPassingCompiled.C+
-                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
+                    ENVIRONMENT LEGACY_PYROOT=${legacy_pyroot})
 
   ROOTTEST_ADD_TEST(datatype
                     MACRO PyROOT_datatypetest.py
@@ -11,7 +11,7 @@ if(ROOT_pyroot_FOUND)
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ DataTypes.C+
                     ENVIRONMENT CLING_STANDARD_PCH=none
                                 CPPYY_BACKEND_LIBRARY=${CMAKE_BINARY_DIR}/lib/libcppyy_backend${PYTHON_UNDER_VERSION_STRING}.so
-                                ENVIRONMENT EXP_PYROOT=${exp_pyroot})
+                                ENVIRONMENT LEGACY_PYROOT=${legacy_pyroot})
 
 
   ROOTTEST_ADD_TEST(operator
@@ -25,5 +25,5 @@ if(ROOT_pyroot_FOUND)
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ Overloads.C+
                     ENVIRONMENT CLING_STANDARD_PCH=none
                                 CPPYY_BACKEND_LIBRARY=${CMAKE_BINARY_DIR}/lib/libcppyy_backend${PYTHON_UNDER_VERSION_STRING}.so
-                                ENVIRONMENT EXP_PYROOT=${exp_pyroot})
+                                ENVIRONMENT LEGACY_PYROOT=${legacy_pyroot})
 endif()

--- a/python/basic/PyROOT_basictests.py
+++ b/python/basic/PyROOT_basictests.py
@@ -260,7 +260,7 @@ class Basic4ArgumentPassingTestCase( MyTestCase ):
 class Basic5PythonizationTestCase( MyTestCase ):
    @classmethod
    def setUpClass(cls):
-      cls.exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
+      cls.legacy_pyroot = os.environ.get('LEGACY_PYROOT') == 'True'
 
    def test1Strings( self ):
       """Test string/TString/TObjString compatibility"""
@@ -338,7 +338,7 @@ class Basic5PythonizationTestCase( MyTestCase ):
       l.insert(  3, TObjString('6') )
       l.insert( 20, TObjString('7') )
       l.insert( -1, TObjString('8') )
-      if self.exp_pyroot:
+      if not self.legacy_pyroot:
          # The pythonisation of TSeqCollection in experimental PyROOT mimics the
          # behaviour of the Python list, in this case for insert.
          # The Python list insert always inserts before the specified index, so if

--- a/python/basic/PyROOT_datatypetest.py
+++ b/python/basic/PyROOT_datatypetest.py
@@ -34,8 +34,8 @@ class TestClassDATATYPES:
         cls.test_dct = "DataTypes_C"
         cls.datatypes = cppyy.load_reflection_info(cls.test_dct)
         cls.N = cppyy.gbl.N
-        cls.exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
-        if cls.exp_pyroot:
+        cls.legacy_pyroot = os.environ.get('LEGACY_PYROOT') == 'True'
+        if not cls.legacy_pyroot:
             # In new Cppyy, nullptr can't be found in gbl.
             # Take it from libcppyy (we could also use ROOT.nullptr)
             import libcppyy
@@ -198,7 +198,7 @@ class TestClassDATATYPES:
         c.set_uchar(45);  assert c.m_uchar     == chr(45)
 
         # limits and checks
-        if self.exp_pyroot:
+        if not self.legacy_pyroot:
            # This throws ValueError in new Cppyy
            raises(ValueError,  'c.set_char("string")')
            raises(ValueError,  'c.set_uchar("string")')
@@ -798,7 +798,7 @@ class TestClassDATATYPES:
 
         import cppyy
 
-        if self.exp_pyroot:
+        if not self.legacy_pyroot:
             # New Cppyy does not allow conversion from None to null pointer anymore
             t = (0, )
         else:
@@ -895,7 +895,7 @@ class TestClassDATATYPES:
             if not PYTEST_MIGRATION:
                 arr = arr.shape.fromaddress(arr.itemaddress(0), self.N)
             if PYTEST_MIGRATION:
-                if self.exp_pyroot:
+                if not self.legacy_pyroot:
                     # In new Cppyy, buffers have a reshape method
                     arr.reshape((self.N,))
 
@@ -964,7 +964,7 @@ class TestClassDATATYPES:
         def null_test(null):
             c.m_voidp = null
             assert c.m_voidp is self.nullptr
-        if self.exp_pyroot:
+        if not self.legacy_pyroot:
             # New Cppyy does not allow assignment of pointer type to None
             null_list = [0, self.nullptr]
         else:

--- a/python/basic/PyROOT_overloadtests.py
+++ b/python/basic/PyROOT_overloadtests.py
@@ -30,7 +30,7 @@ class TestClassOVERLOADS:
         import cppyy
         cls.test_dct = "Overloads_C"
         cls.datatypes = cppyy.load_reflection_info(cls.test_dct)
-        cls.exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
+        cls.legacy_pyroot = os.environ.get('LEGACY_PYROOT') == 'True'
 
     def test01_class_based_overloads(self):
         """Functions overloaded on different C++ class arguments"""
@@ -101,7 +101,7 @@ class TestClassOVERLOADS:
         from cppyy.gbl import get_OlBB, get_OlDD
 
         # first verify that BB and DD are indeed unknown
-        if self.exp_pyroot:
+        if not self.legacy_pyroot:
             # In new Cppyy, this raises a TypeError
             raises(TypeError, OlBB)
             raises(TypeError, OlDD)
@@ -111,7 +111,7 @@ class TestClassOVERLOADS:
 
         # then try overloads based on them
         assert MoreOverloads().call(OlAA())     == "OlAA"
-        if self.exp_pyroot:
+        if not self.legacy_pyroot:
             # New Cppyy calls the same overload as C++: (const OlBB&, void*)
             get_olbb_res = "OlBB"
         else:

--- a/python/cling/CMakeLists.txt
+++ b/python/cling/CMakeLists.txt
@@ -1,8 +1,8 @@
 if(ROOT_pyroot_FOUND)
-  if (ROOT_pyroot_experimental_FOUND)
-    set(api_macro_file runPyAPITestCppyy.C) # Uses new Cppyy API
-  else()
+  if (ROOT_pyroot_legacy_FOUND)
     set(api_macro_file runPyAPITest.C)
+  else()
+    set(api_macro_file runPyAPITestCppyy.C) # Uses new Cppyy API
   endif()
   ROOTTEST_ADD_TEST(api
                     MACRO ${api_macro_file}

--- a/python/cpp/CMakeLists.txt
+++ b/python/cpp/CMakeLists.txt
@@ -5,19 +5,19 @@ if(ROOT_pyroot_FOUND)
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ Namespace.C+
                                          -e .L\ PointerPassing.C+
                                          -e .L\ Namespace2.C+
-                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
+                    ENVIRONMENT LEGACY_PYROOT=${legacy_pyroot})
 
   ROOTTEST_ADD_TEST(advanced
                     MACRO PyROOT_advancedtests.py
                     COPY_TO_BUILDDIR AdvancedCpp.C Template.C
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ AdvancedCpp.C+
                                                      -e .L\ Template.C+
-                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
+                    ENVIRONMENT LEGACY_PYROOT=${legacy_pyroot})
 
   ROOTTEST_ADD_TEST(cpp11
                     MACRO PyROOT_cpp11tests.py
                     COPY_TO_BUILDDIR Cpp11Features.C
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ Cpp11Features.C+
-                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
+                    ENVIRONMENT LEGACY_PYROOT=${legacy_pyroot})
 
 endif()

--- a/python/cpp/PyROOT_advancedtests.py
+++ b/python/cpp/PyROOT_advancedtests.py
@@ -44,7 +44,7 @@ GetD = ROOT.GetD
 T1 = ROOT.T1
 T2 = ROOT.T2
 
-exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
+legacy_pyroot = os.environ.get('LEGACY_PYROOT') == 'True'
 
 
 ### C++ virtual inheritence test cases =======================================
@@ -205,13 +205,13 @@ class Cpp02TemplateLookup( MyTestCase ):
       try:
          m.GetSize()
       except TypeError as e:
-         if exp_pyroot:
+         if not legacy_pyroot:
             # The error message has changed in new Cppyy
             self.assert_( "Template method resolution failed" in str(e) )
          else:
             self.assert_( "must be explicit" in str(e) )
 
-      if exp_pyroot:
+      if not legacy_pyroot:
          # New cppyy needs square brackets for explicit instantiation here,
          # otherwise it tries to call the template proxy with the passed
          # argument and it fails, since no instantiation is available.
@@ -253,7 +253,7 @@ class Cpp02TemplateLookup( MyTestCase ):
 
     # note that the function and template arguments are reverted
       self.assertRaises( TypeError, m.GetSize2( 'char', 'long' ), 'a', 1 )
-      if exp_pyroot:
+      if not legacy_pyroot:
          # In the new Cppyy, we need to use square brackets in this case for
          # the bindings to know we are explicitly instantiating for char,long.
          # Otherwise, the templated parameters are just (mis)interpreted as
@@ -264,7 +264,7 @@ class Cpp02TemplateLookup( MyTestCase ):
          # Test new support for square bracket syntax
          self.assertEqual(m.GetSize2['char', 'long']( 1, 'a' ), m.GetCharSize() - m.GetLongSize() )
 
-      if exp_pyroot:
+      if not legacy_pyroot:
          # Cppyy's Long will be deprecated in favour of ctypes.c_long
          # https://bitbucket.org/wlav/cppyy/issues/101
          long_par = ctypes.c_long(256).value
@@ -292,7 +292,7 @@ class Cpp02TemplateLookup( MyTestCase ):
       self.assertEqual( len(dir(MyTemplatedMethodClass)), nd )
 
     # use existing explicit instantiations
-      if exp_pyroot:
+      if not legacy_pyroot:
          # New cppyy: use bracket syntax for explicit instantiation
          self.assertEqual( m.GetSizeOL[float]( 3.14 ),  m.GetFloatSize() )
       else:
@@ -305,7 +305,7 @@ class Cpp02TemplateLookup( MyTestCase ):
       self.assertEqual( len(dir(MyTemplatedMethodClass)), nd + num_new_inst)
 
     # explicit forced instantiation
-      if exp_pyroot:
+      if not legacy_pyroot:
          # New cppyy: use bracket syntax for explicit instantiation
          inst = m.GetSizeOL[int]
          self.assertEqual( inst( 1 ),       m.GetIntSize() )
@@ -349,7 +349,7 @@ class Cpp02TemplateLookup( MyTestCase ):
       m = MyTemplatedMethodClass()
 
       # Test the templated overload
-      if exp_pyroot:
+      if not legacy_pyroot:
          # In the new Cppyy, we need to use square brackets in this case for
          # the bindings to know we are explicitly instantiating for char.
          # Otherwise, the templated parameter is just (mis)interpreted as
@@ -397,7 +397,7 @@ class Cpp02TemplateLookup( MyTestCase ):
       v = ROOT.std.vector("float")()
       v.push_back(val)
 
-      if exp_pyroot:
+      if not legacy_pyroot:
          inst_float = f["float"]
          inst_float_t = f["Float_t"]
          inst_vec_float = f["vector<float>"]
@@ -431,7 +431,7 @@ class Cpp03PassByNonConstRef( MyTestCase ):
    def test1TestPlaceHolders( self ):
       """Test usage of Long/Double place holders"""
 
-      if not exp_pyroot:
+      if legacy_pyroot:
          # Cppyy's Long and Double are deprecated in favour of ctypes
          # https://bitbucket.org/wlav/cppyy/issues/101
          l = ROOT.Long( pylong(42) )
@@ -451,7 +451,7 @@ class Cpp03PassByNonConstRef( MyTestCase ):
       SetDoubleThroughRef = ROOT.SetDoubleThroughRef
       SetIntThroughRef = ROOT.SetIntThroughRef
 
-      if not exp_pyroot and sys.hexversion < 0x3000000:
+      if legacy_pyroot and sys.hexversion < 0x3000000:
          # Cppyy's Long is deprecated in favour of ctypes.c_long
          # https://bitbucket.org/wlav/cppyy/issues/101
          l = ROOT.Long( pylong(42) )
@@ -464,14 +464,14 @@ class Cpp03PassByNonConstRef( MyTestCase ):
          SetLongThroughRef( l, 41 )
          self.assertEqual( l.value, 41 )
 
-      if not exp_pyroot:
+      if legacy_pyroot:
          # Cppyy's Double is deprecated in favour of ctypes.c_double
          # https://bitbucket.org/wlav/cppyy/issues/101
          d = ROOT.Double( 3.14 )
          SetDoubleThroughRef( d, 3.1415 )
          self.assertEqual( d, 3.1415 )
 
-      if not exp_pyroot and sys.hexversion < 0x3000000:
+      if legacy_pyroot and sys.hexversion < 0x3000000:
          i = ROOT.Long( pylong(42) )
          SetIntThroughRef( i, 13 )
          self.assertEqual( i, 13 )
@@ -535,7 +535,7 @@ class Cpp05AssignToRefArbitraryClass( MyTestCase ):
       try:
          a[0] = RefTesterNoAssign()
       except TypeError as e:
-         if exp_pyroot:
+         if not legacy_pyroot:
             # Message has changed in new Cppyy
             self.assert_( 'cannot assign' in str(e) )
          else:

--- a/python/cpp/PyROOT_cpp11tests.py
+++ b/python/cpp/PyROOT_cpp11tests.py
@@ -60,7 +60,7 @@ class Cpp2Cpp11LanguageConstructsTestCase( MyTestCase ):
       nullptr = ROOT.nullptr
 
       self.assertNotEqual( nullptr, 0 )
-      if os.environ.get('EXP_PYROOT') == 'False':
+      if os.environ.get('LEGACY_PYROOT') == 'True':
          # In new Cppyy, TGraphErrors(0,0,0) is accepted.
          # I.e. it is allowed to pass 0 when the argument is of pointer type.
          self.assertRaises( TypeError, TGraphErrors, 0, 0, 0 )

--- a/python/cpp/PyROOT_cpptests.py
+++ b/python/cpp/PyROOT_cpptests.py
@@ -26,7 +26,7 @@ __all__ = [
 class Cpp1LanguageFeatureTestCase( MyTestCase ):
    @classmethod
    def setUpClass(cls):
-      cls.exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
+      cls.legacy_pyroot = os.environ.get('LEGACY_PYROOT') == 'True'
 
    def test01ClassEnum( self ):
       """Test class enum access and values"""
@@ -57,7 +57,7 @@ class Cpp1LanguageFeatureTestCase( MyTestCase ):
       self.assertEqual(ROOT.aa, 0)
       self.assertEqual(ROOT.bb, 1)
 
-      if self.exp_pyroot:
+      if not self.legacy_pyroot:
          cppname = ROOT.foo.__cpp_name__
       else:
          cppname = ROOT.foo.__cppname__
@@ -73,7 +73,7 @@ class Cpp1LanguageFeatureTestCase( MyTestCase ):
       self.assertEqual(ROOT.myns.aa, 0)
       self.assertEqual(ROOT.myns.bb, 1)
 
-      if self.exp_pyroot:
+      if not self.legacy_pyroot:
          cppname = ROOT.myns.foo.__cpp_name__
       else:
          cppname = ROOT.myns.foo.__cppname__
@@ -117,7 +117,7 @@ class Cpp1LanguageFeatureTestCase( MyTestCase ):
       for i in range(4):
          self.assertEqual( t1[i], t3[i] )
 
-      if self.exp_pyroot:
+      if not self.legacy_pyroot:
          # Test copy constructor with null pointer
          t4 = MakeNullPointer(TLorentzVector)
          t4.__init__(TLorentzVector(0, 1, 2, 3))
@@ -244,7 +244,7 @@ class Cpp1LanguageFeatureTestCase( MyTestCase ):
 
       import array
       if hasattr( array.array, 'buffer_info' ):   # not supported in p2.2
-         if self.exp_pyroot:
+         if not self.legacy_pyroot:
             # New cppyy uses unsigned long to represent void* returns, as in DynamicCast.
             # To prevent an overflow error when converting the Python integer returned by
             # DynamicCast into a 4-byte signed long in 32 bits, we use unsigned long ('L')
@@ -258,13 +258,13 @@ class Cpp1LanguageFeatureTestCase( MyTestCase ):
 
       self.assertEqual( 0, Z.GimeAddressPtr( 0 ) );
       self.assertEqual( 0, Z.GimeAddressObject( 0 ) );
-      if not self.exp_pyroot:
+      if self.legacy_pyroot:
          # The conversion None -> ptr is not supported in new Cppyy
          self.assertEqual( 0, Z.GimeAddressPtr( None ) );
          self.assertEqual( 0, Z.GimeAddressObject( None ) );
 
       ptr = MakeNullPointer( TObject )
-      if self.exp_pyroot:
+      if not self.legacy_pyroot:
          # New Cppyy does not raise ValueError,
          # it just returns zero
          self.assertEqual(addressof(ptr), 0)
@@ -278,7 +278,7 @@ class Cpp1LanguageFeatureTestCase( MyTestCase ):
 
    def test13Macro( self ):
       """Test access to cpp macro's"""
-      if not self.exp_pyroot:
+      if self.legacy_pyroot:
          # In new PyROOT, we will just provide ROOT.nullptr
          self.assertEqual( ROOT.NULL, 0 );
 
@@ -290,7 +290,7 @@ class Cpp1LanguageFeatureTestCase( MyTestCase ):
       # see above, is a special case)
       ROOT.PyConfig.ExposeCppMacros = True
 
-      if not self.exp_pyroot:
+      if self.legacy_pyroot:
          # New Cppyy does not do lookup of macros
          self.assertEqual( ROOT.aap, "aap" )
          self.assertEqual( ROOT.noot, 1 )

--- a/python/function/CMakeLists.txt
+++ b/python/function/CMakeLists.txt
@@ -5,5 +5,5 @@ if(ROOT_pyroot_FOUND)
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ InstallableFunction.C+
                                              -e .L\ GlobalFunction2.C+
                                              -e .L\ GlobalFunction3.C+
-                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
+                    ENVIRONMENT LEGACY_PYROOT=${legacy_pyroot})
 endif()

--- a/python/memory/CMakeLists.txt
+++ b/python/memory/CMakeLists.txt
@@ -3,5 +3,5 @@ if(ROOT_pyroot_FOUND)
                     MACRO PyROOT_memorytests.py
                     COPY_TO_BUILDDIR MemTester.C
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ MemTester.C+
-                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
+                    ENVIRONMENT LEGACY_PYROOT=${legacy_pyroot})
 endif()

--- a/python/memory/PyROOT_memorytests.py
+++ b/python/memory/PyROOT_memorytests.py
@@ -39,7 +39,7 @@ else:
 class Memory1TestCase( MyTestCase ):
    @classmethod
    def setUpClass(cls):
-      cls.exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
+      cls.legacy_pyroot = os.environ.get('LEGACY_PYROOT') == 'True'
 
    def test1ObjectCreationDestruction( self ):
       """Test object creation and destruction"""
@@ -85,7 +85,7 @@ class Memory1TestCase( MyTestCase ):
 
    def set_mem_policy(self, callable_obj, pol):
       # Set the memory policy of the callable object received
-      if self.exp_pyroot:
+      if not self.legacy_pyroot:
          callable_obj.__mempolicy__ = pol
       else:
          callable_obj._mempolicy = pol

--- a/python/pickle/CMakeLists.txt
+++ b/python/pickle/CMakeLists.txt
@@ -3,10 +3,10 @@ if(ROOT_pyroot_FOUND)
                     MACRO PyROOT_writetests.py
                     COPY_TO_BUILDDIR PickleTypes.C
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ PickleTypes.C+
-                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
+                    ENVIRONMENT LEGACY_PYROOT=${legacy_pyroot})
 
   ROOTTEST_ADD_TEST(read
                     MACRO PyROOT_readtests.py
                     DEPENDS write
-                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
+                    ENVIRONMENT LEGACY_PYROOT=${legacy_pyroot})
 endif()

--- a/python/pickle/PyROOT_readtests.py
+++ b/python/pickle/PyROOT_readtests.py
@@ -107,12 +107,12 @@ class PickleReadingSimpleObjectsTestCase( MyTestCase ):
    def test5ReadCustomTypes( self ):
       """Test reading PyROOT custom types"""
 
-      exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
+      legacy_pyroot = os.environ.get('LEGACY_PYROOT') == 'True'
 
       p = pickle.load( self.in1 )
       cp = cPickle.load( self.in2 )
 
-      if exp_pyroot:
+      if not legacy_pyroot:
          # Cppyy's Long and Double will be deprecated in favour of
          # ctypes.c_long and ctypes.c_double, respectively
          # https://bitbucket.org/wlav/cppyy/issues/101

--- a/python/pickle/PyROOT_writetests.py
+++ b/python/pickle/PyROOT_writetests.py
@@ -75,9 +75,9 @@ class PickleWritingSimpleObjectsTestCase( MyTestCase ):
    def test5WriteCustomTypes( self ):
       """Test writing PyROOT custom types"""
 
-      exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
+      legacy_pyroot = os.environ.get('LEGACY_PYROOT') == 'True'
 
-      if exp_pyroot:
+      if not legacy_pyroot:
          # Cppyy's Long and Double will be deprecated in favour of
          # ctypes.c_long and ctypes.c_double, respectively
          # https://bitbucket.org/wlav/cppyy/issues/101

--- a/python/pythonizations/CMakeLists.txt
+++ b/python/pythonizations/CMakeLists.txt
@@ -3,11 +3,11 @@ if(ROOT_pyroot_FOUND)
                     MACRO PyROOT_pythonizationtest.py
                     COPY_TO_BUILDDIR Pythonizables.C Pythonizables.h
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ Pythonizables.C+
-                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
+                    ENVIRONMENT LEGACY_PYROOT=${legacy_pyroot})
 
   ROOTTEST_ADD_TEST(smartptr
                     MACRO PyROOT_smartptrtest.py
                     COPY_TO_BUILDDIR SmartPtr.C SmartPtr.h
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ SmartPtr.C+
-                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
+                    ENVIRONMENT LEGACY_PYROOT=${legacy_pyroot})
 endif()

--- a/python/pythonizations/PyROOT_pythonizationtest.py
+++ b/python/pythonizations/PyROOT_pythonizationtest.py
@@ -28,22 +28,22 @@ class TestClassPYTHONIZATIONS:
         import cppyy
         cls.test_dct = "Pythonizables_C"
         cls.pythonizables = cppyy.load_reflection_info(cls.test_dct)
-        cls.exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
+        cls.legacy_pyroot = os.environ.get('LEGACY_PYROOT') == 'True'
 
     def test01_size_mapping(self):
         """Use composites to map GetSize() onto buffer returns"""
 
         import cppyy
 
-        exp_pyroot = self.exp_pyroot
+        legacy_pyroot = self.legacy_pyroot
         def set_size(self, buf):
-            if exp_pyroot:
+            if not legacy_pyroot:
                 buf.reshape((self.GetN(),))
             else:
                 buf.SetSize(self.GetN())
             return buf
 
-        if exp_pyroot:
+        if not legacy_pyroot:
             cppyy.py.add_pythonization(
                 cppyy.py.compose_method("pythonizables::MyBufferReturner$", "Get[XY]$", set_size)
                 )
@@ -67,9 +67,9 @@ class TestClassPYTHONIZATIONS:
         """Verify pinnability of returns"""
 
         import cppyy
-        exp_pyroot = self.exp_pyroot
+        legacy_pyroot = self.legacy_pyroot
 
-        if exp_pyroot:
+        if not legacy_pyroot:
             cppyy.gbl.pythonizables.GimeDerived.__creates__ = True
         else:
             cppyy.gbl.pythonizables.GimeDerived._creates = True
@@ -77,7 +77,7 @@ class TestClassPYTHONIZATIONS:
         result = cppyy.gbl.pythonizables.GimeDerived()
         assert type(result) == cppyy.gbl.pythonizables.MyDerived
 
-        if exp_pyroot:
+        if not legacy_pyroot:
             cppyy.py.pin_type(cppyy.gbl.pythonizables.MyBase)
         else:
             cppyy.make_interface(cppyy.gbl.pythonizables.MyBase)
@@ -94,7 +94,7 @@ class TestClassPYTHONIZATIONS_FRAGILITY:
 
 class TestClassROOT_PYTHONIZATIONS:
     def setup_class(cls):
-        cls.exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
+        cls.legacy_pyroot = os.environ.get('LEGACY_PYROOT') == 'True'
 
     def test01_tgraph(self):
         """TGraph has GetN() mapped as size to its various buffer returns"""
@@ -162,7 +162,7 @@ class TestClassROOT_PYTHONIZATIONS:
     def test05_rooargset_iter(self):
         """STL sequence iterator injected in RooAbsCollection, inherited by RooArgSet"""
 
-        if self.exp_pyroot:
+        if not self.legacy_pyroot:
             # ROOT-10606
             import ROOT
 

--- a/python/pythonizations/PyROOT_smartptrtest.py
+++ b/python/pythonizations/PyROOT_smartptrtest.py
@@ -32,7 +32,7 @@ class TestClassSMARTPTRS:
 
         # We need to introduce it in order to distinguish between
         # _get_smart_ptr in old Cppyy and __smartptr__ in new Cppyy
-        cls.exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
+        cls.legacy_pyroot = os.environ.get('LEGACY_PYROOT') == 'True'
 
     def test01_transparency(self):
         import cppyy
@@ -41,7 +41,7 @@ class TestClassSMARTPTRS:
         mine = cppyy.gbl.mine
 
         assert type(mine) == MyShareable
-        if self.exp_pyroot:
+        if not self.legacy_pyroot:
             assert type(mine.__smartptr__()) == cppyy.gbl.std.shared_ptr(MyShareable)
         else:
             assert type(mine._get_smart_ptr()) == cppyy.gbl.std.shared_ptr(MyShareable)
@@ -60,7 +60,7 @@ class TestClassSMARTPTRS:
         cppyy.gbl.pass_mine_sp_ptr(mine)
         cppyy.gbl.pass_mine_sp_ref(mine)
 
-        if self.exp_pyroot:
+        if not self.legacy_pyroot:
             cppyy.gbl.pass_mine_sp_ptr(mine.__smartptr__())
             cppyy.gbl.pass_mine_sp_ref(mine.__smartptr__())
         else:
@@ -68,7 +68,7 @@ class TestClassSMARTPTRS:
             cppyy.gbl.pass_mine_sp_ref(mine._get_smart_ptr())
 
         cppyy.gbl.pass_mine_sp(mine)
-        if self.exp_pyroot:
+        if not self.legacy_pyroot:
             cppyy.gbl.pass_mine_sp(mine.__smartptr__())
         else:
             cppyy.gbl.pass_mine_sp(mine._get_smart_ptr())
@@ -84,7 +84,7 @@ class TestClassSMARTPTRS:
 
         mine = cppyy.gbl.gime_mine_ptr()
         assert type(mine) == MyShareable
-        if self.exp_pyroot:
+        if not self.legacy_pyroot:
             assert type(mine.__smartptr__()) == cppyy.gbl.std.shared_ptr(MyShareable)
         else:
             assert type(mine._get_smart_ptr()) == cppyy.gbl.std.shared_ptr(MyShareable)
@@ -92,7 +92,7 @@ class TestClassSMARTPTRS:
 
         mine = cppyy.gbl.gime_mine_ref()
         assert type(mine) == MyShareable
-        if self.exp_pyroot:
+        if not self.legacy_pyroot:
             assert type(mine.__smartptr__()) == cppyy.gbl.std.shared_ptr(MyShareable)
         else:
             assert type(mine._get_smart_ptr()) == cppyy.gbl.std.shared_ptr(MyShareable)
@@ -100,7 +100,7 @@ class TestClassSMARTPTRS:
 
         mine = cppyy.gbl.gime_mine()
         assert type(mine) == MyShareable
-        if self.exp_pyroot:
+        if not self.legacy_pyroot:
             assert type(mine.__smartptr__()) == cppyy.gbl.std.shared_ptr(MyShareable)
         else:
             assert type(mine._get_smart_ptr()) == cppyy.gbl.std.shared_ptr(MyShareable)

--- a/python/regression/CMakeLists.txt
+++ b/python/regression/CMakeLists.txt
@@ -1,8 +1,8 @@
 if(ROOT_pyroot_FOUND)
-  if (ROOT_pyroot_experimental_FOUND)
-    set(scott_file ScottCppyy.C) # Uses Cppyy header
-  else()
+  if (ROOT_pyroot_legacy_FOUND)
     set(scott_file Scott.C)
+  else()
+    set(scott_file ScottCppyy.C) # Uses Cppyy header
   endif()
 
   ROOTTEST_ADD_TEST(regression
@@ -19,7 +19,7 @@ if(ROOT_pyroot_FOUND)
                                          -e .L\ ULongLong.C+
                                          -e .L\ Till.C+
                                          -e .L\ CoralAttributeList.C+
-                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
+                    ENVIRONMENT LEGACY_PYROOT=${legacy_pyroot})
 
   ROOTTEST_ADD_TEST(root_6023
                     MACRO exec_root_6023.py

--- a/python/regression/PyROOT_regressiontests.py
+++ b/python/regression/PyROOT_regressiontests.py
@@ -51,7 +51,7 @@ __all__ = [
 ### "from ROOT import *" done in import-*-ed module ==========================
 from Amir import *
 
-exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
+legacy_pyroot = os.environ.get('LEGACY_PYROOT') == 'True'
 
 
 class Regression01TwiceImportStar( MyTestCase ):
@@ -314,7 +314,7 @@ class Regression08CheckEnumExactMatch( MyTestCase ):
       self.assertEqual( ROOT.cow,  a.testEnum2( ROOT.cow ) )
       self.assertEqual( ROOT.bird, a.testEnum3( ROOT.bird ) )
       self.assertEqual( ROOT.marsupilami, a.testEnum4( ROOT.marsupilami ) )
-      if exp_pyroot:
+      if not legacy_pyroot:
          # Cppyy's Long is deprecated in favour of ctypes.c_long
          # https://bitbucket.org/wlav/cppyy/issues/101
          import ctypes
@@ -339,7 +339,7 @@ class Regression09TVector3Pythonize( MyTestCase ):
    def test2TVector3(self):
       """Verify that using one operator* overload does not mask the others"""
       # ROOT-10278
-      if exp_pyroot:
+      if not legacy_pyroot:
          v = TVector3(1., 2., 3.)
          v*2
          self.assertEqual(v*v, 14.0)
@@ -375,7 +375,7 @@ class Regression11GlobalsLookup( MyTestCase ):
       """Test that ROOT.cout does not cause error messages"""
 
       import ROOT
-      if exp_pyroot:
+      if not legacy_pyroot:
          # Look for cout in std
          c = ROOT.std.cout
       else:
@@ -396,7 +396,7 @@ class Regression12WriteTGraph( MyTestCase ):
       gr = TGraph()
       ff = TFile( "test.root", "RECREATE" )
       ff.WriteObject( gr, "grname", "" )
-      if exp_pyroot:
+      if not legacy_pyroot:
          # In new PyROOT, use a nicer way to get objects in files:
          # (1) getattr syntax
          ff.grname
@@ -425,7 +425,7 @@ class Regression14TPyException( MyTestCase ):
    def test1PythonAccessToTPyException( self ):
       """Load TPyException into python and make sure its usable"""
 
-      if exp_pyroot:
+      if not legacy_pyroot:
          # In exp PyROOT, TPyException is called PyException and it belongs
          # to the CPyCppyy namespace.
          # Also, it is not included in the PCH, so we need to include the
@@ -504,7 +504,7 @@ class Regression19TGL(MyTestCase):
    def test1TGLVertex3OperatorPlus(self):
       """Try invoking TGLVertex3::operator+ twice"""
       # ROOT-10166
-      if exp_pyroot:
+      if not legacy_pyroot:
          from ROOT import TGLVertex3, TGLVector3
 
          scatteringPoint = TGLVertex3(2., 3., 0.2)
@@ -516,7 +516,7 @@ class Regression19TGL(MyTestCase):
    def test2TGLLine3Constructor(self):
       """Check that the right constructor of TGLLine3 is called"""
       # ROOT-10102
-      if exp_pyroot:
+      if not legacy_pyroot:
          from ROOT import TGLLine3, TGLVertex3, TGLVector3
 
          trackAfterScattering = TGLLine3(TGLVertex3(2., 3., 0.2), TGLVector3(0., 0., -20.))
@@ -531,7 +531,7 @@ class Regression20gEnv(MyTestCase):
    def test1GetSetValue(self):
       """Set a value with gEnv and retrieve it afterwards"""
       # ROOT-10155
-      if exp_pyroot:
+      if not legacy_pyroot:
          from ROOT import gEnv
 
          optname = "SomeOption"
@@ -546,7 +546,7 @@ class Regression21ReuseProxies(MyTestCase):
    def test1ReuseProxies(self):
       """Test that Python proxies are reused in attribute lookups"""
       # ROOT-8843
-      if exp_pyroot:
+      if not legacy_pyroot:
          import ROOT
          ROOT.gInterpreter.LoadText("struct A { A* otherA=nullptr;};")
          a1 = ROOT.A()
@@ -564,7 +564,7 @@ class Regression22ObjectCleanup(MyTestCase):
    def test1GetListOfGraphs(self):
       """List returned by GetListOfGraphs should not have kMustCleanup set to true"""
       # ROOT-9040
-      if exp_pyroot:
+      if not legacy_pyroot:
          mg = ROOT.TMultiGraph()
          mg.Add(ROOT.TGraph())
 

--- a/python/stl/CMakeLists.txt
+++ b/python/stl/CMakeLists.txt
@@ -3,6 +3,6 @@ if(ROOT_pyroot_FOUND)
                     MACRO PyROOT_stltests.py
                     COPY_TO_BUILDDIR StlTypes.C
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ StlTypes.C+
-                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
+                    ENVIRONMENT LEGACY_PYROOT=${legacy_pyroot})
 endif()
 

--- a/python/stl/PyROOT_stltests.py
+++ b/python/stl/PyROOT_stltests.py
@@ -28,7 +28,7 @@ class TestClasSTLVECTOR:
         cls.test_dct = "StlTypes_C"
         cls.datatypes = cppyy.load_reflection_info(cls.test_dct)
         cls.N = 13
-        cls.exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
+        cls.legacy_pyroot = os.environ.get('LEGACY_PYROOT') == 'True'
 
     def test01_builtin_vector_type(self):
         """Test access to a vector<int> (part of cintdlls)"""
@@ -92,7 +92,7 @@ class TestClasSTLVECTOR:
         for arg in a:
             pass
 
-        if self.exp_pyroot:
+        if not self.legacy_pyroot:
             # ROOT-10118
             # In current Cppyy, STL containers evaluate to True
             # if they contain at least one element
@@ -140,7 +140,7 @@ class TestClasSTLVECTOR:
     def test07_vector_bool_iter(self):
         """Iteration over a vector<bool>"""
         # ROOT-9397
-        if self.exp_pyroot:
+        if not self.legacy_pyroot:
             from cppyy.gbl import std
             v = std.vector[bool]()
             l = [True, False]
@@ -317,7 +317,7 @@ class TestClasSTLSTRINGHANDLING:
         import cppyy
         cls.test_dct = "StlTypes_C"
         cls.datatypes = cppyy.load_reflection_info(cls.test_dct)
-        cls.exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
+        cls.legacy_pyroot = os.environ.get('LEGACY_PYROOT') == 'True'
 
     def test01_string_argument_passing(self):
         """Test mapping of python strings and std::string"""
@@ -372,7 +372,7 @@ class TestClasSTLSTRINGHANDLING:
         t0 = "aap\0noot"
         assert t0 == "aap\0noot"
 
-        if self.exp_pyroot:
+        if not self.legacy_pyroot:
            c, s = StringyClass(), std.string(t0, 0, len(t0))
         else:
            c, s = StringyClass(), std.string(t0, len(t0))

--- a/python/ttree/CMakeLists.txt
+++ b/python/ttree/CMakeLists.txt
@@ -3,5 +3,5 @@ if(ROOT_pyroot_FOUND)
                     MACRO PyROOT_ttreetests.py
                     COPY_TO_BUILDDIR TTreeTypes.C
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ TTreeTypes.C+
-                    ENVIRONMENT EXP_PYROOT=${exp_pyroot})
+                    ENVIRONMENT LEGACY_PYROOT=${legacy_pyroot})
 endif()

--- a/python/ttree/PyROOT_ttreetests.py
+++ b/python/ttree/PyROOT_ttreetests.py
@@ -11,7 +11,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import ROOT
 from ROOT import gROOT, gDirectory, TArrayI, TFile, TTree, TObject, std, AddressOf, addressof, MakeNullPointer, TObjArray, TNamed
 
-exp_pyroot = os.environ.get('EXP_PYROOT') == 'True'
+legacy_pyroot = os.environ.get('LEGACY_PYROOT') == 'True'
 
 from common import *
 
@@ -142,7 +142,7 @@ class TTree1ReadWriteSimpleObjectsTestCase( MyTestCase ):
       fl = d.Floats
       t.Branch( 'floats', fl )
 
-      if exp_pyroot:
+      if not legacy_pyroot:
           # The Branch pythonization expects an integer with the
           # address of the field of the struct
           addressof_nlabel = addressof( d, 'NLabel' )
@@ -185,7 +185,7 @@ class TTree1ReadWriteSimpleObjectsTestCase( MyTestCase ):
             self.assertEqual( i, int(entry) )
             i += 1
 
-         if exp_pyroot:
+         if not legacy_pyroot:
             # In new cppyy, character arrays are read as Python strings,
             # ignoring the size of the branch buffer.
             # Here, no character '\0' is part of the returned string.
@@ -215,7 +215,7 @@ class TTree1ReadWriteSimpleObjectsTestCase( MyTestCase ):
       myarray = f.Get( 'myarray' )
       self.assert_( isinstance( myarray, TArrayI ) )
 
-      if exp_pyroot:
+      if not legacy_pyroot:
          # New PyROOT does not implement a pythonisation for GetObject.
          # Just use the getattr syntax, which is much nicer
          arr = f.myarray
@@ -297,7 +297,7 @@ class TTree1ReadWriteSimpleObjectsTestCase( MyTestCase ):
       s = SomeDataStruct()
 
       # Same reason for this difference as in test05WriteSomeDataObjectBranched
-      if exp_pyroot:
+      if not legacy_pyroot:
          addressof_nlabel = addressof(s, 'NLabel')
       else:
          addressof_nlabel = AddressOf(s, 'NLabel')


### PR DESCRIPTION
... and to the creation of the pyroot_legacy flag

Backport of https://github.com/root-project/roottest/pull/531