### PR TITLE
Fix several CI failures on Windows

### DIFF
--- a/root/meta/autoloading/headerParsingOnDemand/CMakeLists.txt
+++ b/root/meta/autoloading/headerParsingOnDemand/CMakeLists.txt
@@ -6,18 +6,22 @@
 # system will complain at startup, making the test fail. Clearly for backwards
 # compatibility reasons the current behaviour should be preserved :)
 
-ROOTTEST_GENERATE_REFLEX_DICTIONARY(FullheaderParsingOnDemand
-                                    FullheaderParsingOnDemand.h
-                                    SELECTION FullheaderParsingOnDemand_selection.xml
-                                    LIBNAME libFullheaderParsingOnDemand_dictrflx
-                                    NO_ROOTMAP)
+# disable tests which are failing on Windows because of their PATH being too long
+# (>260 characters) when run in the CI (Jenkins)
+if(NOT MSVC OR win_broken_tests)
+  ROOTTEST_GENERATE_REFLEX_DICTIONARY(FullheaderParsingOnDemand
+                                      FullheaderParsingOnDemand.h
+                                      SELECTION FullheaderParsingOnDemand_selection.xml
+                                      LIBNAME libFullheaderParsingOnDemand_dictrflx
+                                      NO_ROOTMAP)
 
-ROOTTEST_ADD_TEST(runFullheaderParsingOnDemand
-                  COPY_TO_BUILDDIR headerParsingOnDemand.rootmap
-                  MACRO runFullheaderParsingOnDemand.C
-                  OUTREF headerParsingOnDemand.ref
-                  OUTCNV FullheaderParsingOnDemand_convert.sh
-                  DEPENDS ${GENERATE_REFLEX_TEST})
+  ROOTTEST_ADD_TEST(runFullheaderParsingOnDemand
+                    COPY_TO_BUILDDIR headerParsingOnDemand.rootmap
+                    MACRO runFullheaderParsingOnDemand.C
+                    OUTREF headerParsingOnDemand.ref
+                    OUTCNV FullheaderParsingOnDemand_convert.sh
+                    DEPENDS ${GENERATE_REFLEX_TEST})
+endif()
 
 ROOTTEST_GENERATE_REFLEX_DICTIONARY(complexTypedefs
                                     complexTypedefs.h

--- a/root/meta/genreflex/noStreamer_noInputOperator/CMakeLists.txt
+++ b/root/meta/genreflex/noStreamer_noInputOperator/CMakeLists.txt
@@ -1,3 +1,7 @@
+# disable tests which are failing on Windows because of their PATH being too long
+# (>260 characters) when run in the CI (Jenkins)
+if(NOT MSVC OR win_broken_tests)
+
 ROOTTEST_ADD_TESTDIRS()
 
 # ------------------------------------------------------------------------------
@@ -42,3 +46,5 @@ ROOTTEST_GENERATE_REFLEX_DICTIONARY(noInputOperator_rflx foo_custom_input_operat
 
 #   noInputOperator = false
 ROOTTEST_GENERATE_REFLEX_DICTIONARY(noInputOperator_false_rflx foo_custom_input_operator.h SELECTION noInputOperator_false_selection.xml NO_ROOTMAP)
+
+endif()

--- a/root/tree/cloning/CMakeLists.txt
+++ b/root/tree/cloning/CMakeLists.txt
@@ -59,7 +59,7 @@ if(NOT TARGET eventexe)
 
 else()
    if(MSVC)
-      set(RootExeOptions -e "gSystem->Load(\"${ROOTSYS}/test/Release/libEvent\")")
+      set(RootExeOptions -e "gSystem->Load(\"${ROOTSYS}/test/$<CONFIG>/libEvent\")")
    else()
       set(RootExeOptions -e "gSystem->Load(\"../test/libEvent\")")
 


### PR DESCRIPTION
- use the proper `$<CONFIG>` value instead of `Release`
- disable several tests which are failing because of their PATH being too long (>260 characters) when running in Jenkins