### PR TITLE
Never run two JupyROOT tests concurrently

### DIFF
--- a/python/JupyROOT/CMakeLists.txt
+++ b/python/JupyROOT/CMakeLists.txt
@@ -35,7 +35,8 @@ if(PY_IPYTHON_FOUND)
     get_filename_component(NOTEBOOKBASE ${NOTEBOOK} NAME_WE)
     ROOTTEST_ADD_TEST(${NOTEBOOKBASE}_notebook
                       COPY_TO_BUILDDIR ${NOTEBOOK}
-                      COMMAND ${PYTHON_EXECUTABLE} ${NBDIFFUTIL} ${NOTEBOOK})
+                      COMMAND ${PYTHON_EXECUTABLE} ${NBDIFFUTIL} ${NOTEBOOK}
+                      RUN_SERIAL)
   endforeach()
 endif()
 


### PR DESCRIPTION
Jupyter processes are not meant to run concurrently. In particular,
we observed issues with jupyter-migrate trying to concurrently create
the `kernels` directory and with jupyter processes fighting over
sockets.