### PR TITLE
Throw in those `std::` needed by dictionary not having `using namespa…

### DIFF
--- a/root/io/complex/classWithComplex.h
+++ b/root/io/complex/classWithComplex.h
@@ -5,12 +5,12 @@ class classWithComplex {
 public:
 classWithComplex(float re, float im, double red, double imd):fcf(re,im),fcd(red,imd){};
 classWithComplex():fcf(0,0),fcd(0,0){};
-complex<float> GetF() const {return fcf;}
-complex<double> GetD() const {return fcd;}
+  std::complex<float> GetF() const {return fcf;}
+  std::complex<double> GetD() const {return fcd;}
 
 private:
-complex<float> fcf;
-complex<double> fcd;
+  std::complex<float> fcf;
+  std::complex<double> fcd;
 
 };
 

--- a/root/io/cpp11Containers/commonUtils.h
+++ b/root/io/cpp11Containers/commonUtils.h
@@ -19,42 +19,42 @@ bool gVerboseComparison = false;
 
 template <class T>
 bool IsSame(const T& a, const T& b){
-   cout << "ERROR\n";
+   std::cout << "ERROR\n";
    return a==b;
 }
 
 template <>
 bool IsSame<>(const int& a, const int& b){
    if (a==b) return true;
-   cout << "Error numbers differ: " << a << " " << b << std::endl;
+   std::cout << "Error numbers differ: " << a << " " << b << std::endl;
    return false;
 }
 
 template <>
 bool IsSame<>(const Long64_t& a, const Long64_t& b){
    if (a==b) return true;
-   cout << "Error numbers differ: " << a << " " << b << std::endl;
+   std::cout << "Error numbers differ: " << a << " " << b << std::endl;
    return false;
 }
 
 template <>
 bool IsSame<>(const double& a, const double& b){
    if (a==b) return true;
-   cout << "Error numbers differ: " << a << " " << b << std::endl;
+   std::cout << "Error numbers differ: " << a << " " << b << std::endl;
    return false;
 }
 
 template <>
 bool IsSame<>(const float& a, const float& b){
    if (a==b) return true;
-   cout << "Error numbers differ: " << a << " " << b << std::endl;
+   std::cout << "Error numbers differ: " << a << " " << b << std::endl;
    return false;
 }
 
 template <class T>
 bool IsSame(const std::complex<T>& a, const std::complex<T>& b){
    if (a==b) return true;
-   cout << "Error complex numbers differ: " << a << " " << b << std::endl;
+   std::cout << "Error complex numbers differ: " << a << " " << b << std::endl;
    return false;
 }
 

--- a/root/io/cpp11Containers/forwardList.h
+++ b/root/io/cpp11Containers/forwardList.h
@@ -8,10 +8,10 @@
 #ifndef __COMPLEX__INSTANCES__
 #define __COMPLEX__INSTANCES__
 template<class T> class instantiator{
-std::forward_list<complex<T>> a1;
-std::list<complex<T>> a2;
-std::vector<complex<T>> a3;
-std::deque<complex<T>> a4;
+  std::forward_list<std::complex<T>> a1;
+  std::list<std::complex<T>> a2;
+  std::vector<std::complex<T>> a3;
+  std::deque<std::complex<T>> a4;
 };
 instantiator<float> i1;
 instantiator<double> i2;

--- a/root/io/rootcint/doubleconst/AlgClusterSRList.h
+++ b/root/io/rootcint/doubleconst/AlgClusterSRList.h
@@ -13,12 +13,12 @@ public:
   AlgClusterSRList();
   virtual ~AlgClusterSRList();
   std::map<const CandStripHandle*, Int_t> fNNeighbors;
-map<CandStripHandle *, double> fLikelihoods;
+  std::map<CandStripHandle *, double> fLikelihoods;
 
-map<CandStripHandle *,  AltCandStpProbHandle *> fLikelihoods2;
+  std::map<CandStripHandle *,  AltCandStpProbHandle *> fLikelihoods2;
 
 
-ClassDef(AlgClusterSRList,1)                // ClusterSRList Algorithm Class
+  ClassDef(AlgClusterSRList,1)                // ClusterSRList Algorithm Class
 };
 
 #endif                                                 // ALGCLUSTERSRLIST_H

--- a/root/io/uniquePointer/classes3.h
+++ b/root/io/uniquePointer/classes3.h
@@ -5,8 +5,8 @@
 #include <map>
 
 class Class01{
-   vector<unique_ptr<int>> a0;
-   vector<unique_ptr<double>> a1;
+   std::vector<std::unique_ptr<int>> a0;
+   std::vector<std::unique_ptr<double>> a1;
 };
 
 class  TrackingRegion{};
@@ -17,19 +17,19 @@ namespace edm {
 }
 
 namespace DummyNS {
-   vector<unique_ptr<int>> a0;
-   vector<unique_ptr<double>> a1;
-   vector<list<double>*> a2;
-   set<vector<unique_ptr<int>>> a3;
-   map<char, vector<unique_ptr<list<double>>>> a4;
-   set<vector<unique_ptr<Class01>>> a5;
-   map<char, vector<unique_ptr<list<Class01>>>> a6;
-   set<vector<unique_ptr<double>>> a7;
-   set<vector<unique_ptr<Class01>>> a8;
-   map<char,unique_ptr<list<Class01>>> a9;
-   vector<unique_ptr<TrackingRegion>> a10;
+   std::vector<std::unique_ptr<int>> a0;
+   std::vector<std::unique_ptr<double>> a1;
+   std::vector<std::list<double>*> a2;
+   std::set<std::vector<std::unique_ptr<int>>> a3;
+   std::map<char, std::vector<std::unique_ptr<std::list<double>>>> a4;
+   std::set<std::vector<std::unique_ptr<Class01>>> a5;
+   std::map<char, std::vector<std::unique_ptr<std::list<Class01>>>> a6;
+   std::set<std::vector<std::unique_ptr<double>>> a7;
+   std::set<std::vector<std::unique_ptr<Class01>>> a8;
+   std::map<char,std::unique_ptr<std::list<Class01>>> a9;
+   std::vector<std::unique_ptr<TrackingRegion>> a10;
 }
 
 class Class02{
-   map<char,unique_ptr<list<Class01>>> a9;
+   std::map<char,std::unique_ptr<std::list<Class01>>> a9;
 };

--- a/root/meta/MakeProject/stl_makeproject_test.h
+++ b/root/meta/MakeProject/stl_makeproject_test.h
@@ -3,6 +3,7 @@
 #define _stl_makeproject_test_h
 
 #include <bitset>
+#include <string>
 #include <vector>
 #include <unordered_map>
 #include <unordered_set>
@@ -16,8 +17,8 @@ private:
    std::bitset<16> foo = 0xfa2;
    std::vector<int> bar = {1,2};
    std::unordered_set<double> spam = {1,3,5,6,8};
-   std::unordered_map<int,string> eggs = {{2,"two"},{4,"four"}};
-   std::unordered_multimap<string,TH1D> strange = {{"one",TH1D("","one",11,0,10)},
+   std::unordered_map<int,std::string> eggs = {{2,"two"},{4,"four"}};
+   std::unordered_multimap<std::string,TH1D> strange = {{"one",TH1D("","one",11,0,10)},
                                                    {"one",TH1D("","oneBis",100,0,10)},
                                                    {"two",TH1D("","two",123,0,10)}};
 

--- a/root/meta/genreflex/iorules/DataModelV2genreflex.h
+++ b/root/meta/genreflex/iorules/DataModelV2genreflex.h
@@ -28,17 +28,17 @@ protected:
    }
 
    void Print() {
-      cout << "ACache::x " << GetX() << endl;
-      cout << "ACache::y " << GetY() << endl;
-      cout << "ACache::z " << GetZ() << endl;
-      cout << "ACache::c " << c << endl;
-      cout << "ACache::fN    " << fN << endl;
-      //cout << "ACache::fArray" << (void*)fArray << endl;
+      std::cout << "ACache::x " << GetX() << std::endl;
+      std::cout << "ACache::y " << GetY() << std::endl;
+      std::cout << "ACache::z " << GetZ() << std::endl;
+      std::cout << "ACache::c " << c << std::endl;
+      std::cout << "ACache::fN    " << fN << std::endl;
+      //std::cout << "ACache::fArray" << (void*)fArray << std::endl;
       if (fArray) for(int i = 0; i < fN; ++i) { 
-         cout << "ACache::fArray["<<i<<"] "<< (short)fArray[i] << endl;
+         std::cout << "ACache::fArray["<<i<<"] "<< (short)fArray[i] << std::endl;
       }
       for(unsigned int j = 0; j < sizeof(fValues) / sizeof(fValues[0]); ++j) { 
-         cout << "ACache::fValues["<<j<<"] "<< fValues[j] << endl;
+         std::cout << "ACache::fValues["<<j<<"] "<< fValues[j] << std::endl;
          
       }
    }

--- a/root/meta/genreflex/stlPatternSelection.h
+++ b/root/meta/genreflex/stlPatternSelection.h
@@ -1,6 +1,7 @@
 #include <map>
+#include <string>
 
-std::map<string, bool> a1;
+std::map<std::string, bool> a1;
 std::map<char, bool> a2;
 std::map<const char*, bool> a3;
 std::map<int, bool> a11;
@@ -10,7 +11,7 @@ std::map<double, bool> b12;
 std::map<double, const double*> b22;
 std::map<double, unsigned long int> b32;
 
-std::multimap<string, bool> a12;
+std::multimap<std::string, bool> a12;
 std::multimap<char, bool> a22;
 std::multimap<const char*, bool> a32;
 std::multimap<int, bool> a112;


### PR DESCRIPTION
…ce std` anymore.

(cherry picked from commit fa9abaf531d0a1a3fea4a4b8c7994cc74cfdab6b)