### PR TITLE
[RF] Fix link dependencies.

### DIFF
--- a/root/roofitstats/CMakeLists.txt
+++ b/root/roofitstats/CMakeLists.txt
@@ -19,11 +19,11 @@ if(ROOT_roofit_FOUND)
                      COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/stabilityTests_data_1.root)
     endif()
   else()
-    ROOT_ADD_GTEST(stabilityTests stabilityTests.cxx LIBRARIES Core Tree RIO RooFitCore RooFit
+    ROOT_ADD_GTEST(stabilityTests stabilityTests.cxx LIBRARIES ROOT::RooFit
                    COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/stabilityTests_data_1.root)
   endif()
 
-  ROOT_ADD_GTEST(loadOldWorkspace loadOldWorkspace.cxx LIBRARIES RooFitCore RooFit
+  ROOT_ADD_GTEST(loadOldWorkspace loadOldWorkspace.cxx LIBRARIES ROOT::RooFit
                  COPY_TO_BUILDDIR
                  ${CMAKE_CURRENT_SOURCE_DIR}/rf502_workspace_v5.34.root
                  ${CMAKE_CURRENT_SOURCE_DIR}/rf502_workspace_v6.04.root


### PR DESCRIPTION
Standalone roottest doesn't handle transitive dependencies, so this
fixes it.