### PR TITLE
Closes JIRA issue ROOT-8245 (re-enable cling/reload/reloadvector test)

### DIFF
--- a/cling/reload/CMakeLists.txt
+++ b/cling/reload/CMakeLists.txt
@@ -1,7 +1,7 @@
-#ROOTTEST_ADD_TEST(reloadvector
-#                  MACRO runreloadvector.C
-#                  OUTREF reloadvector.ref
-#                  LABELS roottest regression cling)
+ROOTTEST_ADD_TEST(reloadvector
+                  MACRO runreloadvector.C
+                  OUTREF reloadvector.ref
+                  LABELS roottest regression cling)
                   
                   
 ROOTTEST_ADD_TEST(ROOT-7364


### PR DESCRIPTION
The underlying issue was solved with commit https://github.com/root-project/root/commit/afba1d737aeafd554ac4763fcc2d542de961be2a.

Thus, this PR re-enables this test.