### PR TITLE
Remove usage of deprecated SetMaxTasksPerFilePerWorker

### DIFF
--- a/root/multicore/tp_process_imt.cpp
+++ b/root/multicore/tp_process_imt.cpp
@@ -59,7 +59,7 @@ std::tuple<int,std::string,std::string,std::string,int> parseOptions(int argc, c
 int main(int argc, char** argv) {
 
   // We do not want to limit the number of tasks for this particular test:
-  ROOT::TTreeProcessorMT::SetMaxTasksPerFilePerWorker(1024);
+  ROOT::TTreeProcessorMT::SetTasksPerWorkerHint(1024);
 
   auto options = parseOptions(argc,argv);
   const int kNThreads = std::get<0>(options);


### PR DESCRIPTION
Fixes the test after the changes in https://github.com/root-project/root/pull/7106