### PR TITLE
[ntuple] add rntuple merge test skeleton

### DIFF
--- a/root/io/filemerger/CMakeLists.txt
+++ b/root/io/filemerger/CMakeLists.txt
@@ -10,6 +10,10 @@ ROOTTEST_ADD_TEST(execFileMerger
                   MACRO execFileMerger.C
                   OUTREF references/execFileMerger.ref)
 
+ROOTTEST_ADD_TEST(execRNTupleMerge
+                  MACRO execRNTupleMerge.C
+                  OUTREF references/execRNTupleMerge.ref)
+
 # FIXME: Should be CTEST fixtures
 ROOTTEST_ADD_TEST(datagen-hadd-mfile12
                      COMMAND ${ROOT_hadd_CMD} -f mfile1-2.root mfile1.root mfile2.root

--- a/root/io/filemerger/execRNTupleMerge.C
+++ b/root/io/filemerger/execRNTupleMerge.C
@@ -1,0 +1,3 @@
+int execRNTupleMerge(int n = 2) {
+   return 0; 
+}

--- a/root/io/filemerger/references/execRNTupleMerge.ref
+++ b/root/io/filemerger/references/execRNTupleMerge.ref
@@ -1,0 +1,3 @@
+
+Processing /home/max/projects/rootdev/roottest/root/io/filemerger/execRNTupleMerger.C...
+(int) 0


### PR DESCRIPTION
Add empty unit test intended to test RNTuple merges. We add a new macro `execRNTupleMerge.C` which will create RNTuples on the fly to be merged (following what happens for `TTree`, etc. in `execFileMerger.C`) 

We can add future RNTuple merge tests using the files created as part of execRNTupleMerge (e.g. testing for hadd): 

```cmake 
ROOTTEST_ADD_TEST(hadd-rntuple
                     COMMAND ${ROOT_hadd_CMD} -f merged.root ntuple1.root ntuple2.root
                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                     DEPENDS execRNTupleMerge)
``` 