### PR TITLE
[DF] Fix test for ROOT-9674 (v6.22)

### DIFF
--- a/root/dataframe/readShip.C
+++ b/root/dataframe/readShip.C
@@ -3,8 +3,8 @@ int readShip()
 {
    ROOT::RDataFrame f("cbmsim","ship_ROOT_9674.root");
    auto name = f.GetColumnType("MCTrack.fPdgCode");
-   if(name != "Int_t") {
-      std::cerr << "ERROR: expecting the type name Int_t for column MCTrack.fPdgCode" << std::endl;
+   if(name != "ROOT::VecOps::RVec<Int_t>") {
+      std::cerr << "ERROR: expecting the type name ROOT::VecOps::RVec<Int_t> for column MCTrack.fPdgCode" << std::endl;
       return 1;
    }
    return 0;


### PR DESCRIPTION
Column type is RVec<int>, not int, and RDF gets it wrong.
https://github.com/root-project/root/pull/6258 fixes the type inference
problem (and therefore this test) for master.