### PR TITLE
The llvm9 orders the annotate attributes differently, fix the subopti…

### DIFF
--- a/cling/typedef_global/CMakeLists.txt
+++ b/cling/typedef_global/CMakeLists.txt
@@ -9,11 +9,13 @@ ROOTTEST_ADD_TEST(scopeTest
                   OUTREF output.ref-cling
                   OUTCNV scopeTest_conversion.sh
                   DEPENDS ${depends}
-                  LABELS roottest regression cling)
+                  LABELS roottest regression cling
+                  COPY_TO_BUILDDIR helper.h)
 
 ROOTTEST_ADD_TEST(scopeTest2
                   MACRO rungood.C
                   OUTREF output.ref-cling
                   OUTCNV scopeTest_conversion.sh
                   DEPENDS ${depends}
-                  LABELS roottest regression cling)
+                  LABELS roottest regression cling
+                  COPY_TO_BUILDDIR helper.h)

--- a/cmake/modules/RoottestMacros.cmake
+++ b/cmake/modules/RoottestMacros.cmake
@@ -640,6 +640,7 @@ endmacro(ROOTTEST_SETUP_EXECTEST)
 #                            [WORKING_DIR dir]
 #                            [TIMEOUT tmout]
 #                            [COPY_TO_BUILDDIR file1 file2 ...])
+#                            [ENVIRONMENT ENV_VAR1=value1;ENV_VAR2=value2; ...])
 #
 # This function defines a roottest test. It adds a number of additional
 # options on top of the ROOT defined ROOT_ADD_TEST.

--- a/cmake/modules/RoottestMacros.cmake
+++ b/cmake/modules/RoottestMacros.cmake
@@ -852,6 +852,8 @@ function(ROOTTEST_ADD_TEST testname)
 
   if(MSVC)
     set(environment ENVIRONMENT
+                    ${ROOTTEST_ENV_EXTRA}
+                    ${ARG_ENVIRONMENT}
                     ROOTSYS=${ROOTSYS}
                     PYTHONPATH=${ROOTTEST_ENV_PYTHONPATH})
   else()

--- a/root/io/transient/base/CMakeLists.txt
+++ b/root/io/transient/base/CMakeLists.txt
@@ -20,14 +20,14 @@ ROOTTEST_ADD_TEST(WriteFile
                   PRECMD ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config $<CONFIG> --target base${fast}
                   MACRO execWriteFile.cxx+
                   OUTREF execWriteFile${ref_suffix})
+
 if(${compression_default} STREQUAL "lz4")
-	ROOTTEST_ADD_TEST(hadd_autoload
-                  	COMMAND hadd -f data_merge.root data1.root data2.root
-                  	OUTREF hadd_autoloadLZ4.ref
-                  	DEPENDS WriteFile)
+  set(outref_suffix "LZ4")
 else()
-	ROOTTEST_ADD_TEST(hadd_autoload
-                  	COMMAND hadd -f data_merge.root data1.root data2.root
-                  	OUTREF hadd_autoloadZLIB.ref
-                  	DEPENDS WriteFile)
+  set(outref_suffix "ZLIB")
 endif()
+ROOTTEST_ADD_TEST(hadd_autoload
+  COMMAND hadd -f data_merge.root data1.root data2.root
+  OUTREF hadd_autoload${outref_suffix}.ref
+  DEPENDS WriteFile
+  ENVIRONMENT ROOT_INCLUDE_PATH=${CMAKE_CURRENT_SOURCE_DIR})

--- a/root/io/transient/base/CMakeLists.txt
+++ b/root/io/transient/base/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 set(RootExeOptions -e "gSystem->Load(\"libbase\")")   # Adding a ; to avoid the output is complicated
 
 ROOTTEST_ADD_TEST(WriteFile
+                  COPY_TO_BUILDDIR testobject.h testobjectderived.h
                   PRECMD ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config $<CONFIG> --target base${fast}
                   MACRO execWriteFile.cxx+
                   OUTREF execWriteFile${ref_suffix})

--- a/root/io/treeForeign/CMakeLists.txt
+++ b/root/io/treeForeign/CMakeLists.txt
@@ -4,7 +4,6 @@ if(${compression_default} STREQUAL "lz4")
                   MACRO Run.C
                   PRECMD ${ROOT_root_CMD} -b -q -l ${CMAKE_CURRENT_SOURCE_DIR}/def.C+
                   OUTREF testForeignDrawLZ4.ref
-                  ${WILLFAIL_ON_WIN32}
                   DEPENDS test-dataset)
 else(${compression_default} STREQUAL "zlib")
    if(ZLIB_CF)
@@ -12,14 +11,12 @@ else(${compression_default} STREQUAL "zlib")
                   MACRO Run.C
                   PRECMD ${ROOT_root_CMD} -b -q -l ${CMAKE_CURRENT_SOURCE_DIR}/def.C+
                   OUTREF testForeignDrawZLIB_builtinzlib.ref
-                  ${WILLFAIL_ON_WIN32}
                   DEPENDS test-dataset)
    else()
 	  ROOTTEST_ADD_TEST(testForeignDraw
                   MACRO Run.C
                   PRECMD ${ROOT_root_CMD} -b -q -l ${CMAKE_CURRENT_SOURCE_DIR}/def.C+
                   OUTREF testForeignDrawZLIB.ref
-                  ${WILLFAIL_ON_WIN32}
                   DEPENDS test-dataset)
    endif()
 endif()


### PR DESCRIPTION
…mal test.

LLVM9 orders the annotate attributes in reverse order for this test. With llvm5
we got:
RecordDecl <...> "Toy"
  AnnotateAttr "clingAutoload$/abs/path/to/mycl.C"
  AnnotateAttr "clingAutoload$helper.h"

LLVM9;
RecordDecl <...> "Toy"
  AnnotateAttr "clingAutoload$helper.h"
  AnnotateAttr "clingAutoload$/abs/path/to/mycl.C"

While the first worked as discovering the file entry for mycl.C (being absolute
path) and skipping the second, llvm9 fails because cannot find the helper.h.

This patch copies helper.h into the build folder as we do not expose the
CURRENT_CMAKE_SOURCE_DIR to the gInterpreter's include paths.

This is part of root-project/root#6385 