### PR TITLE
Backport 622: TClingMethodInfo now skips deleted functions

### DIFF
--- a/root/meta/MemberComments.ref
+++ b/root/meta/MemberComments.ref
@@ -627,10 +627,8 @@ childCl::Class()->GetListOfAllPublicMethods():
 childCl::childCl() // 
 childCl::childCl(const childCl&) // 
 childCl::fGetIndex(Int_t aIndex) // Title Derived
-childCl::operator=(const childCl&) // 
 childCl::~childCl() // 
 baseCl::baseCl() // 
 baseCl::baseCl(const baseCl&) // 
 baseCl::fGetIndex(Int_t aIndex = 0) // Title Base
-baseCl::operator=(const baseCl&) // 
 baseCl::~baseCl() // 

--- a/root/meta/genreflex/TClass/execbasic.ref
+++ b/root/meta/genreflex/TClass/execbasic.ref
@@ -136,11 +136,10 @@ Class category: foreign.
 --- Class class6
 Class category: foreign.
  * Version: -1
- o Methods (4):
+ o Methods (3):
   * class6 class6::class6(int i)
   * void class6::~class6()
   * class6 class6::class6(const class6&)
-  * class6& class6::operator=(const class6&)
  o Members (20):
   * const int m_arrSize [ isBasic ]
   * int* m_arr1 [ isPtr isBasic "[m_arrSize]" ]

--- a/root/meta/method/execTemplate.ref
+++ b/root/meta/method/execTemplate.ref
@@ -81,11 +81,7 @@ TClass::New() on Outer<int> does create an object
 OBJ: TListOfFunctions	TListOfFunctions	List of TFunctions for a class : 0
  OBJ: TMethod	Wrapper<int&>	 : 0
       Wrapper<int&> Wrapper<int&>::Wrapper<int&>(const Wrapper<int&>&)
- OBJ: TMethod	operator=	 : 0
-      Wrapper<int&>& Wrapper<int&>::operator=(const Wrapper<int&>&)
  OBJ: TMethod	Wrapper<int&>	 : 0
       Wrapper<int&> Wrapper<int&>::Wrapper<int&>(Wrapper<int&>&&)
- OBJ: TMethod	operator=	 : 0
-      Wrapper<int&>& Wrapper<int&>::operator=(Wrapper<int&>&&)
  OBJ: TMethod	~Wrapper<int&>	 : 0
       void Wrapper<int&>::~Wrapper<int&>()


### PR DESCRIPTION
Backport of https://github.com/root-project/roottest/pull/572