### PR TITLE
Always link explicitly, even if we want (no) rootmap.

### DIFF
--- a/cling/dict/.rootrc
+++ b/cling/dict/.rootrc
@@ -1,2 +1,2 @@
 Rint.History:            .root_hist
-ACLiC.LinkLibs: 0
+ACLiC.LinkLibs: 1

--- a/cling/dict/ROOT-8739/.rootrc
+++ b/cling/dict/ROOT-8739/.rootrc
@@ -1,2 +1,2 @@
 Rint.History:            .root_hist
-ACLiC.LinkLibs: 0
+ACLiC.LinkLibs: 1

--- a/root/io/alloc/.rootrc
+++ b/root/io/alloc/.rootrc
@@ -1,2 +1,2 @@
 Rint.History:            .root_hist
-ACLiC.LinkLibs:  0
+ACLiC.LinkLibs:  1

--- a/root/io/datamodelevolution/misc/.rootrc
+++ b/root/io/datamodelevolution/misc/.rootrc
@@ -1,2 +1,2 @@
 Rint.History:            .root_hist
-ACLiC.LinkLibs: 0
+ACLiC.LinkLibs: 1

--- a/root/io/double32/.rootrc
+++ b/root/io/double32/.rootrc
@@ -1,2 +1,2 @@
 Rint.History:            .root_hist
-ACLiC.LinkLibs: 0
+ACLiC.LinkLibs: 1

--- a/root/io/emulated/.rootrc
+++ b/root/io/emulated/.rootrc
@@ -1,2 +1,2 @@
-ACLiC.LinkLibs: 0
+ACLiC.LinkLibs: 1
 Rint.History:            .root_hist

--- a/root/io/evolution/array/.rootrc
+++ b/root/io/evolution/array/.rootrc
@@ -1,2 +1,2 @@
 Rint.History:            .root_hist
-ACLiC.LinkLibs: 0
+ACLiC.LinkLibs: 1

--- a/root/io/perf/slowreading/.rootrc
+++ b/root/io/perf/slowreading/.rootrc
@@ -1,2 +1,2 @@
 Rint.History:            .root_hist
-ACLiC.LinkLibs:  0
+ACLiC.LinkLibs:  1

--- a/root/io/withoutDictionaries/.rootrc
+++ b/root/io/withoutDictionaries/.rootrc
@@ -1,2 +1,2 @@
 Rint.History:            .root_hist
-ACLiC.LinkLibs:      2
+ACLiC.LinkLibs:      3

--- a/root/tree/selector/.rootrc
+++ b/root/tree/selector/.rootrc
@@ -1,2 +1,2 @@
-ACLiC.LinkLibs: 0
+ACLiC.LinkLibs: 1
 Rint.History:            .root_hist


### PR DESCRIPTION
The ": 0" lines were added reasoning "we want no rootmaps" (but that doesn't mean we also need to disable explicit linking!)
The ": 2" lines were added to *force* rootmaps (but that doesn't mean we also need to disable explicit linking!)

https://github.com/root-project/root/pull/8017 needs this.