### PR TITLE
[PyROOT] Check if CPPYY_BACKEND_LIBRARY points to an existing file

### DIFF
--- a/python/cling/cppyy_backend_check.h
+++ b/python/cling/cppyy_backend_check.h
@@ -1,0 +1,35 @@
+using std::string;
+
+std::pair<string,string> SplitPathAndName(const char *path)
+{
+   char sep = '/';
+
+#ifdef WIN32
+   sep = '\\';
+#endif
+
+   string s(path);
+   size_t i = s.rfind(sep, s.length());
+   if (i != string::npos) {
+      return std::make_pair(s.substr(0, i), s.substr(i+1));
+   }
+
+   return std::make_pair("", path);
+}
+
+// Helper function to check if CPPYY_BACKEND_LIBRARY
+// points to an existing file.
+// If it does not, the variable is unset to let cppyy
+// look for the library in its default directories.
+void check_cppyy_backend()
+{
+   auto lcb = gSystem->Getenv("CPPYY_BACKEND_LIBRARY");
+   if (lcb) {
+      auto pathAndName = SplitPathAndName(lcb);
+      auto path = pathAndName.first;
+      TString name(pathAndName.second);
+      if (!gSystem->FindFile(path.c_str(), name))
+         gSystem->Unsetenv("CPPYY_BACKEND_LIBRARY");
+   }
+}
+

--- a/python/cling/runPyAPITestCppyy.C
+++ b/python/cling/runPyAPITestCppyy.C
@@ -1,7 +1,10 @@
 #include "TPython.h"
 #include "TError.h"
+#include "cppyy_backend_check.h"
 
 void runPyAPITestCppyy() {
+   check_cppyy_backend();
+
 // The higher warning ignore level is to suppress warnings about
 // classes already being in the class table (on Mac).
    int eil = gErrorIgnoreLevel;

--- a/python/cling/runPyClassTest.C
+++ b/python/cling/runPyClassTest.C
@@ -1,4 +1,5 @@
 #include "TPython.h"
+#include "cppyy_backend_check.h"
 
 // This test is no longer one script as it once was: Cling compiles code
 // within a single macro, so there is a problem of initialization of the
@@ -7,6 +8,8 @@
 // different from the line-to-line behaviour of CINT (and the ROOT CLI).
 
 void runPyClassTest() {
+   check_cppyy_backend();
+
 // load a python class and test its use
    TPython::LoadMacro( "MyPyClass.py" );
    gROOT->ProcessLine( ".x PyClassTest1.C" );


### PR DESCRIPTION
If not, unset the environment variable. This will give to cppyy
the opportunity to find the library on its own, by looking in its
default directories.

This should solve this kind of failures in the conda builds:
https://lcgapp-services.cern.ch/root-jenkins/view/conda/job/conda-nightlies/104/testReport/projectroot.python/cling/roottest_python_cling_api/

which are due to the fact that the tests are run in standalone
mode and, therefore, {CMAKE_BINARY_DIR}/lib does not contain
the ROOT libraries.