### PR TITLE
Fix deprecated file mode 'U'

### DIFF
--- a/scripts/custom_diff.py
+++ b/scripts/custom_diff.py
@@ -82,8 +82,8 @@ def main():
     fromlines = open(fromfile).readlines()
     tolines = open(tofile).readlines()
   else:
-    fromlines = open(fromfile, 'U').readlines()
-    tolines = open(tofile, 'U').readlines()
+    fromlines = open(fromfile, 'r' if sys.version_info >= (3, 4) else 'U').readlines()
+    tolines = open(tofile, 'r' if sys.version_info >= (3, 4) else 'U').readlines()
 
   fromlines = filter(fromlines)
   tolines = filter(tolines)


### PR DESCRIPTION
The file mode 'U' (the universal newlines mode) is officialy
deprecated since python 3.4 (see https://docs.python.org/3.4/library/functions.html#open).

Fixes root-project/root#6480