### PR TITLE
Fix non-standalone roottest on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,14 @@ if(MSVC)
   if (NOT PYTHON_EXECUTABLE)
     find_package(PythonInterp)
   endif()
+
+  if(DEFINED ROOT_SOURCE_DIR)
+    # ROOT_BINDIR is set by ROOTConfig.cmake
+    get_filename_component(realfp "${ROOT_BINDIR}/../" ABSOLUTE)
+    file(TO_CMAKE_PATH ${realfp} ROOTSYS)
+    set(ROOT_LIBRARIES libCore libRIO libNet libHist libGpad libTree libRint libMatrix libMathCore)
+  endif()
+
   include(${ROOT_USE_FILE})
   set(ROOTSYS ${ROOTSYS} CACHE INTERNAL "")
   file(READ "${ROOTSYS}/bin/root-config" root_config)
@@ -181,13 +189,19 @@ endif()
 set(ROOTTEST_ENV_LIBRARYPATH ${ROOT_LIBRARY_DIR})
 set(ROOTTEST_ENV_EXTRA)
 
-set(ROOTTEST_ENVIRONMENT
-    ROOTSYS=${ROOTSYS}
-    PATH=${ROOTTEST_ENV_PATH}:$ENV{PATH}
-    PYTHONPATH=${ROOTTEST_ENV_PYTHONPATH}:$ENV{PYTHONPATH}
-    ${ld_library_path}=${ROOTTEST_ENV_LIBRARYPATH}:$ENV{${ld_library_path}})
-if (gnuinstall)
-  set(ROOTTEST_ENVIRONMENT ${ROOTTEST_ENVIRONMENT} ROOTIGNOREPREFIX=1)
+if(MSVC)
+  set(ROOTTEST_ENVIRONMENT
+      ROOTSYS=${ROOTSYS}
+      PYTHONPATH=${ROOTTEST_ENV_PYTHONPATH})
+else()
+  set(ROOTTEST_ENVIRONMENT
+      ROOTSYS=${ROOTSYS}
+      PATH=${ROOTTEST_ENV_PATH}:$ENV{PATH}
+      PYTHONPATH=${ROOTTEST_ENV_PYTHONPATH}:$ENV{PYTHONPATH}
+      ${ld_library_path}=${ROOTTEST_ENV_LIBRARYPATH}:$ENV{${ld_library_path}})
+  if (gnuinstall)
+    set(ROOTTEST_ENVIRONMENT ${ROOTTEST_ENVIRONMENT} ROOTIGNOREPREFIX=1)
+  endif()
 endif()
 
 # Resolve symbolic links for the ROOTTEST_DIR variable.

--- a/cling/stl/dicts/CMakeLists.txt
+++ b/cling/stl/dicts/CMakeLists.txt
@@ -7,4 +7,4 @@ ROOT_LINKER_LIBRARY(stldictTest TEST MyClass1.cpp MyClass2.cpp MyClass3.cpp
                                 LIBRARIES ${ROOT_LIBRARIES})
 
 ROOT_ADD_TEST(roottest-cling-stl-dicts-build 
-              COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target stldictTest${fast})
+              COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config $<CONFIG> --target stldictTest${fast})

--- a/cmake/modules/RoottestMacros.cmake
+++ b/cmake/modules/RoottestMacros.cmake
@@ -831,7 +831,12 @@ function(ROOTTEST_ADD_TEST testname)
     set(run_serial RUN_SERIAL ${ARG_RUN_SERIAL})
   endif()
 
-  if (NOT MSVC)
+  if(MSVC)
+    set(environment ENVIRONMENT
+                    ROOTSYS=${ROOTSYS}
+                    PYTHONPATH=${ROOTTEST_ENV_PYTHONPATH})
+
+  else()
     string(REPLACE ";" ":" _path "${ROOTTEST_ENV_PATH}")
     string(REPLACE ";" ":" _pythonpath "${ROOTTEST_ENV_PYTHONPATH}")
     string(REPLACE ";" ":" _librarypath "${ROOTTEST_ENV_LIBRARYPATH}")
@@ -1047,7 +1052,12 @@ function(ROOTTEST_ADD_UNITTEST_DIR)
     endforeach()
   endif(ARG_DEPENDS)
 
-  if(NOT MSVC)
+  if(MSVC)
+    set(environment ENVIRONMENT
+                    ROOTSYS=${ROOTSYS}
+                    PYTHONPATH=${ROOTTEST_ENV_PYTHONPATH})
+
+  else()
     string(REPLACE ";" ":" _path "${ROOTTEST_ENV_PATH}")
     string(REPLACE ";" ":" _pythonpath "${ROOTTEST_ENV_PYTHONPATH}")
     string(REPLACE ";" ":" _librarypath "${ROOTTEST_ENV_LIBRARYPATH}")

--- a/root/tree/cloning/CMakeLists.txt
+++ b/root/tree/cloning/CMakeLists.txt
@@ -58,6 +58,9 @@ if(NOT TARGET eventexe)
                   OUTREF references/treeCloneTest.ref)
 
 else()
+   if(MSVC)
+      set(RootExeOptions -e "gSystem->Load(\"${ROOTSYS}/test/Release/libEvent\")")
+   else()
       set(RootExeOptions -e "gSystem->Load(\"../test/libEvent\")")
 
       ROOTTEST_ADD_TEST(treeCloneTest
@@ -65,7 +68,7 @@ else()
                   COMMAND ${ROOT_root_CMD} -b -q -l ${CMAKE_CURRENT_SOURCE_DIR}/run.C -e "gSystem->Load(\"../test/libEvent\")"
                   POSTCMD ${ROOT_root_CMD} -b -q -l ${CMAKE_CURRENT_SOURCE_DIR}/runEvent.C -e "gSystem->Load(\"../test/libEvent\")"
                   OUTREF references/treeCloneTest.ref)
-
+   endif()
 endif()
 
 if(ROOTTEST_DIR)


### PR DESCRIPTION
 - Properly set `PYTHONPATH` for CMake
 - Add missing `--config $<CONFIG>` for `roottest-cling-stl-dicts-build`, preventing to trigger a full rebuild of ROOT