### PR TITLE
[RF] Test for vectorised PDFs: Add tests and reduce run times

### DIFF
--- a/root/roofitstats/vectorisedPDFs/CMakeLists.txt
+++ b/root/roofitstats/vectorisedPDFs/CMakeLists.txt
@@ -1,12 +1,17 @@
-if(CMAKE_CXX_COMPILER_ID STREQUAL Intel AND DEFINED ENV{VTUNE_AMPLIFIER_2019_DIR})
+if(CMAKE_CXX_COMPILER_ID STREQUAL Intel)
+  if(DEFINED ENV{VTUNE_AMPLIFIER_2019_DIR})
+    set(VTUNE_DIR ENV{VTUNE_AMPLIFIER_2019_DIR})
+  elseif(DEFINED ENV{VTUNE_PROFILER_2020_DIR})
+    set(VTUNE_DIR ENV{VTUNE_PROFILER_2020_DIR})
+  endif()
   # To be able to start/stop the vtune profiler, ittnotify must be available.
-  include_directories("$ENV{VTUNE_AMPLIFIER_2019_DIR}/include/")
-  link_directories("$ENV{VTUNE_AMPLIFIER_2019_DIR}/lib64/")
-  link_libraries(-littnotify)
+  target_include_directories(VectorisedPDFTests PUBLIC "${VTUNE_DIR}/include/")
+  target_link_libraries(VectorisedPDFTests INTERFACE "${VTUNE_DIR}/lib64/libittnotify.a")
 endif()
 
 add_library(VectorisedPDFTests STATIC VectorisedPDFTests.cxx)
 target_link_libraries(VectorisedPDFTests PUBLIC gtest ROOT::Gpad ROOT::RooFitCore ROOT::RooFit)
+
 
 ROOT_ADD_GTEST(testCompatMode testCompatMode.cxx
               LIBRARIES VectorisedPDFTests)

--- a/root/roofitstats/vectorisedPDFs/CMakeLists.txt
+++ b/root/roofitstats/vectorisedPDFs/CMakeLists.txt
@@ -57,8 +57,7 @@ endif()
 ROOT_ADD_GTEST(testChiSquarePdf testChiSquarePdf.cxx
               LIBRARIES VectorisedPDFTests)
 ROOT_ADD_GTEST(testDstD0BG testDstD0BG.cxx
-              LIBRARIES VectorisedPDFTests
-              WILLFAIL)
+              LIBRARIES VectorisedPDFTests)
 ROOT_ADD_GTEST(testLognormal testLognormal.cxx
               LIBRARIES VectorisedPDFTests)
 ROOT_ADD_GTEST(testNovosibirsk testNovosibirsk.cxx

--- a/root/roofitstats/vectorisedPDFs/CMakeLists.txt
+++ b/root/roofitstats/vectorisedPDFs/CMakeLists.txt
@@ -51,3 +51,14 @@ if(ROOT_mathmore_FOUND)
 endif()
 ROOT_ADD_GTEST(testChiSquarePdf testChiSquarePdf.cxx
               LIBRARIES VectorisedPDFTests)
+ROOT_ADD_GTEST(testDstD0BG testDstD0BG.cxx
+              LIBRARIES VectorisedPDFTests
+              WILLFAIL)
+ROOT_ADD_GTEST(testLognormal testLognormal.cxx
+              LIBRARIES VectorisedPDFTests)
+ROOT_ADD_GTEST(testNovosibirsk testNovosibirsk.cxx
+              LIBRARIES VectorisedPDFTests
+              WILLFAIL)
+ROOT_ADD_GTEST(testVoigtian testVoigtian.cxx
+              LIBRARIES VectorisedPDFTests
+              WILLFAIL)

--- a/root/roofitstats/vectorisedPDFs/CMakeLists.txt
+++ b/root/roofitstats/vectorisedPDFs/CMakeLists.txt
@@ -61,8 +61,6 @@ ROOT_ADD_GTEST(testDstD0BG testDstD0BG.cxx
 ROOT_ADD_GTEST(testLognormal testLognormal.cxx
               LIBRARIES VectorisedPDFTests)
 ROOT_ADD_GTEST(testNovosibirsk testNovosibirsk.cxx
-              LIBRARIES VectorisedPDFTests
-              WILLFAIL)
+              LIBRARIES VectorisedPDFTests)
 ROOT_ADD_GTEST(testVoigtian testVoigtian.cxx
-              LIBRARIES VectorisedPDFTests
-              WILLFAIL)
+              LIBRARIES VectorisedPDFTests)

--- a/root/roofitstats/vectorisedPDFs/VectorisedPDFTests.h
+++ b/root/roofitstats/vectorisedPDFs/VectorisedPDFTests.h
@@ -45,7 +45,7 @@ class PDFTest : public ::testing::Test
 
     void kickParameters();
 
-    void compareFixedValues(double& maximalError, bool normalise, bool compareLogs, bool runTimer = true, unsigned int nChunks = 1);
+    void compareFixedValues(double& maximalError, bool normalise, bool compareLogs, bool runTimer = false, unsigned int nChunks = 1);
 
     void checkParameters();
 

--- a/root/roofitstats/vectorisedPDFs/testAddPdf.cxx
+++ b/root/roofitstats/vectorisedPDFs/testAddPdf.cxx
@@ -25,7 +25,7 @@ class TestGaussPlusPoisson : public PDFTest
 {
   protected:
     TestGaussPlusPoisson() :
-      PDFTest("Gauss + Poisson", 200000)
+      PDFTest("Gauss + Poisson", 100000)
     {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
       auto x = new RooRealVar("x", "x", -1.5, 40.5);
@@ -58,7 +58,7 @@ class TestGaussPlusPoisson : public PDFTest
 
       // Gauss is slightly less accurate
       _toleranceCompareBatches = 2.E-14;
-      _toleranceParameter = 3.E-6;
+      _toleranceParameter = 5.E-5;
       _toleranceCorrelation = 5.E-4;
     }
 };
@@ -67,8 +67,8 @@ COMPARE_FIXED_VALUES_UNNORM(TestGaussPlusPoisson, CompareFixedValuesUnnorm)
 COMPARE_FIXED_VALUES_NORM(TestGaussPlusPoisson, CompareFixedValuesNorm)
 COMPARE_FIXED_VALUES_NORM_LOG(TestGaussPlusPoisson, CompareFixedValuesNormLog)
 
-FIT_TEST_SCALAR(TestGaussPlusPoisson, Scalar)
-FIT_TEST_BATCH(TestGaussPlusPoisson, Batch)
+FIT_TEST_SCALAR(TestGaussPlusPoisson, DISABLED_Scalar) // Save time
+FIT_TEST_BATCH(TestGaussPlusPoisson, DISABLED_Batch)   // Save time
 FIT_TEST_BATCH_VS_SCALAR(TestGaussPlusPoisson, CompareBatchScalar)
 
 
@@ -76,7 +76,7 @@ class TestGaussPlusGaussPlusExp : public PDFTest
 {
   protected:
     TestGaussPlusGaussPlusExp() :
-      PDFTest("Gauss + Gauss + Exp")
+      PDFTest("Gauss + Gauss + Exp", 100000)
     {
       auto x = new RooRealVar("x", "x", 0., 100.);
 
@@ -128,7 +128,7 @@ COMPARE_FIXED_VALUES_NORM(TestGaussPlusGaussPlusExp, CompareFixedValuesNorm)
 COMPARE_FIXED_VALUES_NORM_LOG(TestGaussPlusGaussPlusExp, CompareFixedValuesNormLog)
 
 
-FIT_TEST_SCALAR(TestGaussPlusGaussPlusExp, DISABLED_Scalar)
-FIT_TEST_BATCH(TestGaussPlusGaussPlusExp, DISABLED_Batch)
+FIT_TEST_SCALAR(TestGaussPlusGaussPlusExp, DISABLED_Scalar) // Save time
+FIT_TEST_BATCH(TestGaussPlusGaussPlusExp, DISABLED_Batch)   // Save time
 FIT_TEST_BATCH_VS_SCALAR(TestGaussPlusGaussPlusExp, CompareBatchScalar)
 

--- a/root/roofitstats/vectorisedPDFs/testArgusBG.cxx
+++ b/root/roofitstats/vectorisedPDFs/testArgusBG.cxx
@@ -21,7 +21,7 @@ class TestArgus : public PDFTest
 {
   protected:
     TestArgus() :
-      PDFTest("Argus", 300000)
+      PDFTest("Argus", 100000)
   { 
       auto m = new RooRealVar("m", "m", 300.0, 1.0, 800.0);
       auto m0 = new RooRealVar("m0", "m0", 1100.0, 800.0, 1400.0);

--- a/root/roofitstats/vectorisedPDFs/testBernstein.cxx
+++ b/root/roofitstats/vectorisedPDFs/testBernstein.cxx
@@ -21,7 +21,7 @@ class TestBernstein2 : public PDFTest
 {
   protected:
     TestBernstein2() :
-      PDFTest("Bernstein2", 300000)
+      PDFTest("Bernstein2", 100000)
   {
         auto x = new RooRealVar("x", "x", -10, 10);
         auto a1 = new RooRealVar("a1", "a1", 1, 0.8, 1.2);
@@ -54,7 +54,7 @@ class TestBernstein5 : public PDFTest
 {
   protected:
     TestBernstein5() :
-      PDFTest("Bernstein5", 300000)
+      PDFTest("Bernstein5", 100000)
   {
         auto x = new RooRealVar("x", "x", -100, 50);
         auto a1 = new RooRealVar("a1", "a1", 0.8, 0.6, 1.2);

--- a/root/roofitstats/vectorisedPDFs/testBifurGauss.cxx
+++ b/root/roofitstats/vectorisedPDFs/testBifurGauss.cxx
@@ -22,7 +22,7 @@ class TestBifurGauss : public PDFTest
 {
   protected:
     TestBifurGauss() :
-      PDFTest("BifurGauss", 300000)
+      PDFTest("BifurGauss", 100000)
   { 
     auto x = new RooRealVar("x", "x", 300.0, 100.0, 800.0);
     auto mean = new RooRealVar("mean", "mean", 350.0, 250.0, 500.0);
@@ -41,6 +41,8 @@ class TestBifurGauss : public PDFTest
     for (auto par : {mean, sigmaL, sigmaR}) {
       _parameters.addOwned(*par);
     }
+
+    _toleranceParameter = 8.E-6;
   }
 };
 

--- a/root/roofitstats/vectorisedPDFs/testBreitWigner.cxx
+++ b/root/roofitstats/vectorisedPDFs/testBreitWigner.cxx
@@ -34,6 +34,7 @@ class TestBreitWigner : public PDFTest
 
 //      _variablesToPlot.add(*x);
 
+
       for (auto par : {mean, width}) {
         _parameters.addOwned(*par);
       }

--- a/root/roofitstats/vectorisedPDFs/testBreitWigner.cxx
+++ b/root/roofitstats/vectorisedPDFs/testBreitWigner.cxx
@@ -21,11 +21,11 @@ class TestBreitWigner : public PDFTest
 {
   protected:
     TestBreitWigner() :
-      PDFTest("BreitWigner", 300000)
+      PDFTest("BreitWigner", 100000)
   {
         auto x = new RooRealVar("x", "x", -10, 10);
         auto mean = new RooRealVar("mean", "mean", 1, -7, 7);
-        auto width = new RooRealVar("a2", "a2", 1, 0.5, 2.5);
+        auto width = new RooRealVar("a2", "a2", 1.8, 0.5, 2.5);
 
         _pdf = std::make_unique<RooBreitWigner>("breitWigner", "breitWigner PDF", *x, *mean, *width);
 
@@ -37,7 +37,9 @@ class TestBreitWigner : public PDFTest
       for (auto par : {mean, width}) {
         _parameters.addOwned(*par);
       }
-      _toleranceCompareLogs = 4.1774312644789e-13;
+
+      _toleranceCompareLogs = 5.e-13;
+      _toleranceCorrelation = 0.007;
   }
 };
 

--- a/root/roofitstats/vectorisedPDFs/testBreitWigner.cxx
+++ b/root/roofitstats/vectorisedPDFs/testBreitWigner.cxx
@@ -34,7 +34,6 @@ class TestBreitWigner : public PDFTest
 
 //      _variablesToPlot.add(*x);
 
-
       for (auto par : {mean, width}) {
         _parameters.addOwned(*par);
       }

--- a/root/roofitstats/vectorisedPDFs/testBukin.cxx
+++ b/root/roofitstats/vectorisedPDFs/testBukin.cxx
@@ -22,7 +22,7 @@ class TestBukin : public PDFTest
 {
   protected:
     TestBukin() :
-      PDFTest("Bukin", 300000)
+      PDFTest("Bukin", 100000)
   { 
       auto x = new RooRealVar("x", "x", 0.6, -15., 10.);
       auto Xp = new RooRealVar("Xp", "Xp", 0.5, -3., 5.);

--- a/root/roofitstats/vectorisedPDFs/testCBShape.cxx
+++ b/root/roofitstats/vectorisedPDFs/testCBShape.cxx
@@ -21,14 +21,14 @@ class TestCBShape : public PDFTest
 {
   protected:
     TestCBShape() :
-      PDFTest("CBShape", 300000)
+      PDFTest("CBShape", 100000)
   {
         auto m = new RooRealVar("m", "m", -10, 10);
         auto m0 = new RooRealVar("m0", "m0", 1, -7, 7);
         auto sigma = new RooRealVar("sigma", "sigma", 1, 0.5, 2.5);
         auto alpha = new RooRealVar("alpha", "alpha", 1, -3, 3);
         auto n = new RooRealVar("n", "n", 1, 0.5, 2.5);
-        
+
         _pdf = std::make_unique<RooCBShape>("CBShape", "CBShape PDF", *m, *m0, *sigma, *alpha, *n);
 
 
@@ -41,6 +41,7 @@ class TestCBShape : public PDFTest
       }
 
       // For i686:
+      _toleranceParameter = 1.E-5;
       _toleranceCompareBatches = 1.5E-14;
       _toleranceCorrelation = 1.5E-3;
   }

--- a/root/roofitstats/vectorisedPDFs/testChebychev.cxx
+++ b/root/roofitstats/vectorisedPDFs/testChebychev.cxx
@@ -22,7 +22,7 @@ class TestChebychev2 : public PDFTest
 {
   protected:
     TestChebychev2() :
-      PDFTest("Chebychev2", 300000)
+      PDFTest("Chebychev2", 100000)
   {
         auto x = new RooRealVar("x", "x", -10, 10);
         auto a1 = new RooRealVar("a1", "a1", 0.3, -0.5, 0.5);
@@ -52,7 +52,7 @@ class TestChebychev5 : public PDFTest
 {
   protected:
     TestChebychev5() :
-      PDFTest("Chebychev5", 300000)
+      PDFTest("Chebychev5", 50000)
   {
         auto x = new RooRealVar("x", "x", -10, 10);
         auto a1 = new RooRealVar("a1", "a1", 0.15, -0.3, 0.3);
@@ -60,6 +60,7 @@ class TestChebychev5 : public PDFTest
         auto a3 = new RooRealVar("a3", "a3", 0.20, 0.10, 0.30);
         auto a4 = new RooRealVar("a4", "a4", 0.35, 0.3, 0.5);
         auto a5 = new RooRealVar("a5", "a5", -0.07, -0.2, 0.2);
+        a2->setConstant(true);
         a3->setConstant(true);
 
         _pdf = std::make_unique<RooChebychev>("chebychev5", "chebychev PDF 5 coefficients", *x, RooArgSet(*a1, *a2, *a3, *a4, *a5));

--- a/root/roofitstats/vectorisedPDFs/testChiSquarePdf.cxx
+++ b/root/roofitstats/vectorisedPDFs/testChiSquarePdf.cxx
@@ -21,7 +21,7 @@ class TestChiSquarePdfinX: public PDFTest
 {
   protected:
     TestChiSquarePdfinX() :
-      PDFTest("ChiSquarePdf", 300000)
+      PDFTest("ChiSquarePdf", 100000)
     {
       auto x = new RooRealVar("x", "x", 0.1, 100);
       auto ndof = new RooRealVar("ndof", "ndof of chiSquarePdf", 2, 1, 5);
@@ -53,7 +53,7 @@ class TestChiSquarePdfinNdof: public PDFTest
 {
   protected:
     TestChiSquarePdfinNdof() :
-      PDFTest("ChiSquarePdf", 300000)
+      PDFTest("ChiSquarePdf", 100000)
     {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
       auto x = new RooRealVar("x", "x", 0.01, 20);
@@ -87,7 +87,7 @@ class TestChiSquarePdfinXandNdof: public PDFTest
 {
   protected:
     TestChiSquarePdfinXandNdof() :
-      PDFTest("ChiSquarePdf", 300000)
+      PDFTest("ChiSquarePdf", 100000)
     {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
       auto x = new RooRealVar("x", "x", 0.1, 50);

--- a/root/roofitstats/vectorisedPDFs/testCompatMode.cxx
+++ b/root/roofitstats/vectorisedPDFs/testCompatMode.cxx
@@ -217,12 +217,12 @@ class TestNonVecGaussWeighted : public PDFTestWeightedData
 {
   protected:
     TestNonVecGaussWeighted() :
-      PDFTestWeightedData("GaussNoBatchesWithWeights", 300000)
+      PDFTestWeightedData("GaussNoBatchesWithWeights", 50000)
   {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
       auto x = new RooRealVar("x", "x", -10, 10);
       auto mean = new RooRealVar("mean", "mean of gaussian", 1, -10, 10);
-      auto sigma = new RooRealVar("sigma", "width of gaussian", 1, 0.1, 10);
+      auto sigma = new RooRealVar("sigma", "width of gaussian", 2.3, 0.1, 10);
 
       // Build gaussian p.d.f in terms of x,mean and sigma
       _pdf = std::make_unique<RooNonVecGaussian>("gauss", "gaussian PDF", *x, *mean, *sigma);
@@ -242,8 +242,8 @@ COMPARE_FIXED_VALUES_UNNORM(TestNonVecGaussWeighted, CompareFixedUnnorm)
 COMPARE_FIXED_VALUES_NORM(TestNonVecGaussWeighted, CompareFixedNorm)
 COMPARE_FIXED_VALUES_NORM_LOG(TestNonVecGaussWeighted, CompareFixedNormLog)
 
-FIT_TEST_SCALAR(TestNonVecGaussWeighted, RunScalar)
-FIT_TEST_BATCH(TestNonVecGaussWeighted, RunBatch)
+FIT_TEST_SCALAR(TestNonVecGaussWeighted, DISABLED_RunScalar) // Would need SumW2 error matrix correction, but no done in macro
+FIT_TEST_BATCH(TestNonVecGaussWeighted, DISABLED_RunBatch)   // As above
 FIT_TEST_BATCH_VS_SCALAR(TestNonVecGaussWeighted, CompareBatchScalar)
 
 

--- a/root/roofitstats/vectorisedPDFs/testDstD0BG.cxx
+++ b/root/roofitstats/vectorisedPDFs/testDstD0BG.cxx
@@ -15,44 +15,45 @@
  *****************************************************************************/
 
 #include "VectorisedPDFTests.h"
-
-#include "RooGaussian.h"
-#include "RooAddPdf.h"
-#include "RooExponential.h"
+#include "RooDstD0BG.h"
 
 
-class TestExponential : public PDFTest
+class TestDstD0BG : public PDFTest
 {
   protected:
-    TestExponential() :
-      PDFTest("Exp(x, c1)", 300000)
-  {
-      //Beyond ~19, the VDT polynomials break down when c1 is very negative
-      auto x = new RooRealVar("x", "x", 0.001, 18.);
-      auto c1 = new RooRealVar("c1", "c1", -0.2, -50., -0.001);
-      _pdf = std::make_unique<RooExponential>("expo1", "expo1", *x, *c1);
-
-      for (auto var : {x}) {
+    TestDstD0BG() :
+      PDFTest("DstD0BG", 300000)
+  { 
+      auto m = new RooRealVar("m", "m", 750, 500, 1000);
+      auto m0 = new RooRealVar("m0", "m0", 350, 100, 450);
+      auto C = new RooRealVar("C", "C", 500, 300, 800);
+      auto A = new RooRealVar("A", "A", 1, 0.5, 4);
+      auto B = new RooRealVar("B", "B", 1, 0.5, 2);
+      
+      _pdf = std::make_unique<RooDstD0BG>("DstD0BG", "DstD0BG", *m, *m0, *C, *A, *B);
+      m0->setConstant(true);
+      //C->setConstant(true);
+      
+      for (auto var : {m}) {
         _variables.addOwned(*var);
       }
 
-//      for (auto var : {x}) {
-//        _variablesToPlot.add(*var);
-//      }
-
-      for (auto par : {c1}) {
-        _parameters.addOwned(*par);
+      for (auto var : {m}) {
+        _variablesToPlot.add(*var);
       }
 
-      _toleranceCompareLogs = 3E-13;
-      // For i686, this needs to be a bit less strict:
-      _toleranceCompareBatches = 2.E-14;
+      for (auto par : {C, A, B}) {
+        _parameters.addOwned(*par);
+      }
+    _printLevel = 1;
+    //_toleranceParameter = 3e-5;
+
   }
 };
 
-COMPARE_FIXED_VALUES_UNNORM(TestExponential, CompareFixedValuesUnnorm)
-COMPARE_FIXED_VALUES_NORM(TestExponential, CompareFixedValuesNorm)
-COMPARE_FIXED_VALUES_NORM_LOG(TestExponential, CompareFixedValuesNormLog)
-FIT_TEST_SCALAR(TestExponential, RunScalar)
-FIT_TEST_BATCH(TestExponential, RunBatch)
-FIT_TEST_BATCH_VS_SCALAR(TestExponential, CompareBatchScalar)
+COMPARE_FIXED_VALUES_UNNORM(TestDstD0BG, CompareFixedValuesUnnorm)
+COMPARE_FIXED_VALUES_NORM(TestDstD0BG, CompareFixedValuesNorm)
+COMPARE_FIXED_VALUES_NORM_LOG(TestDstD0BG, CompareFixedNormLog)
+FIT_TEST_SCALAR(TestDstD0BG, RunScalar)
+FIT_TEST_BATCH(TestDstD0BG, RunBatch)
+FIT_TEST_BATCH_VS_SCALAR(TestDstD0BG, CompareBatchScalar)

--- a/root/roofitstats/vectorisedPDFs/testDstD0BG.cxx
+++ b/root/roofitstats/vectorisedPDFs/testDstD0BG.cxx
@@ -22,31 +22,26 @@ class TestDstD0BG : public PDFTest
 {
   protected:
     TestDstD0BG() :
-      PDFTest("DstD0BG", 300000)
+      PDFTest("DstD0BG", 100000)
   { 
-      auto m = new RooRealVar("m", "m", 750, 500, 1000);
-      auto m0 = new RooRealVar("m0", "m0", 350, 100, 450);
-      auto C = new RooRealVar("C", "C", 500, 300, 800);
-      auto A = new RooRealVar("A", "A", 1, 0.5, 4);
-      auto B = new RooRealVar("B", "B", 1, 0.5, 2);
-      
+      auto m = new RooRealVar("m", "m", 2.0, 1.61, 3);
+      auto m0 = new RooRealVar("m0", "m0", 1.6);
+      auto C = new RooRealVar("C", "C", 1, 0.1, 2);
+      auto A = new RooRealVar("A", "A", -1.2);
+      auto B = new RooRealVar("B", "B", 0.1);
+
       _pdf = std::make_unique<RooDstD0BG>("DstD0BG", "DstD0BG", *m, *m0, *C, *A, *B);
-      m0->setConstant(true);
-      //C->setConstant(true);
-      
+
       for (auto var : {m}) {
         _variables.addOwned(*var);
       }
 
-      for (auto var : {m}) {
-        _variablesToPlot.add(*var);
-      }
-
-      for (auto par : {C, A, B}) {
+      for (auto par : {C}) {
         _parameters.addOwned(*par);
       }
-    _printLevel = 1;
-    //_toleranceParameter = 3e-5;
+
+    _toleranceCompareBatches = 3.E-14;
+    _toleranceCompareLogs    = 3.E-10;
 
   }
 };

--- a/root/roofitstats/vectorisedPDFs/testExponential.cxx
+++ b/root/roofitstats/vectorisedPDFs/testExponential.cxx
@@ -25,7 +25,7 @@ class TestExponential : public PDFTest
 {
   protected:
     TestExponential() :
-      PDFTest("Exp(x, c1)", 300000)
+      PDFTest("Exp(x, c1)", 100000)
   {
       //Beyond ~19, the VDT polynomials break down when c1 is very negative
       auto x = new RooRealVar("x", "x", 0.001, 18.);

--- a/root/roofitstats/vectorisedPDFs/testGamma.cxx
+++ b/root/roofitstats/vectorisedPDFs/testGamma.cxx
@@ -22,7 +22,7 @@ class TestGamma : public PDFTest
 {
   protected:
     TestGamma() :
-      PDFTest("Gamma", 300000)
+      PDFTest("Gamma", 100000)
   {
     auto x = new RooRealVar("x", "x", 5, 4, 10);
     auto gamma = new RooRealVar("gamma", "N+1", 6, 4, 8);

--- a/root/roofitstats/vectorisedPDFs/testGauss.cxx
+++ b/root/roofitstats/vectorisedPDFs/testGauss.cxx
@@ -62,7 +62,7 @@ class TestGaussWeighted : public PDFTestWeightedData
 {
   protected:
     TestGaussWeighted() :
-      PDFTestWeightedData("GaussWithWeights", 300000)
+      PDFTestWeightedData("GaussWithWeights", 100000)
   {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
       auto x = new RooRealVar("x", "x", -10, 10);
@@ -81,7 +81,7 @@ class TestGaussWeighted : public PDFTestWeightedData
   }
 };
 
-FIT_TEST_BATCH(TestGaussWeighted, RunBatch)
+FIT_TEST_BATCH(TestGaussWeighted, DISABLED_RunBatch) // Would need SumW2 or asymptotic error correction, but that's not in test macro.
 FIT_TEST_BATCH_VS_SCALAR(TestGaussWeighted, CompareBatchScalar)
 
 

--- a/root/roofitstats/vectorisedPDFs/testGauss.cxx
+++ b/root/roofitstats/vectorisedPDFs/testGauss.cxx
@@ -23,7 +23,7 @@ class TestGauss : public PDFTest
 {
   protected:
     TestGauss() :
-      PDFTest("Gauss", 200000)
+      PDFTest("Gauss", 300000)
   {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
         auto x = new RooRealVar("x", "x", -10, 10);
@@ -90,7 +90,7 @@ class TestGaussInMeanAndX : public PDFTest
 {
   protected:
     TestGaussInMeanAndX() :
-      PDFTest("Gauss(x, mean)")
+      PDFTest("Gauss(x, mean)", 300000)
   {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
       auto x = new RooRealVar("x", "x", -10, 10);
@@ -124,7 +124,7 @@ class TestGaussWithFormulaParameters : public PDFTest
 {
   protected:
     TestGaussWithFormulaParameters() :
-      PDFTest("Gauss(x, mean)", 50000)
+      PDFTest("Gauss(x, mean)", 300000)
   {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
       auto x = new RooRealVar("x", "x", 0, 30);

--- a/root/roofitstats/vectorisedPDFs/testGauss.cxx
+++ b/root/roofitstats/vectorisedPDFs/testGauss.cxx
@@ -23,7 +23,7 @@ class TestGauss : public PDFTest
 {
   protected:
     TestGauss() :
-      PDFTest("Gauss", 300000)
+      PDFTest("Gauss", 200000)
   {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
         auto x = new RooRealVar("x", "x", -10, 10);
@@ -90,7 +90,7 @@ class TestGaussInMeanAndX : public PDFTest
 {
   protected:
     TestGaussInMeanAndX() :
-      PDFTest("Gauss(x, mean)", 300000)
+      PDFTest("Gauss(x, mean)")
   {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
       auto x = new RooRealVar("x", "x", -10, 10);
@@ -124,7 +124,7 @@ class TestGaussWithFormulaParameters : public PDFTest
 {
   protected:
     TestGaussWithFormulaParameters() :
-      PDFTest("Gauss(x, mean)", 300000)
+      PDFTest("Gauss(x, mean)", 50000)
   {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
       auto x = new RooRealVar("x", "x", 0, 30);

--- a/root/roofitstats/vectorisedPDFs/testLandau.cxx
+++ b/root/roofitstats/vectorisedPDFs/testLandau.cxx
@@ -21,7 +21,7 @@ class TestLandauEvil: public PDFTest
 {
   protected:
     TestLandauEvil() :
-      PDFTest("Landau_evil", 300000)
+      PDFTest("Landau_evil", 100000)
     {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
         auto x = new RooRealVar("x", "x", -250, 3000);
@@ -38,7 +38,8 @@ class TestLandauEvil: public PDFTest
       for (auto par : {mean, sigma}) {
         _parameters.addOwned(*par);
       }
-     
+
+      _toleranceParameter = 8.E-6;
     }
 };
 
@@ -54,7 +55,7 @@ class TestLandau: public PDFTest
 {
   protected:
     TestLandau() :
-      PDFTest("Landau_convenient", 300000)
+      PDFTest("Landau_convenient", 100000)
     {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
         auto x = new RooRealVar("x", "x", -3, 40);
@@ -72,7 +73,7 @@ class TestLandau: public PDFTest
         _parameters.addOwned(*par);
       }
 
-     
+      _toleranceParameter = 8.E-6;
     }
 };
 

--- a/root/roofitstats/vectorisedPDFs/testLegendre.cxx
+++ b/root/roofitstats/vectorisedPDFs/testLegendre.cxx
@@ -23,7 +23,7 @@ class TestLegendre : public PDFTest
 {
   protected:
     TestLegendre() :
-      PDFTest("Legendre", 300000)
+      PDFTest("Legendre", 100000)
   {
     auto x = new RooRealVar("x", "x", 0.5, 0.1, 1.0);
     auto coef = new RooRealVar("coef", "coef", 0.5, 0.3, 1.0);

--- a/root/roofitstats/vectorisedPDFs/testLognormal.cxx
+++ b/root/roofitstats/vectorisedPDFs/testLognormal.cxx
@@ -1,0 +1,87 @@
+// Author: Stephan Hageboeck, CERN  26 Apr 2019
+
+/*****************************************************************************
+ * RooFit
+ * Authors:                                                                  *
+ *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
+ *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
+ *                                                                           *
+ * Copyright (c) 2000-2019, Regents of the University of California          *
+ *                          and Stanford University. All rights reserved.    *
+ *                                                                           *
+ * Redistribution and use in source and binary forms,                        *
+ * with or without modification, are permitted according to the terms        *
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
+ *****************************************************************************/
+
+#include "VectorisedPDFTests.h"
+
+#include "RooLognormal.h"
+
+class TestLognormal : public PDFTest
+{
+  protected:
+    TestLognormal() :
+      PDFTest("Lognormal", 300000)
+  {
+        auto x = new RooRealVar("x", "x", 1, 0.1, 10);
+        auto m0 = new RooRealVar("m0", "m0", 1, 0.1, 10);
+        auto k = new RooRealVar("k", "k", 0.5, 0.1, 0.9);
+
+        _pdf = std::make_unique<RooLognormal>("Lognormal", "Lognormal PDF", *x, *m0, *k);
+
+
+      _variables.addOwned(*x);
+
+      //_variablesToPlot.add(*x);
+
+      for (auto par : {m0, k}) {
+        _parameters.addOwned(*par);
+      }
+
+       //Standard of 1.E-14 is too strong.
+      _toleranceCompareBatches = 6.E-14;
+      _toleranceParameter = 2e-6;
+  }
+};
+
+COMPARE_FIXED_VALUES_UNNORM(TestLognormal, CompareFixedUnnorm)
+COMPARE_FIXED_VALUES_NORM(TestLognormal, CompareFixedNorm)
+COMPARE_FIXED_VALUES_NORM_LOG(TestLognormal, CompareFixedNormLog)
+FIT_TEST_SCALAR(TestLognormal, RunScalar)
+FIT_TEST_BATCH(TestLognormal, RunBatch)
+FIT_TEST_BATCH_VS_SCALAR(TestLognormal, CompareBatchScalar)
+
+class TestLognormalInMeanAndX : public PDFTest
+{
+  protected:
+    TestLognormalInMeanAndX() :
+      PDFTest("Lognormal(x, mean)", 300000)
+  {
+        auto x = new RooRealVar("x", "x", 1, 0.1, 10);
+        auto m0 = new RooRealVar("m0", "m0", 1, 0.1, 10);
+        auto k = new RooRealVar("k", "k", 2, 1.1, 10);
+
+        _pdf = std::make_unique<RooLognormal>("Lognormal", "Lognormal PDF", *x, *m0, *k);
+
+
+      for (auto var : {x, m0}) {
+        _variables.addOwned(*var);
+      }
+      //_variablesToPlot.add(*x);
+
+      for (auto par : {k}) {
+        _parameters.addOwned(*par);
+      }
+
+      // Standard of 1.E-14 is slightly too strong.
+      _toleranceCompareBatches = 2.E-14;
+  }
+};
+
+COMPARE_FIXED_VALUES_UNNORM(TestLognormalInMeanAndX, CompareFixedUnnorm)
+COMPARE_FIXED_VALUES_NORM(TestLognormalInMeanAndX, CompareFixedNorm)
+COMPARE_FIXED_VALUES_NORM_LOG(TestLognormalInMeanAndX, CompareFixedNormLog)
+FIT_TEST_SCALAR(TestLognormalInMeanAndX, RunScalar)
+FIT_TEST_BATCH(TestLognormalInMeanAndX, RunBatch)
+FIT_TEST_BATCH_VS_SCALAR(TestLognormalInMeanAndX, CompareBatchScalar)

--- a/root/roofitstats/vectorisedPDFs/testLognormal.cxx
+++ b/root/roofitstats/vectorisedPDFs/testLognormal.cxx
@@ -22,18 +22,16 @@ class TestLognormal : public PDFTest
 {
   protected:
     TestLognormal() :
-      PDFTest("Lognormal", 300000)
+      PDFTest("Lognormal", 100000)
   {
         auto x = new RooRealVar("x", "x", 1, 0.1, 10);
-        auto m0 = new RooRealVar("m0", "m0", 1, 0.1, 10);
-        auto k = new RooRealVar("k", "k", 0.5, 0.1, 0.9);
+        auto m0 = new RooRealVar("m0", "m0", 5, 0.1, 10);
+        auto k = new RooRealVar("k", "k", 0.6, 0.1, 0.9);
 
         _pdf = std::make_unique<RooLognormal>("Lognormal", "Lognormal PDF", *x, *m0, *k);
 
 
       _variables.addOwned(*x);
-
-      //_variablesToPlot.add(*x);
 
       for (auto par : {m0, k}) {
         _parameters.addOwned(*par);
@@ -56,7 +54,7 @@ class TestLognormalInMeanAndX : public PDFTest
 {
   protected:
     TestLognormalInMeanAndX() :
-      PDFTest("Lognormal(x, mean)", 300000)
+      PDFTest("Lognormal(x, mean)", 100000)
   {
         auto x = new RooRealVar("x", "x", 1, 0.1, 10);
         auto m0 = new RooRealVar("m0", "m0", 1, 0.1, 10);

--- a/root/roofitstats/vectorisedPDFs/testNovosibirsk.cxx
+++ b/root/roofitstats/vectorisedPDFs/testNovosibirsk.cxx
@@ -15,44 +15,41 @@
  *****************************************************************************/
 
 #include "VectorisedPDFTests.h"
-
-#include "RooGaussian.h"
-#include "RooAddPdf.h"
-#include "RooExponential.h"
+#include "RooNovosibirsk.h"
 
 
-class TestExponential : public PDFTest
+class TestNovosibirsk : public PDFTest
 {
   protected:
-    TestExponential() :
-      PDFTest("Exp(x, c1)", 300000)
-  {
-      //Beyond ~19, the VDT polynomials break down when c1 is very negative
-      auto x = new RooRealVar("x", "x", 0.001, 18.);
-      auto c1 = new RooRealVar("c1", "c1", -0.2, -50., -0.001);
-      _pdf = std::make_unique<RooExponential>("expo1", "expo1", *x, *c1);
-
+    TestNovosibirsk() :
+      PDFTest("Novosibirsk", 300000)
+  { 
+      auto x = new RooRealVar("x", "x", 0, -5, 2);
+      auto peak = new RooRealVar("peak", "peak", 0.5, 0, 1);
+      auto width = new RooRealVar("width", "width", 3, 2.5, 3.5);
+      auto tail = new RooRealVar("tail", "tail", 0.8, 0.5, 1.1);
+      
+      _pdf = std::make_unique<RooNovosibirsk>("Novosibirsk", "Novosibirsk", *x, *peak, *width, *tail);
+      
       for (auto var : {x}) {
         _variables.addOwned(*var);
       }
 
-//      for (auto var : {x}) {
-//        _variablesToPlot.add(*var);
-//      }
+      //for (auto var : {x}) {
+        //_variablesToPlot.add(*var);
+      //}
 
-      for (auto par : {c1}) {
+      for (auto par : { peak, width, tail}) {
         _parameters.addOwned(*par);
       }
-
-      _toleranceCompareLogs = 3E-13;
-      // For i686, this needs to be a bit less strict:
-      _toleranceCompareBatches = 2.E-14;
+      
+      _toleranceParameter = 1e-4;
   }
 };
 
-COMPARE_FIXED_VALUES_UNNORM(TestExponential, CompareFixedValuesUnnorm)
-COMPARE_FIXED_VALUES_NORM(TestExponential, CompareFixedValuesNorm)
-COMPARE_FIXED_VALUES_NORM_LOG(TestExponential, CompareFixedValuesNormLog)
-FIT_TEST_SCALAR(TestExponential, RunScalar)
-FIT_TEST_BATCH(TestExponential, RunBatch)
-FIT_TEST_BATCH_VS_SCALAR(TestExponential, CompareBatchScalar)
+COMPARE_FIXED_VALUES_UNNORM(TestNovosibirsk, CompareFixedValuesUnnorm)
+COMPARE_FIXED_VALUES_NORM(TestNovosibirsk, CompareFixedValuesNorm)
+COMPARE_FIXED_VALUES_NORM_LOG(TestNovosibirsk, CompareFixedNormLog)
+FIT_TEST_SCALAR(TestNovosibirsk, RunScalar)
+FIT_TEST_BATCH(TestNovosibirsk, RunBatch)
+FIT_TEST_BATCH_VS_SCALAR(TestNovosibirsk, CompareBatchScalar)

--- a/root/roofitstats/vectorisedPDFs/testNovosibirsk.cxx
+++ b/root/roofitstats/vectorisedPDFs/testNovosibirsk.cxx
@@ -23,26 +23,26 @@ class TestNovosibirsk : public PDFTest
   protected:
     TestNovosibirsk() :
       PDFTest("Novosibirsk", 100000)
-  { 
-      auto x = new RooRealVar("x", "x", 0, -5, 2);
+  {
+      auto x = new RooRealVar("x", "x", 0, -5, 1.1);
       auto peak = new RooRealVar("peak", "peak", 0.5, 0, 1);
-      auto width = new RooRealVar("width", "width", 3, 2.5, 3.5);
-      auto tail = new RooRealVar("tail", "tail", 0.8, 0.5, 1.1);
-      
+      auto width = new RooRealVar("width", "width", 1.1, 0.5, 3.);
+      auto tail = new RooRealVar("tail", "tail", 1.0, 0.5, 1.1);
+
       _pdf = std::make_unique<RooNovosibirsk>("Novosibirsk", "Novosibirsk", *x, *peak, *width, *tail);
-      
+
       for (auto var : {x}) {
         _variables.addOwned(*var);
       }
 
-      //for (auto var : {x}) {
-        //_variablesToPlot.add(*var);
-      //}
+//      for (auto var : {x}) {
+//        _variablesToPlot.add(*var);
+//      }
 
       for (auto par : { peak, width, tail}) {
         _parameters.addOwned(*par);
       }
-      
+
       _toleranceParameter = 1e-4;
   }
 };

--- a/root/roofitstats/vectorisedPDFs/testNovosibirsk.cxx
+++ b/root/roofitstats/vectorisedPDFs/testNovosibirsk.cxx
@@ -22,7 +22,7 @@ class TestNovosibirsk : public PDFTest
 {
   protected:
     TestNovosibirsk() :
-      PDFTest("Novosibirsk", 300000)
+      PDFTest("Novosibirsk", 100000)
   { 
       auto x = new RooRealVar("x", "x", 0, -5, 2);
       auto peak = new RooRealVar("peak", "peak", 0.5, 0, 1);

--- a/root/roofitstats/vectorisedPDFs/testPoisson.cxx
+++ b/root/roofitstats/vectorisedPDFs/testPoisson.cxx
@@ -69,7 +69,7 @@ class TestPoissonOddMeanNoRounding : public PDFTest
 {
   protected:
     TestPoissonOddMeanNoRounding() :
-      PDFTest("PoissonOddMeanNoRounding", 1000)
+      PDFTest("PoissonOddMeanNoRounding", 300000)
   {
       auto x = new RooRealVar("x", "x", 0., 100);
       auto mean = new RooRealVar("mean", "Mean of Poisson", 7.8529298854862928, 0., 10);

--- a/root/roofitstats/vectorisedPDFs/testPoisson.cxx
+++ b/root/roofitstats/vectorisedPDFs/testPoisson.cxx
@@ -69,7 +69,7 @@ class TestPoissonOddMeanNoRounding : public PDFTest
 {
   protected:
     TestPoissonOddMeanNoRounding() :
-      PDFTest("PoissonOddMeanNoRounding", 300000)
+      PDFTest("PoissonOddMeanNoRounding", 1000)
   {
       auto x = new RooRealVar("x", "x", 0., 100);
       auto mean = new RooRealVar("mean", "Mean of Poisson", 7.8529298854862928, 0., 10);

--- a/root/roofitstats/vectorisedPDFs/testPolynomial.cxx
+++ b/root/roofitstats/vectorisedPDFs/testPolynomial.cxx
@@ -21,7 +21,7 @@ class TestPolynomial2 : public PDFTest
 {
   protected:
     TestPolynomial2() :
-      PDFTest("Polynomial2", 300000)
+      PDFTest("Polynomial2", 100000)
   {
         auto x = new RooRealVar("x", "x", -10, 10);
         auto a1 = new RooRealVar("a1", "a1", 0.3, 0.01, 0.5);
@@ -43,15 +43,15 @@ class TestPolynomial2 : public PDFTest
 COMPARE_FIXED_VALUES_UNNORM(TestPolynomial2, CompareFixedValuesUnnorm)
 COMPARE_FIXED_VALUES_NORM(TestPolynomial2, CompareFixedValuesNorm)
 COMPARE_FIXED_VALUES_NORM_LOG(TestPolynomial2, CompareFixedNormLog)
-FIT_TEST_SCALAR(TestPolynomial2, RunScalar)
-FIT_TEST_BATCH(TestPolynomial2, RunBatch)
+FIT_TEST_SCALAR(TestPolynomial2, DISABLED_RunScalar) // Save time
+FIT_TEST_BATCH(TestPolynomial2, DISABLED_RunBatch)   // Save time
 FIT_TEST_BATCH_VS_SCALAR(TestPolynomial2, CompareBatchScalar)
 
 class TestPolynomial5 : public PDFTest
 {
   protected:
     TestPolynomial5() :
-      PDFTest("Polynomial5", 300000)
+      PDFTest("Polynomial5", 100000)
   {
       auto x = new RooRealVar("x", "x", -150, 40);
       auto a0 = new RooRealVar("a0", "a0", 1000.0);
@@ -83,7 +83,7 @@ class TestPolynomial5 : public PDFTest
 COMPARE_FIXED_VALUES_UNNORM(TestPolynomial5, CompareFixedValuesUnnorm)
 COMPARE_FIXED_VALUES_NORM(TestPolynomial5, CompareFixedValuesNorm)
 COMPARE_FIXED_VALUES_NORM_LOG(TestPolynomial5, CompareFixedNormLog)
-FIT_TEST_SCALAR(TestPolynomial5, RunScalar)
-FIT_TEST_BATCH(TestPolynomial5, RunBatch)
+FIT_TEST_SCALAR(TestPolynomial5, DISABLED_RunScalar) // Save time
+FIT_TEST_BATCH(TestPolynomial5, DISABLED_RunBatch)   // Save time
 FIT_TEST_BATCH_VS_SCALAR(TestPolynomial5, CompareBatchScalar)
 

--- a/root/roofitstats/vectorisedPDFs/testVoigtian.cxx
+++ b/root/roofitstats/vectorisedPDFs/testVoigtian.cxx
@@ -1,0 +1,83 @@
+// Author: Stephan Hageboeck, CERN  26 Apr 2019
+
+/*****************************************************************************
+ * RooFit
+ * Authors:                                                                  *
+ *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
+ *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
+ *                                                                           *
+ * Copyright (c) 2000-2019, Regents of the University of California          *
+ *                          and Stanford University. All rights reserved.    *
+ *                                                                           *
+ * Redistribution and use in source and binary forms,                        *
+ * with or without modification, are permitted according to the terms        *
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
+ *****************************************************************************/
+
+#include "VectorisedPDFTests.h"
+#include "RooVoigtian.h"
+
+class TestVoigtian : public PDFTest
+{
+  protected:
+    TestVoigtian() :
+      PDFTest("Voigtian", 300000)
+  {
+        auto x = new RooRealVar("x", "x", 1, 0.1, 10);
+        auto mean = new RooRealVar("mean", "mean", 1, 0.1, 10);
+        auto width = new RooRealVar("width", "width", 0.5, 0.1, 0.9);
+        auto sigma = new RooRealVar("sigma", "sigma", 0.5, 0.1, 0.9);
+
+        _pdf = std::make_unique<RooVoigtian>("Voigtian", "Voigtian PDF", *x, *mean, *width, *sigma);
+
+
+      _variables.addOwned(*x);
+
+      //_variablesToPlot.add(*x);
+
+      for (auto par : {mean, width, sigma}) {
+        _parameters.addOwned(*par);
+      }
+  }
+};
+
+COMPARE_FIXED_VALUES_UNNORM(TestVoigtian, CompareFixedUnnorm)
+COMPARE_FIXED_VALUES_NORM(TestVoigtian, CompareFixedNorm)
+COMPARE_FIXED_VALUES_NORM_LOG(TestVoigtian, CompareFixedNormLog)
+FIT_TEST_SCALAR(TestVoigtian, RunScalar)
+FIT_TEST_BATCH(TestVoigtian, RunBatch)
+FIT_TEST_BATCH_VS_SCALAR(TestVoigtian, CompareBatchScalar)
+
+class TestVoigtianInXandMean : public PDFTest
+{
+  protected:
+    TestVoigtianInXandMean() :
+      PDFTest("Voigtian(x,m)", 300000)
+  {
+        auto x = new RooRealVar("x", "x", 1, 0.1, 10);
+        auto mean = new RooRealVar("mean", "mean", 1, 0.1, 10);
+        auto width = new RooRealVar("width", "width", 0.5, 0.1, 0.9);
+        auto sigma = new RooRealVar("sigma", "sigma", 0.5, 0.1, 0.9);
+
+        _pdf = std::make_unique<RooVoigtian>("Voigtian", "Voigtian PDF", *x, *mean, *width, *sigma);
+
+
+      for (auto var: {x,mean} ) {
+        _variables.addOwned(*var);
+      }
+
+      //_variablesToPlot.add(*x);
+
+      for (auto par : {width, sigma}) {
+        _parameters.addOwned(*par);
+      }
+
+  }
+};
+
+COMPARE_FIXED_VALUES_UNNORM(TestVoigtianInXandMean, CompareFixedUnnorm)
+COMPARE_FIXED_VALUES_NORM(TestVoigtianInXandMean, CompareFixedNorm)
+COMPARE_FIXED_VALUES_NORM_LOG(TestVoigtianInXandMean, CompareFixedNormLog)
+FIT_TEST_SCALAR(TestVoigtianInXandMean, RunScalar)
+FIT_TEST_BATCH(TestVoigtianInXandMean, RunBatch)
+FIT_TEST_BATCH_VS_SCALAR(TestVoigtianInXandMean, CompareBatchScalar)

--- a/root/roofitstats/vectorisedPDFs/testVoigtian.cxx
+++ b/root/roofitstats/vectorisedPDFs/testVoigtian.cxx
@@ -21,7 +21,7 @@ class TestVoigtian : public PDFTest
 {
   protected:
     TestVoigtian() :
-      PDFTest("Voigtian", 300000)
+      PDFTest("Voigtian", 100000)
   {
         auto x = new RooRealVar("x", "x", 1, 0.1, 10);
         auto mean = new RooRealVar("mean", "mean", 1, 0.1, 10);
@@ -52,7 +52,7 @@ class TestVoigtianInXandMean : public PDFTest
 {
   protected:
     TestVoigtianInXandMean() :
-      PDFTest("Voigtian(x,m)", 300000)
+      PDFTest("Voigtian(x,m)", 100000)
   {
         auto x = new RooRealVar("x", "x", 1, 0.1, 10);
         auto mean = new RooRealVar("mean", "mean", 1, 0.1, 10);

--- a/root/roofitstats/vectorisedPDFs/testVoigtian.cxx
+++ b/root/roofitstats/vectorisedPDFs/testVoigtian.cxx
@@ -25,19 +25,23 @@ class TestVoigtian : public PDFTest
   {
         auto x = new RooRealVar("x", "x", 1, 0.1, 10);
         auto mean = new RooRealVar("mean", "mean", 1, 0.1, 10);
-        auto width = new RooRealVar("width", "width", 0.5, 0.1, 0.9);
-        auto sigma = new RooRealVar("sigma", "sigma", 0.5, 0.1, 0.9);
+        auto width = new RooRealVar("width", "width", 0.8, 0.1, 0.9);
+        auto sigma = new RooRealVar("sigma", "sigma", 0.7, 0.1, 0.9);
 
         _pdf = std::make_unique<RooVoigtian>("Voigtian", "Voigtian PDF", *x, *mean, *width, *sigma);
 
 
       _variables.addOwned(*x);
 
-      //_variablesToPlot.add(*x);
+//      _variablesToPlot.add(*x);
 
       for (auto par : {mean, width, sigma}) {
         _parameters.addOwned(*par);
       }
+
+      _toleranceParameter = 2.E-5;
+      _toleranceCorrelation = 4.E-4;
+      _toleranceCompareLogs = 5.E-12;
   }
 };
 


### PR DESCRIPTION
- Commit tests that were left unfinished by EM.
- Reduce run times of many tests.
- Stabilise test that were marked `WILLFAIL`.