### PR TITLE
Fix check for RDF feature when roottest is built independently

### DIFF
--- a/root/dataframe/CMakeLists.txt
+++ b/root/dataframe/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(NOT dataframe)
+if(NOT ROOT_dataframe_FOUND)
   return()
 endif()
 


### PR DESCRIPTION
The `dataframe` cmake variable is not set when roottest is built
indepdendently against a pre-installed ROOT. ROOT_dataframe_FOUND
should be set both then and when roottest is built together with ROOT.