### PR TITLE
Remove all usages of ROOT's std::make_unique backport

### DIFF
--- a/root/roofitstats/vectorisedPDFs/VectorisedPDFTests.cxx
+++ b/root/roofitstats/vectorisedPDFs/VectorisedPDFTests.cxx
@@ -22,7 +22,6 @@
 #include "RooFitResult.h"
 #include "RooAbsRealLValue.h"
 #include "RooGaussian.h"
-#include "ROOT/RMakeUnique.hxx"
 #include "TCanvas.h"
 #include "RooPlot.h"
 #include "RooRandom.h"
@@ -30,6 +29,7 @@
 #include "Math/Util.h"
 #include "RooHelpers.h"
 
+#include <memory>
 #include <numeric>
 #include <ctime>
 #include <chrono>

--- a/root/roofitstats/vectorisedPDFs/VectorisedPDFTests.h
+++ b/root/roofitstats/vectorisedPDFs/VectorisedPDFTests.h
@@ -19,9 +19,10 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooFitResult.h"
-#include "ROOT/RMakeUnique.hxx"
 
 #include "gtest/gtest.h"
+
+#include <memory>
 
 class RooAbsPdf;
 


### PR DESCRIPTION
Now that we require C++14 we can use the make_unique provided by the STL.

Companion PR for https://github.com/root-project/root/pull/8601 .