### PR TITLE
Add /build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ AutoDict_*.cxx
 
 # /
 /root_version
+/build
 
 # /cling/cintex/
 /cling/cintex/data.root


### PR DESCRIPTION
It is a fairly common pattern to create a build directory directly
inside small repositories. Adding the directory to .gitignore helps
tools ignore its contents.