### PR TITLE
Fix out-of-range access in executorTests

### DIFF
--- a/root/multicore/executorTests.hxx
+++ b/root/multicore/executorTests.hxx
@@ -105,7 +105,7 @@ int ExecutorTest(T &executor) {
    }
    auto hred = executor.Reduce(vhist);
 
-   for(auto i = 0; i<52; i++){
+   for (auto i = 0; i < 12; i++) {
       if(htot->GetBinContent(i) != hred->GetBinContent(i))
          return 12;
    }


### PR DESCRIPTION
Both `htot` and `hred` have 10 bins, so including the bins for under- and overflow the maximum index to `GetBinContent` should be 11.