### PR TITLE
Allow to re-run dataframe-snapshot_copyaddresses (at least on Windows)

### DIFF
--- a/root/dataframe/CMakeLists.txt
+++ b/root/dataframe/CMakeLists.txt
@@ -224,4 +224,5 @@ ROOTTEST_ADD_TEST(test_progressiveCSV
 
 # need the '+' to autogenerate required dictionaries with ACLiC
 ROOTTEST_ADD_TEST(test_nested_rvec_snapshot MACRO test_nested_rvec_snapshot.C+)
-ROOTTEST_ADD_TEST(test_snapshot_copyaddresses MACRO test_snapshot_copyaddresses.C+)
+ROOTTEST_ADD_TEST(test_snapshot_copyaddresses MACRO test_snapshot_copyaddresses.C+
+                  PRECMD ${CMAKE_COMMAND}  -E remove test_snapshot_copyaddresses_out.root)


### PR DESCRIPTION
Fix the following issue when re-running the tests on Windows:
```
C:\Users\sftnight\build\RelWithDebInfo>ctest -C RelWithDebInfo -R copyaddresses
Test project C:/Users/sftnight/build/RelWithDebInfo
    Start 1346: roottest-root-dataframe-test_snapshot_copyaddresses
1/1 Test #1346: roottest-root-dataframe-test_snapshot_copyaddresses ...   Passed    4.03 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   5.27 sec

C:\Users\sftnight\build\RelWithDebInfo>ctest -C RelWithDebInfo -R copyaddresses
Test project C:/Users/sftnight/build/RelWithDebInfo
    Start 1346: roottest-root-dataframe-test_snapshot_copyaddresses
1/1 Test #1346: roottest-root-dataframe-test_snapshot_copyaddresses ...***Failed    3.96 sec

0% tests passed, 1 tests failed out of 1

Total Test time (real) =   5.15 sec

The following tests FAILED:
        1346 - roottest-root-dataframe-test_snapshot_copyaddresses (Failed)
Errors while running CTest

C:\Users\sftnight\build\RelWithDebInfo>
```