### PR TITLE
Fix parallel building of tests on Windows

### DIFF
--- a/cmake/modules/RoottestMacros.cmake
+++ b/cmake/modules/RoottestMacros.cmake
@@ -238,7 +238,7 @@ macro(ROOTTEST_COMPILE_MACRO filename)
     set_property(TEST ${COMPILE_MACRO_TEST} PROPERTY FAIL_REGULAR_EXPRESSION "Warning in")
   endif()
   set_property(TEST ${COMPILE_MACRO_TEST} PROPERTY ENVIRONMENT ${ROOTTEST_ENVIRONMENT})
-  if(CMAKE_GENERATOR MATCHES Ninja)
+  if(MSVC OR CMAKE_GENERATOR MATCHES Ninja)
     set_property(TEST ${COMPILE_MACRO_TEST} PROPERTY RUN_SERIAL true)
   endif()
 
@@ -328,7 +328,7 @@ macro(ROOTTEST_GENERATE_DICTIONARY dictname)
                                     -- ${always-make})
 
   set_property(TEST ${GENERATE_DICTIONARY_TEST} PROPERTY ENVIRONMENT ${ROOTTEST_ENVIRONMENT})
-  if(CMAKE_GENERATOR MATCHES Ninja)
+  if(MSVC OR CMAKE_GENERATOR MATCHES Ninja)
     set_property(TEST ${GENERATE_DICTIONARY_TEST} PROPERTY RUN_SERIAL true)
   endif()
 
@@ -418,7 +418,7 @@ macro(ROOTTEST_GENERATE_REFLEX_DICTIONARY dictionary)
                                     -- ${always-make})
 
   set_property(TEST ${GENERATE_REFLEX_TEST} PROPERTY ENVIRONMENT ${ROOTTEST_ENVIRONMENT})
-  if(CMAKE_GENERATOR MATCHES Ninja)
+  if(MSVC OR CMAKE_GENERATOR MATCHES Ninja)
     set_property(TEST ${GENERATE_REFLEX_TEST} PROPERTY RUN_SERIAL true)
   endif()
 
@@ -486,7 +486,7 @@ macro(ROOTTEST_GENERATE_EXECUTABLE executable)
                                     --target ${executable}${fast}
                                     -- ${always-make})
   set_property(TEST ${GENERATE_EXECUTABLE_TEST} PROPERTY ENVIRONMENT ${ROOTTEST_ENVIRONMENT})
-  if(CMAKE_GENERATOR MATCHES Ninja)
+  if(MSVC OR CMAKE_GENERATOR MATCHES Ninja)
     set_property(TEST ${GENERATE_EXECUTABLE_TEST} PROPERTY RUN_SERIAL true)
   endif()
 


### PR DESCRIPTION
This should prevent the following kind of errors:
```
error MSB4018: The "Touch" task failed unexpectedly. [C:\Users\sftnight\build\roottest\ZERO_CHECK.vcxproj]
error MSB4018: System.IO.FileNotFoundException: Could not find file 'C:\Users\sftnight\build\roottest\Win32\RelWithDebInfo\ZERO_CHECK\ZERO_CHECK.tlog\unsuccessfulbuild'. [C:\Users\sftnight\build\roottest\ZERO_CHECK.vcxproj]
error MSB4018: File name: 'C:\Users\sftnight\build\roottest\Win32\RelWithDebInfo\ZERO_CHECK\ZERO_CHECK.tlog\unsuccessfulbuild' [C:\Users\sftnight\build\roottest\ZERO_CHECK.vcxproj]
error MSB4018:    at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath) [C:\Users\sftnight\build\roottest\ZERO_CHECK.vcxproj]
error MSB4018:    at System.IO.File.GetAttributes(String path) [C:\Users\sftnight\build\roottest\ZERO_CHECK.vcxproj]
error MSB4018:    at Microsoft.Build.Tasks.Touch.TouchFile(String file, DateTime dt, FileExists fileExists, FileCreate fileCreate, GetAttributes fileGetAttributes, SetAttributes fileSetAttributes, SetLastAccessTime fileSetLastAccessTime, SetLastWriteTime fileSetLastWriteTime) [C:\Users\sftnight\build\roottest\ZERO_CHECK.vcxproj]
error MSB4018:    at Microsoft.Build.Tasks.Touch.ExecuteImpl(FileExists fileExists, FileCreate fileCreate, GetAttributes fileGetAttributes, SetAttributes fileSetAttributes, SetLastAccessTime fileSetLastAccessTime, SetLastWriteTime fileSetLastWriteTime) [C:\Users\sftnight\build\roottest\ZERO_CHECK.vcxproj]
error MSB4018:    at Microsoft.Build.Tasks.Touch.Execute() [C:\Users\sftnight\build\roottest\ZERO_CHECK.vcxproj]
error MSB4018:    at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute() [C:\Users\sftnight\build\roottest\ZERO_CHECK.vcxproj]
error MSB4018:    at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext() [C:\Users\sftnight\build\roottest\ZERO_CHECK.vcxproj]
```