### PR TITLE
Disable roofitstats/stabilityTests on Windows

### DIFF
--- a/root/roofitstats/CMakeLists.txt
+++ b/root/roofitstats/CMakeLists.txt
@@ -14,8 +14,10 @@ if(ROOT_roofit_FOUND)
                     POSTCMD diff ${CMAKE_CURRENT_SOURCE_DIR}/ASCII-in-out_data.txt ./ASCII-in-out_result.txt)
 
   if(MSVC)
-    ROOT_ADD_GTEST(stabilityTests stabilityTests.cxx LIBRARIES libCore libTree libRIO libRooFitCore libRooFit
-                   COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/stabilityTests_data_1.root)
+    if(win_broken_tests)
+      ROOT_ADD_GTEST(stabilityTests stabilityTests.cxx LIBRARIES libCore libTree libRIO libRooFitCore libRooFit
+                     COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/stabilityTests_data_1.root)
+    endif()
   else()
     ROOT_ADD_GTEST(stabilityTests stabilityTests.cxx LIBRARIES Core Tree RIO RooFitCore RooFit
                    COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/stabilityTests_data_1.root)

--- a/root/roofitstats/stabilityTests.cxx
+++ b/root/roofitstats/stabilityTests.cxx
@@ -51,7 +51,7 @@ TEST(Stability, ROOT_10615) {
   RooDataSet dataset("dataset", "dataset", input_tree, dt);
   EXPECT_FALSE(hijack.str().empty());
 
-  if (gSystem->Load("libMinuit2.so") < 0)
+  if (gSystem->Load("libMinuit2") < 0)
     GTEST_SKIP();
 
   auto fitResult = bkg_dt_model_.fitTo(dataset, RooFit::Minimizer("Minuit2"), RooFit::Save(), RooFit::Hesse(false), RooFit::PrintLevel(-1));


### PR DESCRIPTION
 - remove the `.so` file extension
 - disable the test which is failing after the add of RooHelpers::HijackMessageStream