### PR TITLE
Fix building roottest against already installed ROOT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ endif()
 
 find_package(ROOT REQUIRED CONFIG)
 
+if(NOT DEFINED PYTHON_EXECUTABLE)
+  find_package(PythonInterp ${ROOT_PYTHON_VERSION} REQUIRED QUIET)
+endif()
+
 if(MSVC)
 
   set(libsuffix .dll)
@@ -178,10 +182,6 @@ endif()
 # Setup environment.
 set(ROOTTEST_ENV_PATH ${ROOT_BINDIR})
 if(MSVC)
-  if(NOT PYTHON_EXECUTABLE_Development_Main) # Should not happen!
-    # FIXME: Temporary workaround until standalone roottest is properly fixed
-    set(PYTHON_EXECUTABLE_Development_Main ${PYTHON_EXECUTABLE})
-  endif()
   set(ROOTTEST_ENV_PYTHONPATH ${ROOT_BINDIR})
 else()
   set(ROOTTEST_ENV_PYTHONPATH ${ROOT_LIBRARY_DIR})

--- a/cmake/modules/RoottestMacros.cmake
+++ b/cmake/modules/RoottestMacros.cmake
@@ -576,7 +576,7 @@ macro(ROOTTEST_SETUP_MACROTEST)
   # Add python script to CTest.
   elseif(ARG_MACRO MATCHES "[.]py")
     get_filename_component(realfp ${ARG_MACRO} REALPATH)
-    set(command ${PYTHON_EXECUTABLE_Development_Main} ${realfp} ${PYROOT_EXTRAFLAGS})
+    set(command ${PYTHON_EXECUTABLE} ${realfp} ${PYROOT_EXTRAFLAGS})
 
   elseif(DEFINED ARG_MACRO)
     set(command ${root_cmd} ${ARG_MACRO})
@@ -612,7 +612,7 @@ macro(ROOTTEST_SETUP_EXECTEST)
 
   if(MSVC)
     if(${realexec} MATCHES "[.]py" AND NOT ${realexec} MATCHES "[.]exe")
-      set(realexec ${PYTHON_EXECUTABLE_Development_Main} ${realexec})
+      set(realexec ${PYTHON_EXECUTABLE} ${realexec})
     else()
       set(realexec ${realexec})
     endif()
@@ -1121,7 +1121,7 @@ function(find_python_module module)
       endif()
       # A module's location is usually a directory, but for binary modules
       # it's a .so file.
-      execute_process(COMMAND "${PYTHON_EXECUTABLE_Development_Main}" "-c"
+      execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
          "import re, ${module}; print(re.compile('/__init__.py.*').sub('',${module}.__file__))"
          RESULT_VARIABLE _${module}_status
          OUTPUT_VARIABLE _${module}_location

--- a/python/JupyROOT/CMakeLists.txt
+++ b/python/JupyROOT/CMakeLists.txt
@@ -26,7 +26,7 @@ foreach(pyfile ${pyfiles})
   get_filename_component(SHORTPYFILE ${pyfile} NAME_WE)
   if (NOT ${SHORTPYFILE} STREQUAL "__init__")
     ROOTTEST_ADD_TEST(${SHORTPYFILE}_doctest
-                      COMMAND ${PYTHON_EXECUTABLE_Development_Main} ${DOCTEST_LAUNCHER} ${pyfile})
+                      COMMAND ${PYTHON_EXECUTABLE} ${DOCTEST_LAUNCHER} ${pyfile})
   endif()
 endforeach()
 
@@ -35,7 +35,7 @@ foreach(NOTEBOOK ${NOTEBOOKS})
   get_filename_component(NOTEBOOKBASE ${NOTEBOOK} NAME_WE)
   ROOTTEST_ADD_TEST(${NOTEBOOKBASE}_notebook
                     COPY_TO_BUILDDIR ${NOTEBOOK}
-                    COMMAND ${PYTHON_EXECUTABLE_Development_Main} ${NBDIFFUTIL} ${NOTEBOOK}
+                    COMMAND ${PYTHON_EXECUTABLE} ${NBDIFFUTIL} ${NOTEBOOK}
                     RUN_SERIAL)
 endforeach()
 
@@ -45,7 +45,7 @@ if(ROOT_imt_FOUND)
   get_filename_component(NOTEBOOKBASE ${IMT_NB} NAME_WE)
   ROOTTEST_ADD_TEST(${NOTEBOOKBASE}_notebook
                     COPY_TO_BUILDDIR ${IMT_NB}
-                    COMMAND ${PYTHON_EXECUTABLE_Development_Main} ${NBDIFFUTIL} ${IMT_NB} "OFF"
+                    COMMAND ${PYTHON_EXECUTABLE} ${NBDIFFUTIL} ${IMT_NB} "OFF"
                     RUN_SERIAL)
 endif()
 

--- a/python/cmdLineUtils/CMakeLists.txt
+++ b/python/cmdLineUtils/CMakeLists.txt
@@ -6,7 +6,7 @@ configure_file(multipleNameCycles.root . COPYONLY)
 configure_file(MakeNameCyclesRootmvInput.C . COPYONLY)
 
 ############################## PATTERN TESTS ############################
-set (TESTPATTERN_EXE ${PYTHON_EXECUTABLE_Development_Main} ${CMAKE_CURRENT_SOURCE_DIR}/testPatternToFileNameAndPathSplitList.py)
+set (TESTPATTERN_EXE ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/testPatternToFileNameAndPathSplitList.py)
 ROOTTEST_ADD_TEST(SimplePattern1
                   COMMAND ${TESTPATTERN_EXE} test.root
                   OUTREF SimplePattern.ref)
@@ -23,7 +23,7 @@ ROOTTEST_ADD_TEST(SimplePattern3
 if(MSVC)
     # the command line tools works fine in the Windows command prompt but
     # not from CTest, so let's add Python.exe and the .py file extension
-    set(TOOLS_PREFIX ${PYTHON_EXECUTABLE_Development_Main} ${ROOTSYS}/bin)
+    set(TOOLS_PREFIX ${PYTHON_EXECUTABLE} ${ROOTSYS}/bin)
     set(pyext .py)
 else()
     set(TOOLS_PREFIX ${ROOTSYS}/bin)


### PR DESCRIPTION
The variable `PYTHON_EXECUTABLE_Development_Main` is only available when roottest is being built as a subdirectory within a ROOT build. Therefore, to let roottest work again in an independent build, we need to use `PYTHON_EXECUTABLE`, and rely on ROOT's exported version of Python to just find and use the same Python version in roottest.

Ideally, we should add in ROOT a call to `find_dependency` to match this call to `find_package(Python ...)` here, so that even this is not necessary in the future.