### PR TITLE
Do not overwrite ROOTSYS if set from "outside":

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
 
 project(roottest)
 
-# Use ${ROOTSYS} environment variable to search for ROOT.
-# This may be set by sourcing thisroot.sh from an installation.
-if(DEFINED ENV{ROOTSYS})
+# If no explicit ROOTSYS is set, use ${ROOTSYS} environment variable to search
+# for ROOT. This may be set by sourcing thisroot.sh from an installation.
+if(NOT DEFINED ROOTSYS AND DEFINED ENV{ROOTSYS})
   file(TO_CMAKE_PATH $ENV{ROOTSYS} ROOTSYS)
   list(INSERT CMAKE_PREFIX_PATH 0 ${ROOTSYS})
 endif()


### PR DESCRIPTION
This helps e.g. with https://github.com/root-project/root/issues/7081
as *if* roottest is configures with -DROOTSYS, that will be honored
instead of taking whatever the env var $ROOTSYS points to.