### PR TITLE
Fix several issues with roottest on Windows

### DIFF
--- a/cmake/modules/RoottestMacros.cmake
+++ b/cmake/modules/RoottestMacros.cmake
@@ -49,6 +49,7 @@ function(ROOTTEST_ADD_TESTDIRS)
     # create .rootrc in binary directory to avoid filling $HOME/.root_hist
     file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${d}/.rootrc "
 Rint.History:  .root_hist
+ACLiC.LinkLibs:  1
 ")
   endforeach()
 

--- a/root/io/stdarray/CMakeLists.txt
+++ b/root/io/stdarray/CMakeLists.txt
@@ -81,29 +81,27 @@ ROOTTEST_ADD_TEST(modelReadDict2TFile
 #                   DEPENDS aclicModelWrite)
 
 # The dependency is there not to compile the macros simultaneously
-if(NOT MSVC OR win_broken_tests)
-    ROOTTEST_ADD_TEST(modelReadDictTFile
-                      MACRO  modelReadDict.C+
-                      MACROARG "\"model.root\""
-                      OUTREF modelReadDict.ref
-                      DEPENDS modelReadDictTXMLFile)
+ROOTTEST_ADD_TEST(modelReadDictTFile
+                  MACRO  modelReadDict.C+
+                  MACROARG "\"model.root\""
+                  OUTREF modelReadDict.ref
+                  DEPENDS modelReadDictTXMLFile)
 
-    ROOTTEST_ADD_TEST(modelReadDictTXMLFile
-                      MACRO  modelReadDict.C+
-                      MACROARG "\"model.xml\""
-                      OUTREF modelReadDict.ref
-                      DEPENDS aclicModelWrite)
+ROOTTEST_ADD_TEST(modelReadDictTXMLFile
+                  MACRO  modelReadDict.C+
+                  MACROARG "\"model.xml\""
+                  OUTREF modelReadDict.ref
+                  DEPENDS aclicModelWrite)
 
-    ROOTTEST_ADD_TEST(modelReadNoDictTFile
-                      MACRO  modelReadNoDict.C
-                      MACROARG "\"model.root\""
-                      OUTREF modelReadNoDict.ref
-                      DEPENDS aclicModelWrite)
+ROOTTEST_ADD_TEST(modelReadNoDictTFile
+                  MACRO  modelReadNoDict.C
+                  MACROARG "\"model.root\""
+                  OUTREF modelReadNoDict.ref
+                  DEPENDS aclicModelWrite)
 
-    ROOTTEST_ADD_TEST(modelCheckValues
-                      MACRO modelCheckValues.C
-                      DEPENDS aclicModelWrite)
-endif()
+ROOTTEST_ADD_TEST(modelCheckValues
+                  MACRO modelCheckValues.C
+                  DEPENDS aclicModelWrite)
 
 # ROOTTEST_ADD_TEST(modelReadNoDictTXMLFile
 #                   MACRO  modelReadNoDict.C

--- a/root/math/smatrix/CMakeLists.txt
+++ b/root/math/smatrix/CMakeLists.txt
@@ -1,14 +1,11 @@
 ROOTTEST_ADD_TEST(testInversion
-                MACRO ${CMAKE_CURRENT_SOURCE_DIR}/testInversion.cxx+
-                ${WILLFAIL_ON_WIN32})
+                MACRO ${CMAKE_CURRENT_SOURCE_DIR}/testInversion.cxx+)
 
 ROOTTEST_ADD_TEST(testKalman
-                MACRO ${CMAKE_CURRENT_SOURCE_DIR}/testKalman.cxx+
-                ${WILLFAIL_ON_WIN32})
+                MACRO ${CMAKE_CURRENT_SOURCE_DIR}/testKalman.cxx+)
 
 ROOTTEST_ADD_TEST(testOperations
-                MACRO ${CMAKE_CURRENT_SOURCE_DIR}/testOperations.cxx+
-                ${WILLFAIL_ON_WIN32})
+                MACRO ${CMAKE_CURRENT_SOURCE_DIR}/testOperations.cxx+)
 
 ROOTTEST_ADD_TEST(testSMatrix
                 MACRO ${CMAKE_CURRENT_SOURCE_DIR}/testSMatrix.cxx+)

--- a/root/meta/genreflex/ROOT-5594/CMakeLists.txt
+++ b/root/meta/genreflex/ROOT-5594/CMakeLists.txt
@@ -8,5 +8,4 @@
 ROOTTEST_ADD_TEST(5594
                   COMMAND ${ROOT_genreflex_CMD} ${CMAKE_CURRENT_SOURCE_DIR}/AliAODPid.h
                                -o  AliAODPid.cxx 
-                               --select=${CMAKE_CURRENT_SOURCE_DIR}/AliAODPid_selection.xml
-                               ${WILLFAIL_ON_WIN32})
+                               --select=${CMAKE_CURRENT_SOURCE_DIR}/AliAODPid_selection.xml)

--- a/root/meta/tclass/regression/CMakeLists.txt
+++ b/root/meta/tclass/regression/CMakeLists.txt
@@ -24,5 +24,4 @@ ROOTTEST_ADD_TEST(execROOT_6019
 
 ROOTTEST_ADD_TEST(execROOT_6277
                   MACRO execROOT_6277.cxx+
-                  OUTREF execROOT_6277.ref
-                  ${WILLFAIL_ON_WIN32})
+                  OUTREF execROOT_6277.ref)

--- a/root/tree/fastcloning/CMakeLists.txt
+++ b/root/tree/fastcloning/CMakeLists.txt
@@ -29,7 +29,7 @@ ROOTTEST_ADD_TEST(runabstract-datageneration
 ROOTTEST_ADD_TEST(runabstract-copy
                   MACRO runabstract.C
                   PRECMD ${ROOT_root_CMD} -b -q -l "${CMAKE_CURRENT_BINARY_DIR}/abstract.C+(1)"
-                  OUTREF references/abstract${ref_suffix}
+                  OUTREF references/abstract.ref
                   DEPENDS runabstract-datageneration)
 
 ROOTTEST_ADD_TEST(runfilemergererror
@@ -60,7 +60,6 @@ ROOTTEST_ADD_TEST(runbadmix
 ROOTTEST_ADD_TEST(runSplitMismatch
                   COPY_TO_BUILDDIR runSplitMismatch.C
                   MACRO ${CMAKE_CURRENT_BINARY_DIR}/runSplitMismatch.C+
-                  ${WILLFAIL_ON_WIN32}
                   OUTREF references/runSplitMismatch.ref)
 
 ROOTTEST_ADD_TEST(make_CloneTree


### PR DESCRIPTION
Add `ACLiC.LinkLibs:  1` in the `.rootrc` files for Windows (thanks Philippe). According to [the documentation](https://github.com/root-project/root/blob/master/config/rootrc.in#L384-L390), this is already the default for the other platforms, while the default is `3` for Windows.

This allows to:
 - enable several previously disabled tests
 - remove several `WILL_FAIL` flags
 - might allow to run in parallel without the `--repeat until-pass:3` flag
 - re-run roottest several times in a row (should fix incremental and PR builds)