### PR TITLE
Use the proper __FUNCSIG__ macro on Windows

### DIFF
--- a/cling/template/Singleton.h
+++ b/cling/template/Singleton.h
@@ -11,8 +11,8 @@ class Singleton
   static Singleton<T>* instance;
   Singleton() {}
  public:
-#if defined(__CINT__) || defined(_MSC_VER)
-  void DoIt(bool output) { if (output) cout<<"Singleton's DoIt for " << typeid(T).name() <<endl;}
+#ifdef _MSC_VER
+  void DoIt(bool output) { if (output) cout<<__FUNCSIG__<<endl;}
 #else
   void DoIt(bool output) { if (output) cout<<__PRETTY_FUNCTION__<<endl;}
 #endif


### PR DESCRIPTION
This fixes the following error:
```
1134: IncrementalExecutor::executeFunction: symbol '?__type_info_root_node@@3U__type_info_node@@A' unresolved while linking [cling interface function]!
1134: You are probably missing the definition of struct __type_info_node __type_info_root_node
1134: Maybe you need to load the corresponding shared library?
```