### PR TITLE
Add missing testRVecIO dependencies

### DIFF
--- a/root/math/vecops/CMakeLists.txt
+++ b/root/math/vecops/CMakeLists.txt
@@ -1,1 +1,1 @@
-ROOT_ADD_GTEST(testRVecIO testRVecIO.cxx LIBRARIES RIO TreePlayer ROOTVecOps Core Tree)
+ROOT_ADD_GTEST(testRVecIO testRVecIO.cxx LIBRARIES ROOT::RIO ROOT::TreePlayer ROOT::ROOTVecOps)

--- a/root/math/vecops/CMakeLists.txt
+++ b/root/math/vecops/CMakeLists.txt
@@ -1,1 +1,1 @@
-ROOT_ADD_GTEST(testRVecIO testRVecIO.cxx LIBRARIES RIO TreePlayer ROOTVecOps)
+ROOT_ADD_GTEST(testRVecIO testRVecIO.cxx LIBRARIES RIO TreePlayer ROOTVecOps Core Tree)


### PR DESCRIPTION
I found I needed to make this change to make the conda jenkins job build successfully.