### PR TITLE
Prefer ROOT::Lib to Lib when linking some tests

### DIFF
--- a/root/meta/CMakeLists.txt
+++ b/root/meta/CMakeLists.txt
@@ -23,7 +23,7 @@ ROOTTEST_ADD_TEST(execpragmasTest
                   MACRO execpragmasTest.C+
                   OUTREF execpragmasTest.ref)
 
-ROOTTEST_GENERATE_EXECUTABLE(loadernotapp loadernotapp.cxx LIBRARIES Core Hist)
+ROOTTEST_GENERATE_EXECUTABLE(loadernotapp loadernotapp.cxx LIBRARIES ROOT::Core ROOT::Hist)
 
 ROOTTEST_ADD_TEST(loadernotapp
                   EXEC ${CMAKE_CURRENT_BINARY_DIR}/loadernotapp

--- a/root/multicore/CMakeLists.txt
+++ b/root/multicore/CMakeLists.txt
@@ -50,7 +50,7 @@ else()
 endif()
 
 if(NOT MSVC OR win_broken_tests)
-  ROOTTEST_GENERATE_EXECUTABLE(processExecutorH1Test tProcessExecutorH1Test.cpp COMPILE_FLAGS ${PROCESSOREXECUTORH1TEST_EXE_COMPILE_FLAGS} LIBRARIES MultiProc Core Net TreePlayer Tree RIO Hist Gpad Graf)
+  ROOTTEST_GENERATE_EXECUTABLE(processExecutorH1Test tProcessExecutorH1Test.cpp COMPILE_FLAGS ${PROCESSOREXECUTORH1TEST_EXE_COMPILE_FLAGS} LIBRARIES ROOT::MultiProc ROOT::Core ROOT::Net ROOT::TreePlayer ROOT::Tree ROOT::RIO ROOT::Hist ROOT::Gpad ROOT::Graf)
 
   ROOTTEST_ADD_TEST(processExecutorH1Test
                     EXEC ${CMAKE_CURRENT_BINARY_DIR}/processExecutorH1Test


### PR DESCRIPTION
The new spelling ensures transitive dependencies are brought in.