### PR TITLE
backport for v6.24: Build option for distributed RDF tests that use pyspark 

### DIFF
--- a/python/distrdf/CMakeLists.txt
+++ b/python/distrdf/CMakeLists.txt
@@ -4,7 +4,7 @@
 # * pyspark is installed on that label for that python version
 if (ROOT_dataframe_FOUND AND
     ROOT_pyroot_FOUND AND
-    ROOT_dataframe_distpyspark_FOUND)
+    ROOT_test_distrdf_pyspark_FOUND)
 
 file(COPY test_headers DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY test_shared_libraries DESTINATION ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
Sibling PR to https://github.com/root-project/root/pull/7416