### PR TITLE
[PyROOT][ROOT-10870] Add test for boolean value of exceptions

### DIFF
--- a/python/cpp/PyROOT_advancedtests.py
+++ b/python/cpp/PyROOT_advancedtests.py
@@ -684,6 +684,39 @@ class Cpp10StandardExceptions( MyTestCase ):
       self.assert_( e )
       self.assertEqual( e.what(), "runtime pb!!" )
 
+   def test2ExceptionBoolValue(self):
+      """Test boolean value of exception object"""
+      # ROOT-10870
+
+      ROOT.gInterpreter.Declare("""
+      namespace test2Exception {
+         template <typename T>
+         class Handle;
+
+         class Exception : public std::exception {};
+      }
+
+      template <typename T>
+      class test2Exception::Handle {
+      public:
+         std::shared_ptr<test2Exception::Exception const> returnsNull() const noexcept;
+         std::shared_ptr<test2Exception::Exception const> returnsNotNull() const noexcept;
+      };
+
+      template<class T>
+      inline std::shared_ptr<test2Exception::Exception const>
+      test2Exception::Handle<T>::returnsNull() const noexcept { return std::shared_ptr<test2Exception::Exception>(); }
+
+      template<class T>
+      inline std::shared_ptr<test2Exception::Exception const>
+      test2Exception::Handle<T>::returnsNotNull() const noexcept { return std::shared_ptr<test2Exception::Exception>(new test2Exception::Exception()); }
+      """)
+
+      handle = ROOT.test2Exception.Handle('int')()
+
+      self.assert_(not handle.returnsNull());
+      self.assert_(handle.returnsNotNull);
+
 
 ### Test handing over of pointer variables from containers ===================
 class Cpp11PointerContainers( MyTestCase ):


### PR DESCRIPTION
It tests that the boolean semantics for exception objects are
well defined, as well as the absence of a teardown crash
that was reported in ROOT-10870.

Goes together with https://github.com/root-project/root/pull/6024