### PR TITLE
Fix several issues with roottest on Windows

### DIFF
--- a/root/io/stdarray/CMakeLists.txt
+++ b/root/io/stdarray/CMakeLists.txt
@@ -72,7 +72,8 @@ ROOTTEST_ADD_TEST(modelReadDict2TFile
                   MACRO  modelReadDict2.C
                   MACROARG "\"model.root\""
                   OUTREF modelReadDict2.ref
-                  DEPENDS aclicModelWrite)
+                  DEPENDS aclicModelWrite
+                  POSTCMD ${CMAKE_COMMAND} -E remove modelForReadDict2_cpp.rootmap)
 
 # ROOTTEST_ADD_TEST(modelReadDict2TXMLFile
 #                   MACRO  modelReadDict2.C
@@ -81,29 +82,29 @@ ROOTTEST_ADD_TEST(modelReadDict2TFile
 #                   DEPENDS aclicModelWrite)
 
 # The dependency is there not to compile the macros simultaneously
-if(NOT MSVC OR win_broken_tests)
-    ROOTTEST_ADD_TEST(modelReadDictTFile
-                      MACRO  modelReadDict.C+
-                      MACROARG "\"model.root\""
-                      OUTREF modelReadDict.ref
-                      DEPENDS modelReadDictTXMLFile)
+ROOTTEST_ADD_TEST(modelReadDictTFile
+                  MACRO  modelReadDict.C+
+                  MACROARG "\"model.root\""
+                  OUTREF modelReadDict.ref
+                  DEPENDS modelReadDictTXMLFile
+                  POSTCMD ${CMAKE_COMMAND} -E remove modelReadDict_C.rootmap)
 
-    ROOTTEST_ADD_TEST(modelReadDictTXMLFile
-                      MACRO  modelReadDict.C+
-                      MACROARG "\"model.xml\""
-                      OUTREF modelReadDict.ref
-                      DEPENDS aclicModelWrite)
+ROOTTEST_ADD_TEST(modelReadDictTXMLFile
+                  MACRO  modelReadDict.C+
+                  MACROARG "\"model.xml\""
+                  OUTREF modelReadDict.ref
+                  DEPENDS aclicModelWrite
+                  POSTCMD ${CMAKE_COMMAND} -E remove modelReadDict_C.rootmap)
 
-    ROOTTEST_ADD_TEST(modelReadNoDictTFile
-                      MACRO  modelReadNoDict.C
-                      MACROARG "\"model.root\""
-                      OUTREF modelReadNoDict.ref
-                      DEPENDS aclicModelWrite)
+ROOTTEST_ADD_TEST(modelReadNoDictTFile
+                  MACRO  modelReadNoDict.C
+                  MACROARG "\"model.root\""
+                  OUTREF modelReadNoDict.ref
+                  DEPENDS aclicModelWrite)
 
-    ROOTTEST_ADD_TEST(modelCheckValues
-                      MACRO modelCheckValues.C
-                      DEPENDS aclicModelWrite)
-endif()
+ROOTTEST_ADD_TEST(modelCheckValues
+                  MACRO modelCheckValues.C
+                  DEPENDS aclicModelWrite)
 
 # ROOTTEST_ADD_TEST(modelReadNoDictTXMLFile
 #                   MACRO  modelReadNoDict.C
@@ -112,7 +113,8 @@ endif()
 #                   DEPENDS aclicModelWrite)
 
 ROOTTEST_ADD_TEST(aclicModelWrite
-                  MACRO  aclicModelWrite.C+)
+                  MACRO  aclicModelWrite.C+
+                  POSTCMD ${CMAKE_COMMAND} -E remove aclicModelWrite_C.rootmap)
 
 ROOTTEST_ADD_TEST(aclic03
                   MACRO  aclic03.C+

--- a/root/math/smatrix/CMakeLists.txt
+++ b/root/math/smatrix/CMakeLists.txt
@@ -1,14 +1,19 @@
+ROOTTEST_COMPILE_MACRO(testInversion.cxx)
 ROOTTEST_ADD_TEST(testInversion
                 MACRO ${CMAKE_CURRENT_SOURCE_DIR}/testInversion.cxx+
-                ${WILLFAIL_ON_WIN32})
+                DEPENDS ${COMPILE_MACRO_TEST})
 
+ROOTTEST_COMPILE_MACRO(testKalman.cxx)
 ROOTTEST_ADD_TEST(testKalman
                 MACRO ${CMAKE_CURRENT_SOURCE_DIR}/testKalman.cxx+
-                ${WILLFAIL_ON_WIN32})
+                DEPENDS ${COMPILE_MACRO_TEST})
 
+ROOTTEST_COMPILE_MACRO(testOperations.cxx)
 ROOTTEST_ADD_TEST(testOperations
                 MACRO ${CMAKE_CURRENT_SOURCE_DIR}/testOperations.cxx+
-                ${WILLFAIL_ON_WIN32})
+                DEPENDS ${COMPILE_MACRO_TEST})
 
+ROOTTEST_COMPILE_MACRO(testSMatrix.cxx)
 ROOTTEST_ADD_TEST(testSMatrix
-                MACRO ${CMAKE_CURRENT_SOURCE_DIR}/testSMatrix.cxx+)
+                MACRO ${CMAKE_CURRENT_SOURCE_DIR}/testSMatrix.cxx+
+                DEPENDS ${COMPILE_MACRO_TEST})

--- a/root/meta/method/execReuseMethod.cxx
+++ b/root/meta/method/execReuseMethod.cxx
@@ -21,6 +21,10 @@ int execReuseMethod() {
       Error("reuseMethod", "The reuse is not working properly, TFunction for 'size' is no longer there or has moved.");
       return 4;
    }
+#ifdef R__WIN32
+   // clean-up the rootmap file to prevent error when running the test several times in a row
+   gSystem->Exec("del AutoDict_vector_TObject__*.rootmap > nul 2>&1");
+#endif
    return 0;
 }
 

--- a/root/meta/tclass/regression/CMakeLists.txt
+++ b/root/meta/tclass/regression/CMakeLists.txt
@@ -22,7 +22,8 @@ ROOTTEST_ADD_TEST(execROOT_6019
                   MACRO execROOT_6019.C
                   OUTREF execROOT_6019.ref)
 
+ROOTTEST_COMPILE_MACRO(execROOT_6277.cxx)
 ROOTTEST_ADD_TEST(execROOT_6277
                   MACRO execROOT_6277.cxx+
                   OUTREF execROOT_6277.ref
-                  ${WILLFAIL_ON_WIN32})
+                  DEPENDS ${COMPILE_MACRO_TEST})

--- a/root/tree/fastcloning/CMakeLists.txt
+++ b/root/tree/fastcloning/CMakeLists.txt
@@ -29,6 +29,7 @@ ROOTTEST_ADD_TEST(runabstract-datageneration
 ROOTTEST_ADD_TEST(runabstract-copy
                   MACRO runabstract.C
                   PRECMD ${ROOT_root_CMD} -b -q -l "${CMAKE_CURRENT_BINARY_DIR}/abstract.C+(1)"
+                  POSTCMD ${CMAKE_COMMAND} -E remove abstract_C.rootmap
                   OUTREF references/abstract${ref_suffix}
                   DEPENDS runabstract-datageneration)
 
@@ -60,8 +61,9 @@ ROOTTEST_ADD_TEST(runbadmix
 ROOTTEST_ADD_TEST(runSplitMismatch
                   COPY_TO_BUILDDIR runSplitMismatch.C
                   MACRO ${CMAKE_CURRENT_BINARY_DIR}/runSplitMismatch.C+
-                  ${WILLFAIL_ON_WIN32}
-                  OUTREF references/runSplitMismatch.ref)
+                  POSTCMD ${CMAKE_COMMAND} -E remove runSplitMismatch_C.rootmap
+                  OUTREF references/runSplitMismatch.ref
+                  DEPENDS runabstract-copy)
 
 ROOTTEST_ADD_TEST(make_CloneTree
                   MACRO make_CloneTree.C


### PR DESCRIPTION
 - delete several `.rootmap` files to prevent autoloading leading to this kind of error:
      Warning in <TInterpreter::ReadRootmapFile>: class  Top found in runSplitMismatch_C is already in abstract_C
      ./abstract.C:1:7: error: redefinition of 'Top'
   or this other kind:
      Error in <reuseMethod>: Found a dictionary for vector<TObject*>, state: 4
 - add several ROOTTEST_COMPILE_MACRO() to compile the macro beforehand, to prevent DLL access error

This allows to:
 - enable several previously disabled tests
 - remove several WILL_FAIL flags
 - might allow to run in parallel without the `--repeat until-pass:3` flag
 - allow to re-run roottest several times in a row (should fix incremental and PR builds)