### PR TITLE
[MultiProc] Set ROOT to batch mode before using TProcessExecutor

### DIFF
--- a/root/multicore/tExecutorMP.cxx
+++ b/root/multicore/tExecutorMP.cxx
@@ -10,5 +10,8 @@ int main()
       return 1;
    }
 
+   // On MacOS, Cocoa spawns threads. That's very bad for TProcessExecutor's `fork`:
+   // forking a multi-thread program can easily break, see e.g. `man 2 fork`.
+   gROOT->SetBatch(kTRUE);
    return ExecutorTest(ex);
 }


### PR DESCRIPTION
On MacOS, Cocoa spawns threads. That's very bad for TProcessExecutor's `fork`:
forking a multi-thread program can easily break, see e.g. `man 2 fork`.
Setting ROOT to batch mode works around the issue.

I had missed this test in the previous pass :/