### PR TITLE
[RF] Purge old batch interface

### DIFF
--- a/root/roofitstats/vectorisedPDFs/testGauss.cxx
+++ b/root/roofitstats/vectorisedPDFs/testGauss.cxx
@@ -78,6 +78,8 @@ class TestGaussWeighted : public PDFTestWeightedData
       for (auto par : {mean, sigma}) {
         _parameters.addOwned(*par);
       }
+
+      _multiProcess = 4;
   }
 };
 


### PR DESCRIPTION
This PR updates roottest so that the same-named PR in ROOT works correctly. It replaces the tests' roofit method calls to match the new interface. See the corresponding ROOT PR for more details. 