### PR TITLE
[RF] Convert cerr to gtest failure for testing vectorised PDFs.

### DIFF
--- a/root/roofitstats/vectorisedPDFs/VectorisedPDFTests.cxx
+++ b/root/roofitstats/vectorisedPDFs/VectorisedPDFTests.cxx
@@ -374,8 +374,10 @@ void PDFTest::compareFixedValues(double& maximalError, bool normalise, bool comp
 #endif
 
       } catch (std::exception& e) {
-        std::cerr << "ERROR when checking batch computation for event " << i << ":\n"
-            << e.what() << std::endl;
+        ADD_FAILURE() << " ERROR when checking batch computation for event " << i << ":\n"
+            << e.what() << "\n"
+            << "PDF is:"<< std::endl;
+        _pdf->Print("T");
       }
 #endif
     }


### PR DESCRIPTION
When testing the vectorised PDFs with ROOFIT_CHECK_CACHED_VALUES
defined, differences between batch and single-value computations
would be signalled only with cerr. This was converted to a proper
gtest failure with info messages etc.

Note that such a failure *may* be acceptable:
Defining ROOFIT_CHECK_CACHED_VALUES is a very strict checking mode
meant for debugging.
With only a single data point exceeding the tolerance the test will
fail. If the macro is not defined, tests only fail when *multiple*
points exceed the tolerance.

Please merge without my assistance.