### PR TITLE
[Pytest] Fix incompatibility issue with Python>=3.8.4

### DIFF
--- a/python/pytest/_pytest/assertion/rewrite.py
+++ b/python/pytest/_pytest/assertion/rewrite.py
@@ -384,6 +384,13 @@ binop_map = {
     ast.NotIn: "not in"
 }
 
+# Python 3.4+ compatibility
+if hasattr(ast, "NameConstant"):
+    _NameConstant = ast.NameConstant
+else:
+    def _NameConstant(c):
+        return ast.Name(str(c), ast.Load())
+
 
 def set_location(node, lineno, col_offset):
     """Set node location information recursively."""
@@ -537,7 +544,7 @@ class AssertionRewriter(ast.NodeVisitor):
         if self.variables:
             variables = [ast.Name(name, ast.Store())
                          for name in self.variables]
-            clear = ast.Assign(variables, ast.Name("None", ast.Load()))
+            clear = ast.Assign(variables, _NameConstant(None))
             self.statements.append(clear)
         # Fix line numbers.
         for stmt in self.statements:


### PR DESCRIPTION
The issue was detected when running roottest with a conda ROOT
installation:
https://lcgapp-services.cern.ch/root-jenkins/view/conda/job/conda-nightlies/90/testReport/projectroot.python/pythonizations/roottest_python_pythonizations_pythonizations/

The fix corresponds to the following upstream pytest fix:
https://bitbucket.org/pytest-dev/pytest/commits/ce3f55c10452