### PR TITLE
Never run two JupyROOT tests concurrently

### DIFF
--- a/python/JupyROOT/CMakeLists.txt
+++ b/python/JupyROOT/CMakeLists.txt
@@ -32,7 +32,8 @@ foreach(NOTEBOOK ${NOTEBOOKS})
   get_filename_component(NOTEBOOKBASE ${NOTEBOOK} NAME_WE)
   ROOTTEST_ADD_TEST(${NOTEBOOKBASE}_notebook
                     COPY_TO_BUILDDIR ${NOTEBOOK}
-                    COMMAND ${PYTHON_EXECUTABLE_Development_Main} ${NBDIFFUTIL} ${NOTEBOOK})
+                    COMMAND ${PYTHON_EXECUTABLE_Development_Main} ${NBDIFFUTIL} ${NOTEBOOK}
+                    RUN_SERIAL)
 endforeach()
 
 if(ROOT_imt_FOUND)
@@ -41,7 +42,8 @@ if(ROOT_imt_FOUND)
   get_filename_component(NOTEBOOKBASE ${IMT_NB} NAME_WE)
   ROOTTEST_ADD_TEST(${NOTEBOOKBASE}_notebook
                     COPY_TO_BUILDDIR ${IMT_NB}
-                    COMMAND ${PYTHON_EXECUTABLE_Development_Main} ${NBDIFFUTIL} ${IMT_NB} "OFF")
+                    COMMAND ${PYTHON_EXECUTABLE_Development_Main} ${NBDIFFUTIL} ${IMT_NB} "OFF"
+                    RUN_SERIAL)
 endif()
 
 endif()


### PR DESCRIPTION
Jupyter processes are not meant to run concurrently. In particular,
we observed issues with jupyter-migrate trying to concurrently create
the `kernels` directory and with jupyter processes fighting over
sockets.