### PR TITLE
[PyROOT] Check if CPPYY_BACKEND_LIBRARY points to an existing file (P…

### DIFF
--- a/python/basic/PyROOT_datatypetest.py
+++ b/python/basic/PyROOT_datatypetest.py
@@ -27,6 +27,8 @@ def setup_module(mod):
         if err:
             raise OSError("'make' failed (see stderr)")
 
+    check_cppyy_backend()
+
 
 class TestClassDATATYPES:
     def setup_class(cls):

--- a/python/basic/PyROOT_overloadtests.py
+++ b/python/basic/PyROOT_overloadtests.py
@@ -24,6 +24,8 @@ def setup_module(mod):
         if err:
             raise OSError("'make' failed (see stderr)")
 
+    check_cppyy_backend()
+
 
 class TestClassOVERLOADS:
     def setup_class(cls):

--- a/python/common.py
+++ b/python/common.py
@@ -3,7 +3,7 @@
 # Created: 09/24/10
 # Last: 04/04/14
 
-__all__ = [ 'pylong', 'maxvalue', 'MyTestCase', 'run_pytest', 'FIXCLING' ]
+__all__ = [ 'pylong', 'maxvalue', 'MyTestCase', 'run_pytest', 'FIXCLING', 'check_cppyy_backend' ]
 
 import os, sys, unittest, warnings
 
@@ -56,3 +56,12 @@ def run_pytest(test_file=None):
     if test_file: args += [test_file]
     # actual test run
     return pytest.main(args, plugins=[pytest_cov])
+
+def check_cppyy_backend():
+    # Helper function to check if CPPYY_BACKEND_LIBRARY
+    # points to an existing file.
+    # If it does not, the variable is unset to let cppyy
+    # look for the library in its default directories.
+    cbl = os.environ.get('CPPYY_BACKEND_LIBRARY')
+    if cbl is not None and not os.path.isfile(cbl):
+        del os.environ['CPPYY_BACKEND_LIBRARY']

--- a/python/regression/exec_root_6023.py
+++ b/python/regression/exec_root_6023.py
@@ -1,4 +1,10 @@
 # -*- coding: utf-8 -*-
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__))) # for common
+
+from common import check_cppyy_backend
+check_cppyy_backend()
+
 import cppyy
 cppyy.gbl.gROOT.ProcessLine('.L root_6023.h+')
 

--- a/root/meta/tclass/regression/execNormalizationInf.py
+++ b/root/meta/tclass/regression/execNormalizationInf.py
@@ -1,2 +1,9 @@
+import os
+cbl = os.environ.get('CPPYY_BACKEND_LIBRARY')
+if cbl is not None and not os.path.isfile(cbl):
+    # CPPYY_BACKEND_LIBRARY does not point to an existing file
+    # Let cppyy find it on its own
+    del os.environ['CPPYY_BACKEND_LIBRARY']
+
 import cppyy
 cppyy.gbl.std.map('string','string')()


### PR DESCRIPTION
…ython-based tests)

(Follow-up of 1579da4f3)

If not, unset the environment variable. This will give to cppyy
the opportunity to find the library on its own, by looking in its
default directories.

This should solve this kind of failures in the conda builds:
https://lcgapp-services.cern.ch/root-jenkins/view/conda/job/conda-nightlies/104/testReport/projectroot.python/basic/roottest_python_basic_datatype/

which are due to the fact that the tests are run in standalone
mode and, therefore, {CMAKE_BINARY_DIR}/lib does not contain
the ROOT libraries.