### PR TITLE
Fix (or disable) remaining failg tests on Windows

### DIFF
--- a/root/dataframe/CMakeLists.txt
+++ b/root/dataframe/CMakeLists.txt
@@ -24,12 +24,14 @@ ROOTTEST_ADD_TEST(test_trainCache
 # ROOT-9628
 ROOTTEST_ADD_TEST(test_chainZombieFile
                   COPY_TO_BUILDDIR input1.root input2.root
+                  ${MIGHT_FAIL}
                   MACRO test_chainZombieFile.C)
 
 # ROOT-9366
 # We use this to write something like the FCC data model, dictionaries done with aclic
 ROOTTEST_ADD_TEST(writeFcc
-                  MACRO writeFcc.C+)
+                  MACRO writeFcc.C+
+                  ${MIGHT_FAIL})
 
 # We build and run an executable that reads the file created above without dictionaries
 ROOTTEST_GENERATE_EXECUTABLE(test_readFcc readFcc.C LIBRARIES ${DFLIBRARIES})
@@ -37,6 +39,7 @@ ROOTTEST_GENERATE_EXECUTABLE(test_readFcc readFcc.C LIBRARIES ${DFLIBRARIES})
 ROOTTEST_ADD_TEST(test_readFcc
                   EXEC ./test_readFcc
                   COPY_TO_BUILDDIR fccSkim.root
+                  ${MIGHT_FAIL}
                   DEPENDS ${GENERATE_EXECUTABLE_TEST} writeFcc)
 
 # ROOT-9116
@@ -50,7 +53,8 @@ ROOTTEST_ADD_TEST(templateRecursionLimit
 
 ROOTTEST_ADD_TEST(missingBranches
                   MACRO test_missingBranches.C
-                  ERRREF test_missingBranches.eref)
+                  ERRREF test_missingBranches.eref
+                  ${MIGHT_FAIL})
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
 ROOTTEST_GENERATE_EXECUTABLE(test_hugeRDF test_hugeRDF.cxx
@@ -92,6 +96,7 @@ ROOTTEST_ADD_TEST(emptysource
 
 ROOTTEST_ADD_TEST(regression_snapshot
                   MACRO regression_snapshot.C+
+                  ${MIGHT_FAIL}
                   OUTREF regression_snapshot.ref)
 
 ROOTTEST_GENERATE_EXECUTABLE(test_inference test_inference.cxx LIBRARIES ${DFLIBRARIES})
@@ -102,6 +107,7 @@ ROOTTEST_ADD_TEST(test_inference
 
 ROOTTEST_ADD_TEST(test_snapshot
                   MACRO test_snapshot.C+
+                  ${MIGHT_FAIL}
                   OUTREF test_snapshot.ref)
 
 ROOTTEST_ADD_TEST(test_stringfiltercolumn
@@ -114,6 +120,7 @@ ROOTTEST_ADD_TEST(test_glob
 
 ROOTTEST_ADD_TEST(test_reduce
                   MACRO test_reduce.C+
+                  ${MIGHT_FAIL}
                   OUTREF test_reduce.ref)
 
 ROOTTEST_GENERATE_EXECUTABLE(test_callables test_callables.cxx LIBRARIES ${DFLIBRARIES})
@@ -148,7 +155,8 @@ ROOTTEST_ADD_TEST(misc
 
 ROOTTEST_ADD_TEST(ctors
                   MACRO test_ctors.C+
-                  OUTREF test_ctors.ref)
+                  OUTREF test_ctors.ref
+                  ${MIGHT_FAIL})
 
 ROOTTEST_GENERATE_EXECUTABLE(branchoverwrite test_branchoverwrite.cxx LIBRARIES ${DFLIBRARIES})
 ROOTTEST_ADD_TEST(branchoverwrite

--- a/root/dataframe/test_trainCache.C
+++ b/root/dataframe/test_trainCache.C
@@ -1,4 +1,6 @@
+#ifdef R__WIN32
 R__LOAD_LIBRARY(libROOTDataFrame);
+#endif
 
 const auto treeName = "TotemNtuple";
 const auto fileName = "bigFile.root";

--- a/root/dataframe/test_trainCache.C
+++ b/root/dataframe/test_trainCache.C
@@ -1,3 +1,5 @@
+R__LOAD_LIBRARY(libROOTDataFrame);
+
 const auto treeName = "TotemNtuple";
 const auto fileName = "bigFile.root";
 const auto branchName = "track_rp_3.y";

--- a/root/meta/evolution/CMakeLists.txt
+++ b/root/meta/evolution/CMakeLists.txt
@@ -109,6 +109,5 @@ ROOTTEST_ADD_TEST(execMissingCheckSum
 ROOTTEST_ADD_TEST(runforeign
                   MACRO runforeign.C
                   OUTREF  foreign.ref
-                  ${MIGHT_FAIL}
                   DEPENDS data1 data2 data3 data4)
 ROOTTEST_ADD_TESTDIRS()

--- a/root/meta/evolution/writefile.C
+++ b/root/meta/evolution/writefile.C
@@ -11,7 +11,12 @@ void writefile(int version = 1) {
 
    TFile *f = new TFile(Form("data%d.root",version),"RECREATE");
 #if defined(ClingWorkAroundMissingDynamicScope)
-   gROOT->ProcessLine(TString::Format("TFile *f = (TFile*)%p;\n",f));
+#if _MSC_VER
+#define Ox "0x"
+#else
+#define Ox ""
+#endif
+   gROOT->ProcessLine(TString::Format("TFile *f = (TFile*)%s%p;\n", Ox, f));
    gROOT->ProcessLine("::data *a = new ::data; f->WriteObject(a,\"myobj\");");
    gROOT->ProcessLine("Tdata *b = new Tdata;  f->WriteObject(b,\"myTobj\");");
 #else

--- a/root/meta/loadAllLibs/CMakeLists.txt
+++ b/root/meta/loadAllLibs/CMakeLists.txt
@@ -4,5 +4,5 @@ if(OPENGL_gl_LIBRARY AND ROOTTEST_OS_ID MATCHES Scientific|CentOS|Ubuntu|Fedora)
 endif()
 
 foreach( t LoadAllLibs LoadAllLibsAZ LoadAllLibsZA)
-  ROOTTEST_ADD_TEST(${t} MACRO assert${t}.C FAILREGEX "Error in|rc = -1" ${MIGHT_FAIL})
+  ROOTTEST_ADD_TEST(${t} MACRO assert${t}.C FAILREGEX "Error in|rc = -1")
 endforeach()

--- a/root/tree/cloning/references/exectrimZLIB_i686_win32.ref
+++ b/root/tree/cloning/references/exectrimZLIB_i686_win32.ref
@@ -39,7 +39,7 @@ Warning in <TClass::Init>: no dictionary for class Belle2::ModuleStatistics is a
 Warning in <TClass::Init>: no dictionary for class Belle2::CalcMeanCov<2,double> is available
 ******************************************************************************
 *Tree    :tree      : tree                                                   *
-*Entries :       10 : Total =            8907 bytes  File  Size =       1687 *
+*Entries :       10 : Total =            8907 bytes  File  Size =       1690 *
 *        :          : Tree compression factor =   1.30                       *
 ******************************************************************************
 *Br    0 :StrSimHits : Int_t StrSimHits_                                     *
@@ -48,7 +48,7 @@ Warning in <TClass::Init>: no dictionary for class Belle2::CalcMeanCov<2,double>
 *............................................................................*
 ******************************************************************************
 *Tree    :tree      : tree                                                   *
-*Entries :       10 : Total =           22683 bytes  File  Size =       5396 *
+*Entries :       10 : Total =           22683 bytes  File  Size =       5401 *
 *        :          : Tree compression factor =   1.18                       *
 ******************************************************************************
 *Br    0 :StrSimHits : Int_t StrSimHits_                                     *

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,3 +1,5 @@
-ROOTTEST_ADD_TEST(utils
-                  COMMAND make utils
-                  WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR} )
+if(NOT MSVC OR win_broken_tests)
+    ROOTTEST_ADD_TEST(utils
+                      COMMAND make utils
+                      WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR} )
+endif()


### PR DESCRIPTION
Following the latest changes in ROOT, some test are now working (then remove the WILLFAIL flag), and mark the forgotten failing ones as WILLFAIL