### PR TITLE
[DF] Fix test_nested_rvec_snapshot on Windows

### DIFF
--- a/root/dataframe/test_nested_rvec_snapshot.C
+++ b/root/dataframe/test_nested_rvec_snapshot.C
@@ -1,5 +1,6 @@
 #include <ROOT/RDataFrame.hxx>
 #include <ROOT/RVec.hxx>
+#include <TSystem.h>
 using namespace ROOT::VecOps;
 
 struct TwoInts {
@@ -44,12 +45,18 @@ void test_nested_rvec_snapshot()
          {"vv", "vvv", "vvti"});
    };
 
-   // compiled
-   auto out_df1 =
-      df.Snapshot<RVec<RVec<int>>, RVec<RVec<RVec<int>>>, RVec<RVec<TwoInts>>>("t", fname, {"vv", "vvv", "vvti"});
-   check(*out_df1);
+   {
+      // compiled
+      auto out_df1 =
+         df.Snapshot<RVec<RVec<int>>, RVec<RVec<RVec<int>>>, RVec<RVec<TwoInts>>>("t", fname, {"vv", "vvv", "vvti"});
+      check(*out_df1);
+   }
 
-   // jitted
-   auto out_df2 = df.Snapshot("t", fname, {"vv", "vvv", "vvti"});
-   check(*out_df2);
+   {
+      // jitted
+      auto out_df2 = df.Snapshot("t", fname, {"vv", "vvv", "vvti"});
+      check(*out_df2);
+   }
+
+   gSystem->Unlink(fname);
 }


### PR DESCRIPTION
On Windows it is not allowed to delete (or, in this case, "RECREATE")
a file while it is still open. We now enclose each Snapshot call in
its own scope so the file is closed before being recreated.