### PR TITLE
[PyROOT][6915] Skip GL tests when unable to import GL classes

### DIFF
--- a/python/regression/PyROOT_regressiontests.py
+++ b/python/regression/PyROOT_regressiontests.py
@@ -504,30 +504,31 @@ Base* g() { return new Derived(); }
 
 
 ### Tests for TGL classes ================
-class Regression19TGL(MyTestCase):
-   def test1TGLVertex3OperatorPlus(self):
-      """Try invoking TGLVertex3::operator+ twice"""
-      # ROOT-10166
-      if not legacy_pyroot:
-         from ROOT import TGLVertex3, TGLVector3
+try:
+   from ROOT import TGLLine3, TGLVertex3, TGLVector3
+except ImportError:
+   print("GL classes not found, skipping GL tests")
+else:
+   class Regression19TGL(MyTestCase):
+      def test1TGLVertex3OperatorPlus(self):
+         """Try invoking TGLVertex3::operator+ twice"""
+         # ROOT-10166
+         if not legacy_pyroot:
+            scatteringPoint = TGLVertex3(2., 3., 0.2)
+            glvec3 = TGLVector3(1,2,3)
 
-         scatteringPoint = TGLVertex3(2., 3., 0.2)
-         glvec3 = TGLVector3(1,2,3)
+            vertexEnd = scatteringPoint + glvec3
+            vertexEnd = scatteringPoint + glvec3
 
-         vertexEnd = scatteringPoint + glvec3
-         vertexEnd = scatteringPoint + glvec3
+      def test2TGLLine3Constructor(self):
+         """Check that the right constructor of TGLLine3 is called"""
+         # ROOT-10102
+         if not legacy_pyroot:
+            trackAfterScattering = TGLLine3(TGLVertex3(2., 3., 0.2), TGLVector3(0., 0., -20.))
 
-   def test2TGLLine3Constructor(self):
-      """Check that the right constructor of TGLLine3 is called"""
-      # ROOT-10102
-      if not legacy_pyroot:
-         from ROOT import TGLLine3, TGLVertex3, TGLVector3
-
-         trackAfterScattering = TGLLine3(TGLVertex3(2., 3., 0.2), TGLVector3(0., 0., -20.))
-
-         self.assertEqual(trackAfterScattering.Vector().X(), .0)
-         self.assertEqual(trackAfterScattering.Vector().Y(), .0)
-         self.assertEqual(trackAfterScattering.Vector().Z(), -20.0)
+            self.assertEqual(trackAfterScattering.Vector().X(), .0)
+            self.assertEqual(trackAfterScattering.Vector().Y(), .0)
+            self.assertEqual(trackAfterScattering.Vector().Z(), -20.0)
 
 
 ### Getting and setting configuration options of gEnv ================


### PR DESCRIPTION
Fixes https://github.com/root-project/root/issues/6915

Alternatively, the whole `roottest-python-regression-regression` test could be disabled in CMake if not building with opengl, but I prefer this option since `roottest-python-regression-regression` has many other tests that it would be interesting to run even if opengl is not there.