### PR TITLE
Some more Apple M1 roottest fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,13 +152,14 @@ set(compression_default "zlib" CACHE STRING "" FORCE)
 get_filename_component(ROOT_LIBRARY_DIR "${ROOTSYS}/lib" ABSOLUTE)
 
 # Detect bitness.
-if(CMAKE_SYSTEM_PROCESSOR MATCHES amd64.*|x86_64.*|aarch64.*|ppc64.*
-   OR (CMAKE_VERSION VERSION_LESS 3.0 AND CMAKE_SYSTEM_NAME STREQUAL Darwin) )
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
   set(64BIT 1)
   message("-- Check for bitness: Found 64 bit architecture.")
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES i686.*|i386.*|x86.*)
+elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
   set(32BIT 1)
   message("-- Check for bitness: Found 32 bit architecture.")
+else()
+  message(FATAL_ERROR "-- Check for bitness: no support for ${CMAKE_SIZEOF_VOID_P}*8 bit processors.")
 endif()
 
 if (MSVC)

--- a/cling/exception/CMakeLists.txt
+++ b/cling/exception/CMakeLists.txt
@@ -8,7 +8,9 @@ if(NOT MSVC OR win_broken_tests)
   endif()
 endif()
 
-ROOTTEST_ADD_TEST(nullderef-e
-                  COMMAND ${ROOT_root_CMD} -l -b -q -e "int*p=nullptr" -e "*p"
-                  PASSRC 1
-                  LABELS roottest regression cling)
+if(NOT (APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES arm64) OR M1_BROKEN_TESTS)
+  ROOTTEST_ADD_TEST(nullderef-e
+                    COMMAND ${ROOT_root_CMD} -l -b -q -e "int*p=nullptr" -e "*p"
+                    PASSRC 1
+                    LABELS roottest regression cling)
+endif()

--- a/root/dataframe/CMakeLists.txt
+++ b/root/dataframe/CMakeLists.txt
@@ -26,11 +26,14 @@ ROOTTEST_ADD_TEST(test_trainCache
                   COPY_TO_BUILDDIR bigFile.root
                   MACRO test_trainCache.C
                   OUTREF test_trainCache.ref)
-# ROOT-9628
-ROOTTEST_ADD_TEST(test_chainZombieFile
-                  COPY_TO_BUILDDIR input1.root input2.root
-                  ${WILLFAIL_ON_WIN32}
-                  MACRO test_chainZombieFile.C)
+
+if(NOT (APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES arm64) OR M1_BROKEN_TESTS)
+  # ROOT-9628
+  ROOTTEST_ADD_TEST(test_chainZombieFile
+                    COPY_TO_BUILDDIR input1.root input2.root
+                    ${WILLFAIL_ON_WIN32}
+                    MACRO test_chainZombieFile.C)
+endif()
 
 # ROOT-9366
 # We use this to write something like the FCC data model, dictionaries done with aclic
@@ -54,10 +57,12 @@ ROOTTEST_ADD_TEST(test_gdirectoryRestore
 ROOTTEST_ADD_TEST(templateRecursionLimit
                   MACRO test_templateRecursionLimit.C)
 
-ROOTTEST_ADD_TEST(missingBranches
-                  MACRO test_missingBranches.C
-                  ERRREF test_missingBranches.eref
-                  ${WILLFAIL_ON_WIN32})
+if(NOT (APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES arm64) OR M1_BROKEN_TESTS)
+  ROOTTEST_ADD_TEST(missingBranches
+                    MACRO test_missingBranches.C
+                    ERRREF test_missingBranches.eref
+                    ${WILLFAIL_ON_WIN32})
+endif()
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
 ROOTTEST_GENERATE_EXECUTABLE(test_hugeRDF test_hugeRDF.cxx


### PR DESCRIPTION
where evolution/runforeign was looking for "foreign.ref" because ROOTBITS was unset.