### PR TITLE
Do not use iomanip from TTree::MakeProxy in treeproxy test

### DIFF
--- a/root/treeproxy/make_tuple_draw.C
+++ b/root/treeproxy/make_tuple_draw.C
@@ -1,11 +1,13 @@
-Double_t make_tuple_draw() {
-   cout.width(7);
-   cout << std::setprecision(2)  << evt.val1 << ", " << evt.val2 << ", " << evt.val3 << endl;
+Double_t make_tuple_draw()
+{
+   std::cout.width(7);
+   std::cout.precision(2);
+   std::cout << evt.val1 << ", " << evt.val2 << ", " << evt.val3 << std::endl;
    int n = trk.N;
-   cout << n << endl;
+   std::cout << n << std::endl;
    for(int i=0; i<n; ++i) {
       float f = trk.arr[i];
-      cout << i << " " << (int)f << endl;
+      std::cout << i << " " << (int)f << std::endl;
    }
    return evt.val1;
 }


### PR DESCRIPTION
Problem appears while `<iomanip>` is not provided by used ROOT includes
I just used directly `ostream::precision` method.
Is there way to add extra includes in code generated by `TTree::MakeProxy()`