### PR TITLE
Fix errors with std:c++17 on Windows

### DIFF
--- a/boost/functional.hpp
+++ b/boost/functional.hpp
@@ -16,6 +16,29 @@
 #include <boost/call_traits.hpp>
 #include <functional>
 
+#if defined(_MSC_VER) && __cplusplus > 201402L
+namespace std
+{
+    // std::unary_function and std::binary_function were both removed
+    // in C++17.
+
+    template <typename Arg1, typename Result>
+    struct unary_function
+    {
+        typedef Arg1 argument_type;
+        typedef Result result_type;
+    };
+
+    template <typename Arg1, typename Arg2, typename Result>
+    struct binary_function
+    {
+        typedef Arg1 first_argument_type;
+        typedef Arg2 second_argument_type;
+        typedef Result result_type;
+    };
+}
+#endif
+
 namespace boost
 {
 #ifndef BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION

--- a/root/meta/CMakeLists.txt
+++ b/root/meta/CMakeLists.txt
@@ -42,6 +42,7 @@ configure_file(typelist.v5.txt . COPYONLY)
 configure_file(typelist.v6.txt . COPYONLY)
 configure_file(typelist_win32.v5.txt . COPYONLY)
 configure_file(typelist_win32.v6.txt . COPYONLY)
+configure_file(typelist_win32.v6.cxx17.txt . COPYONLY)
 
 ROOTTEST_ADD_AUTOMACROS(DEPENDS ANSTmpltInt.C TmpltInt0.C TmpltInt1.C TmpltFloat.C
                                 TmpltNoSpec.C Event.cxx ${COMPILE_MACRO_TEST}

--- a/root/meta/execTypedefList.C
+++ b/root/meta/execTypedefList.C
@@ -135,7 +135,11 @@ int execTypedefList() {
 
 #ifdef _MSC_VER
    res = check_file("typelist_win32.v5.txt",348); if (res) return res;
-   res = check_file("typelist_win32.v6.txt",1420); if (res) return res;
+   #if __cplusplus > 201402L
+      res = check_file("typelist_win32.v6.cxx17.txt",1408); if (res) return res;
+   #else
+      res = check_file("typelist_win32.v6.txt",1420); if (res) return res;
+   #endif
 #else
    res = check_file("typelist.v5.txt",349); if (res) return res;
    res = check_file("typelist.v6.txt",1465); if (res) return res;

--- a/root/meta/naming/cmsExample01.h
+++ b/root/meta/naming/cmsExample01.h
@@ -11,6 +11,26 @@ namespace reco {
 #include <functional>
 #include <algorithm>
 
+#if defined(_MSC_VER) && __cplusplus > 201402L
+namespace std {
+   // std::unary_function and std::binary_function were both removed
+   // in C++17.
+
+   template <typename Arg1, typename Result>
+   struct unary_function {
+      typedef Arg1 argument_type;
+      typedef Result result_type;
+   };
+
+   template <typename Arg1, typename Arg2, typename Result>
+   struct binary_function {
+      typedef Arg1 first_argument_type;
+      typedef Arg2 second_argument_type;
+      typedef Result result_type;
+   };
+}
+#endif
+
 namespace edm {
    template<typename C, typename T, typename F> class RefVector;
    template<typename T> class RefToBaseVector;

--- a/root/meta/typelist_win32.v6.cxx17.txt
+++ b/root/meta/typelist_win32.v6.cxx17.txt
@@ -1,0 +1,1408 @@
+allocator<const double*>::const_pointer
+allocator<const double*>::const_reference
+allocator<const double*>::difference_type
+allocator<const double*>::pointer
+allocator<const double*>::reference
+allocator<const double*>::size_type
+allocator<const double*>::value_type
+allocator<TBranchSTL::ElementBranchHelper_t>::const_pointer
+allocator<TBranchSTL::ElementBranchHelper_t>::const_reference
+allocator<TBranchSTL::ElementBranchHelper_t>::difference_type
+allocator<TBranchSTL::ElementBranchHelper_t>::pointer
+allocator<TBranchSTL::ElementBranchHelper_t>::reference
+allocator<TBranchSTL::ElementBranchHelper_t>::size_type
+allocator<TBranchSTL::ElementBranchHelper_t>::value_type
+allocator<ROOT::TCollectionProxyInfo::EnvironBase*>::const_pointer
+allocator<ROOT::TCollectionProxyInfo::EnvironBase*>::const_reference
+allocator<ROOT::TCollectionProxyInfo::EnvironBase*>::difference_type
+allocator<ROOT::TCollectionProxyInfo::EnvironBase*>::pointer
+allocator<ROOT::TCollectionProxyInfo::EnvironBase*>::reference
+allocator<ROOT::TCollectionProxyInfo::EnvironBase*>::size_type
+allocator<ROOT::TCollectionProxyInfo::EnvironBase*>::value_type
+allocator<float>::const_pointer
+allocator<float>::const_reference
+allocator<float>::difference_type
+allocator<float>::pointer
+allocator<float>::reference
+allocator<float>::size_type
+allocator<float>::value_type
+allocator<TFitEditor::FuncParamData_t>::const_pointer
+allocator<TFitEditor::FuncParamData_t>::const_reference
+allocator<TFitEditor::FuncParamData_t>::difference_type
+allocator<TFitEditor::FuncParamData_t>::pointer
+allocator<TFitEditor::FuncParamData_t>::reference
+allocator<TFitEditor::FuncParamData_t>::size_type
+allocator<TFitEditor::FuncParamData_t>::value_type
+allocator<int>::const_pointer
+allocator<int>::const_reference
+allocator<int>::difference_type
+allocator<int>::pointer
+allocator<int>::reference
+allocator<int>::size_type
+allocator<int>::value_type
+allocator<Long64_t>::const_pointer
+allocator<Long64_t>::const_reference
+allocator<Long64_t>::difference_type
+allocator<Long64_t>::pointer
+allocator<Long64_t>::reference
+allocator<Long64_t>::size_type
+allocator<Long64_t>::value_type
+allocator<long>::const_pointer
+allocator<long>::const_reference
+allocator<long>::difference_type
+allocator<long>::pointer
+allocator<long>::reference
+allocator<long>::size_type
+allocator<long>::value_type
+allocator<map<double,vector<unsigned int> > >::const_pointer
+allocator<map<double,vector<unsigned int> > >::const_reference
+allocator<map<double,vector<unsigned int> > >::difference_type
+allocator<map<double,vector<unsigned int> > >::pointer
+allocator<map<double,vector<unsigned int> > >::reference
+allocator<map<double,vector<unsigned int> > >::size_type
+allocator<map<double,vector<unsigned int> > >::value_type
+allocator<pair<int,int> >::const_pointer
+allocator<pair<int,int> >::const_reference
+allocator<pair<int,int> >::difference_type
+allocator<pair<int,int> >::pointer
+allocator<pair<int,int> >::reference
+allocator<pair<int,int> >::size_type
+allocator<pair<int,int> >::value_type
+allocator<pair<TDSetElement*,TString> >::const_pointer
+allocator<pair<TDSetElement*,TString> >::const_reference
+allocator<pair<TDSetElement*,TString> >::difference_type
+allocator<pair<TDSetElement*,TString> >::pointer
+allocator<pair<TDSetElement*,TString> >::reference
+allocator<pair<TDSetElement*,TString> >::size_type
+allocator<pair<TDSetElement*,TString> >::value_type
+allocator<pair<TObject*const,TF1*> >::const_pointer
+allocator<pair<TObject*const,TF1*> >::const_reference
+allocator<pair<TObject*const,TF1*> >::difference_type
+allocator<pair<TObject*const,TF1*> >::pointer
+allocator<pair<TObject*const,TF1*> >::reference
+allocator<pair<TObject*const,TF1*> >::size_type
+allocator<pair<TObject*const,TF1*> >::value_type
+allocator<ROOT::Fit::ParameterSettings>::const_pointer
+allocator<ROOT::Fit::ParameterSettings>::const_reference
+allocator<ROOT::Fit::ParameterSettings>::difference_type
+allocator<ROOT::Fit::ParameterSettings>::pointer
+allocator<ROOT::Fit::ParameterSettings>::reference
+allocator<ROOT::Fit::ParameterSettings>::size_type
+allocator<ROOT::Fit::ParameterSettings>::value_type
+allocator<TProofDrawListOfGraphs::Point3D_t>::const_pointer
+allocator<TProofDrawListOfGraphs::Point3D_t>::const_reference
+allocator<TProofDrawListOfGraphs::Point3D_t>::difference_type
+allocator<TProofDrawListOfGraphs::Point3D_t>::pointer
+allocator<TProofDrawListOfGraphs::Point3D_t>::reference
+allocator<TProofDrawListOfGraphs::Point3D_t>::size_type
+allocator<TProofDrawListOfGraphs::Point3D_t>::value_type
+allocator<TProofDrawListOfPolyMarkers3D::Point4D_t>::const_pointer
+allocator<TProofDrawListOfPolyMarkers3D::Point4D_t>::const_reference
+allocator<TProofDrawListOfPolyMarkers3D::Point4D_t>::difference_type
+allocator<TProofDrawListOfPolyMarkers3D::Point4D_t>::pointer
+allocator<TProofDrawListOfPolyMarkers3D::Point4D_t>::reference
+allocator<TProofDrawListOfPolyMarkers3D::Point4D_t>::size_type
+allocator<TProofDrawListOfPolyMarkers3D::Point4D_t>::value_type
+allocator<short>::const_pointer
+allocator<short>::const_reference
+allocator<short>::difference_type
+allocator<short>::pointer
+allocator<short>::reference
+allocator<short>::size_type
+allocator<short>::value_type
+allocator<ROOT::Detail::TBranchProxy*>::const_pointer
+allocator<ROOT::Detail::TBranchProxy*>::const_reference
+allocator<ROOT::Detail::TBranchProxy*>::difference_type
+allocator<ROOT::Detail::TBranchProxy*>::pointer
+allocator<ROOT::Detail::TBranchProxy*>::reference
+allocator<ROOT::Detail::TBranchProxy*>::size_type
+allocator<ROOT::Detail::TBranchProxy*>::value_type
+allocator<TChainIndex::TChainIndexEntry>::const_pointer
+allocator<TChainIndex::TChainIndexEntry>::const_reference
+allocator<TChainIndex::TChainIndexEntry>::difference_type
+allocator<TChainIndex::TChainIndexEntry>::pointer
+allocator<TChainIndex::TChainIndexEntry>::reference
+allocator<TChainIndex::TChainIndexEntry>::size_type
+allocator<TChainIndex::TChainIndexEntry>::value_type
+allocator<TStreamerInfoActions::TConfiguredAction>::const_pointer
+allocator<TStreamerInfoActions::TConfiguredAction>::const_reference
+allocator<TStreamerInfoActions::TConfiguredAction>::difference_type
+allocator<TStreamerInfoActions::TConfiguredAction>::pointer
+allocator<TStreamerInfoActions::TConfiguredAction>::reference
+allocator<TStreamerInfoActions::TConfiguredAction>::size_type
+allocator<TStreamerInfoActions::TConfiguredAction>::value_type
+allocator<TF1*>::const_pointer
+allocator<TF1*>::const_reference
+allocator<TF1*>::difference_type
+allocator<TF1*>::pointer
+allocator<TF1*>::reference
+allocator<TF1*>::size_type
+allocator<TF1*>::value_type
+allocator<ROOT::Internal::TFriendProxy*>::const_pointer
+allocator<ROOT::Internal::TFriendProxy*>::const_reference
+allocator<ROOT::Internal::TFriendProxy*>::difference_type
+allocator<ROOT::Internal::TFriendProxy*>::pointer
+allocator<ROOT::Internal::TFriendProxy*>::reference
+allocator<ROOT::Internal::TFriendProxy*>::size_type
+allocator<ROOT::Internal::TFriendProxy*>::value_type
+allocator<TGListTreeItem*>::const_pointer
+allocator<TGListTreeItem*>::const_reference
+allocator<TGListTreeItem*>::difference_type
+allocator<TGListTreeItem*>::pointer
+allocator<TGListTreeItem*>::reference
+allocator<TGListTreeItem*>::size_type
+allocator<TGListTreeItem*>::value_type
+allocator<TGeoBoolNode::ThreadData_t*>::const_pointer
+allocator<TGeoBoolNode::ThreadData_t*>::const_reference
+allocator<TGeoBoolNode::ThreadData_t*>::difference_type
+allocator<TGeoBoolNode::ThreadData_t*>::pointer
+allocator<TGeoBoolNode::ThreadData_t*>::reference
+allocator<TGeoBoolNode::ThreadData_t*>::size_type
+allocator<TGeoBoolNode::ThreadData_t*>::value_type
+allocator<ROOT::Internal::TSchemaHelper>::const_pointer
+allocator<ROOT::Internal::TSchemaHelper>::const_reference
+allocator<ROOT::Internal::TSchemaHelper>::difference_type
+allocator<ROOT::Internal::TSchemaHelper>::pointer
+allocator<ROOT::Internal::TSchemaHelper>::reference
+allocator<ROOT::Internal::TSchemaHelper>::size_type
+allocator<ROOT::Internal::TSchemaHelper>::value_type
+allocator<TGenCollectionProxy::TStaging*>::const_pointer
+allocator<TGenCollectionProxy::TStaging*>::const_reference
+allocator<TGenCollectionProxy::TStaging*>::difference_type
+allocator<TGenCollectionProxy::TStaging*>::pointer
+allocator<TGenCollectionProxy::TStaging*>::reference
+allocator<TGenCollectionProxy::TStaging*>::size_type
+allocator<TGenCollectionProxy::TStaging*>::value_type
+allocator<TStreamerInfo*>::const_pointer
+allocator<TStreamerInfo*>::const_reference
+allocator<TStreamerInfo*>::difference_type
+allocator<TStreamerInfo*>::pointer
+allocator<TStreamerInfo*>::reference
+allocator<TStreamerInfo*>::size_type
+allocator<TStreamerInfo*>::value_type
+allocator<TString>::const_pointer
+allocator<TString>::const_reference
+allocator<TString>::difference_type
+allocator<TString>::pointer
+allocator<TString>::reference
+allocator<TString>::size_type
+allocator<TString>::value_type
+allocator<TThread*>::const_pointer
+allocator<TThread*>::const_reference
+allocator<TThread*>::difference_type
+allocator<TThread*>::pointer
+allocator<TThread*>::reference
+allocator<TThread*>::size_type
+allocator<TThread*>::value_type
+allocator<ROOT::Internal::TTreeReaderValueBase*>::const_pointer
+allocator<ROOT::Internal::TTreeReaderValueBase**>::const_pointer
+allocator<ROOT::Internal::TTreeReaderValueBase*>::const_reference
+allocator<ROOT::Internal::TTreeReaderValueBase**>::const_reference
+allocator<ROOT::Internal::TTreeReaderValueBase*>::difference_type
+allocator<ROOT::Internal::TTreeReaderValueBase**>::difference_type
+allocator<ROOT::Internal::TTreeReaderValueBase*>::pointer
+allocator<ROOT::Internal::TTreeReaderValueBase**>::pointer
+allocator<ROOT::Internal::TTreeReaderValueBase*>::reference
+allocator<ROOT::Internal::TTreeReaderValueBase**>::reference
+allocator<ROOT::Internal::TTreeReaderValueBase*>::size_type
+allocator<ROOT::Internal::TTreeReaderValueBase**>::size_type
+allocator<ROOT::Internal::TTreeReaderValueBase*>::value_type
+allocator<ROOT::Internal::TTreeReaderValueBase**>::value_type
+allocator<ULong64_t>::const_pointer
+allocator<ULong64_t>::const_reference
+allocator<ULong64_t>::difference_type
+allocator<ULong64_t>::pointer
+allocator<ULong64_t>::reference
+allocator<ULong64_t>::size_type
+allocator<ULong64_t>::value_type
+allocator<unsigned char>::const_pointer
+allocator<unsigned char>::const_reference
+allocator<unsigned char>::difference_type
+allocator<unsigned char>::pointer
+allocator<unsigned char>::reference
+allocator<unsigned char>::size_type
+allocator<unsigned char>::value_type
+allocator<unsigned long>::const_pointer
+allocator<unsigned long>::const_reference
+allocator<unsigned long>::difference_type
+allocator<unsigned long>::pointer
+allocator<unsigned long>::reference
+allocator<unsigned long>::size_type
+allocator<unsigned long>::value_type
+allocator<vector<double> >::const_pointer
+allocator<vector<double> >::const_reference
+allocator<vector<double> >::difference_type
+allocator<vector<double> >::pointer
+allocator<vector<double> >::reference
+allocator<vector<double> >::size_type
+allocator<vector<double> >::value_type
+allocator<vector<pair<bool,bool> > >::const_pointer
+allocator<vector<pair<bool,bool> > >::const_reference
+allocator<vector<pair<bool,bool> > >::difference_type
+allocator<vector<pair<bool,bool> > >::pointer
+allocator<vector<pair<bool,bool> > >::reference
+allocator<vector<pair<bool,bool> > >::size_type
+allocator<vector<pair<bool,bool> > >::value_type
+allocator<void>::const_pointer
+allocator<void>::pointer
+allocator<void>::value_type
+Angle_t
+Atom_t
+Axis_t
+bool
+Bool_t
+Byte_t
+char
+char*
+Char_t
+CheckSecCtx_t
+ClassStreamerFunc_t
+clock_t
+Colormap_t
+Color_t
+Coord_t
+CreateInterpreter_t
+Cursor_t
+deque<int>::allocator_type
+deque<int>::const_iterator
+deque<int>::const_pointer
+deque<int>::const_reference
+deque<int>::const_reverse_iterator
+deque<int>::difference_type
+deque<int>::iterator
+deque<int>::pointer
+deque<int>::reference
+deque<int>::reverse_iterator
+deque<int>::size_type
+deque<int>::value_type
+deque<ROOT::Internal::TTreeReaderValueBase*>::allocator_type
+deque<ROOT::Internal::TTreeReaderValueBase*>::const_iterator
+deque<ROOT::Internal::TTreeReaderValueBase*>::const_pointer
+deque<ROOT::Internal::TTreeReaderValueBase*>::const_reference
+deque<ROOT::Internal::TTreeReaderValueBase*>::const_reverse_iterator
+deque<ROOT::Internal::TTreeReaderValueBase*>::difference_type
+deque<ROOT::Internal::TTreeReaderValueBase*>::iterator
+deque<ROOT::Internal::TTreeReaderValueBase*>::pointer
+deque<ROOT::Internal::TTreeReaderValueBase*>::reference
+deque<ROOT::Internal::TTreeReaderValueBase*>::reverse_iterator
+deque<ROOT::Internal::TTreeReaderValueBase*>::size_type
+deque<ROOT::Internal::TTreeReaderValueBase*>::value_type
+DestroyInterpreter_t
+dev_t
+Display_t
+div_t
+double
+Double32_t
+double_t
+Double_t
+Drawable_t
+ErrorHandlerFunc_t
+FILE
+filebuf
+float
+Float16_t
+float_t
+Float_t
+FontH_t
+FontStruct_t
+Font_t
+fpos_t
+FreeHookFun_t
+fstream
+FT_BBox
+FT_Bitmap
+FT_CharMap
+FT_Face
+FT_Glyph
+FT_Library
+FT_Matrix
+FT_Pos
+FT_Vector
+Func_t
+GContext_t
+GlobusAuth_t
+Handle_t
+IdMap_t
+ifstream
+imaxdiv_t
+ino_t
+int
+int16_t
+int32_t
+int64_t
+int8_t
+int_fast16_t
+int_fast32_t
+int_fast64_t
+int_fast8_t
+int_least16_t
+int_least32_t
+int_least64_t
+int_least8_t
+intmax_t
+intptr_t
+Int_t
+ios
+iostream
+IsAGlobalFunc_t
+istringstream
+iterator<bidirectional_iterator_tag,TObject*,long,const TObject**,const TObject*&>::difference_type
+iterator<bidirectional_iterator_tag,TObject*,long,const TObject**,const TObject*&>::iterator_category
+iterator<bidirectional_iterator_tag,TObject*,long,const TObject**,const TObject*&>::pointer
+iterator<bidirectional_iterator_tag,TObject*,long,const TObject**,const TObject*&>::reference
+iterator<bidirectional_iterator_tag,TObject*,long,const TObject**,const TObject*&>::value_type
+iterator<random_access_iterator_tag,bool,long,bool*,bool&>::difference_type
+iterator<random_access_iterator_tag,bool,long,bool*,bool&>::iterator_category
+iterator<random_access_iterator_tag,bool,long,bool*,bool&>::pointer
+iterator<random_access_iterator_tag,bool,long,bool*,bool&>::reference
+iterator<random_access_iterator_tag,bool,long,bool*,bool&>::value_type
+iterator<random_access_iterator_tag,int,long,int*,int&>::difference_type
+iterator<random_access_iterator_tag,int,long,int*,int&>::iterator_category
+iterator<random_access_iterator_tag,int,long,int*,int&>::pointer
+iterator<random_access_iterator_tag,int,long,int*,int&>::reference
+iterator<random_access_iterator_tag,int,long,int*,int&>::value_type
+iterator<random_access_iterator_tag,TString,long,TString*,TString&>::difference_type
+iterator<random_access_iterator_tag,TString,long,TString*,TString&>::iterator_category
+iterator<random_access_iterator_tag,TString,long,TString*,TString&>::pointer
+iterator<random_access_iterator_tag,TString,long,TString*,TString&>::reference
+iterator<random_access_iterator_tag,TString,long,TString*,TString&>::value_type
+iterator_traits<basic_string<char>*>::difference_type
+iterator_traits<basic_string<char>*>::iterator_category
+iterator_traits<basic_string<char>*>::pointer
+iterator_traits<basic_string<char>*>::reference
+iterator_traits<basic_string<char>*>::value_type
+iterator_traits<char*>::difference_type
+iterator_traits<char*>::iterator_category
+iterator_traits<char*>::pointer
+iterator_traits<char*>::reference
+iterator_traits<char*>::value_type
+iterator_traits<const char*>::difference_type
+iterator_traits<const char*>::iterator_category
+iterator_traits<const char*>::pointer
+iterator_traits<const char*>::reference
+iterator_traits<const char*>::value_type
+iterator_traits<const const basic_string<char>*>::difference_type
+iterator_traits<const const basic_string<char>*>::iterator_category
+iterator_traits<const const basic_string<char>*>::pointer
+iterator_traits<const const basic_string<char>*>::reference
+iterator_traits<const const basic_string<char>*>::value_type
+iterator_traits<const const pair<double,double>*>::difference_type
+iterator_traits<const const pair<double,double>*>::iterator_category
+iterator_traits<const const pair<double,double>*>::pointer
+iterator_traits<const const pair<double,double>*>::reference
+iterator_traits<const const pair<double,double>*>::value_type
+iterator_traits<const const vector<pair<double,double> >*>::difference_type
+iterator_traits<const const vector<pair<double,double> >*>::iterator_category
+iterator_traits<const const vector<pair<double,double> >*>::pointer
+iterator_traits<const const vector<pair<double,double> >*>::reference
+iterator_traits<const const vector<pair<double,double> >*>::value_type
+iterator_traits<const double*const*>::difference_type
+iterator_traits<const double*const*>::iterator_category
+iterator_traits<const double*const*>::pointer
+iterator_traits<const double*const*>::reference
+iterator_traits<const double*const*>::value_type
+iterator_traits<const double*>::difference_type
+iterator_traits<const double**>::difference_type
+iterator_traits<const double*>::iterator_category
+iterator_traits<const double**>::iterator_category
+iterator_traits<const double*>::pointer
+iterator_traits<const double**>::pointer
+iterator_traits<const double*>::reference
+iterator_traits<const double**>::reference
+iterator_traits<const double*>::value_type
+iterator_traits<const double**>::value_type
+iterator_traits<const int*>::difference_type
+iterator_traits<const int*>::iterator_category
+iterator_traits<const int*>::pointer
+iterator_traits<const int*>::reference
+iterator_traits<const int*>::value_type
+iterator_traits<const ROOT::Fit::ParameterSettings*>::difference_type
+iterator_traits<const ROOT::Fit::ParameterSettings*>::iterator_category
+iterator_traits<const ROOT::Fit::ParameterSettings*>::pointer
+iterator_traits<const ROOT::Fit::ParameterSettings*>::reference
+iterator_traits<const ROOT::Fit::ParameterSettings*>::value_type
+iterator_traits<const TString*>::difference_type
+iterator_traits<const TString*>::iterator_category
+iterator_traits<const TString*>::pointer
+iterator_traits<const TString*>::reference
+iterator_traits<const TString*>::value_type
+iterator_traits<const unsigned int*>::difference_type
+iterator_traits<const unsigned int*>::iterator_category
+iterator_traits<const unsigned int*>::pointer
+iterator_traits<const unsigned int*>::reference
+iterator_traits<const unsigned int*>::value_type
+iterator_traits<double*>::difference_type
+iterator_traits<double*>::iterator_category
+iterator_traits<double*>::pointer
+iterator_traits<double*>::reference
+iterator_traits<double*>::value_type
+iterator_traits<int*>::difference_type
+iterator_traits<int*>::iterator_category
+iterator_traits<int*>::pointer
+iterator_traits<int*>::reference
+iterator_traits<int*>::value_type
+iterator_traits<ROOT::Math::MinimTransformVariable*>::difference_type
+iterator_traits<ROOT::Math::MinimTransformVariable*>::iterator_category
+iterator_traits<ROOT::Math::MinimTransformVariable*>::pointer
+iterator_traits<ROOT::Math::MinimTransformVariable*>::reference
+iterator_traits<ROOT::Math::MinimTransformVariable*>::value_type
+iterator_traits<pair<double,double>*>::difference_type
+iterator_traits<pair<double,double>*>::iterator_category
+iterator_traits<pair<double,double>*>::pointer
+iterator_traits<pair<double,double>*>::reference
+iterator_traits<pair<double,double>*>::value_type
+iterator_traits<ROOT::Fit::ParameterSettings*>::difference_type
+iterator_traits<ROOT::Fit::ParameterSettings*>::iterator_category
+iterator_traits<ROOT::Fit::ParameterSettings*>::pointer
+iterator_traits<ROOT::Fit::ParameterSettings*>::reference
+iterator_traits<ROOT::Fit::ParameterSettings*>::value_type
+iterator_traits<TStreamerInfoActions::TConfiguredAction*>::difference_type
+iterator_traits<TStreamerInfoActions::TConfiguredAction*>::iterator_category
+iterator_traits<TStreamerInfoActions::TConfiguredAction*>::pointer
+iterator_traits<TStreamerInfoActions::TConfiguredAction*>::reference
+iterator_traits<TStreamerInfoActions::TConfiguredAction*>::value_type
+iterator_traits<TStreamerInfo**>::difference_type
+iterator_traits<TStreamerInfo**>::iterator_category
+iterator_traits<TStreamerInfo**>::pointer
+iterator_traits<TStreamerInfo**>::reference
+iterator_traits<TStreamerInfo**>::value_type
+iterator_traits<TString*>::difference_type
+iterator_traits<TString*>::iterator_category
+iterator_traits<TString*>::pointer
+iterator_traits<TString*>::reference
+iterator_traits<TString*>::value_type
+iterator_traits<TThread*const*>::difference_type
+iterator_traits<TThread*const*>::iterator_category
+iterator_traits<TThread*const*>::pointer
+iterator_traits<TThread*const*>::reference
+iterator_traits<TThread*const*>::value_type
+iterator_traits<ROOT::Internal::TTreeReaderValueBase**>::difference_type
+iterator_traits<ROOT::Internal::TTreeReaderValueBase**>::iterator_category
+iterator_traits<ROOT::Internal::TTreeReaderValueBase**>::pointer
+iterator_traits<ROOT::Internal::TTreeReaderValueBase**>::reference
+iterator_traits<ROOT::Internal::TTreeReaderValueBase**>::value_type
+iterator_traits<TVirtualArray**>::difference_type
+iterator_traits<TVirtualArray**>::iterator_category
+iterator_traits<TVirtualArray**>::pointer
+iterator_traits<TVirtualArray**>::reference
+iterator_traits<TVirtualArray**>::value_type
+iterator_traits<unsigned int*>::difference_type
+iterator_traits<unsigned int*>::iterator_category
+iterator_traits<unsigned int*>::pointer
+iterator_traits<unsigned int*>::reference
+iterator_traits<unsigned int*>::value_type
+iterator_traits<unsigned long*>::difference_type
+iterator_traits<unsigned long*>::iterator_category
+iterator_traits<unsigned long*>::pointer
+iterator_traits<unsigned long*>::reference
+iterator_traits<unsigned long*>::value_type
+iterator_traits<vector<double>*>::difference_type
+iterator_traits<vector<double>*>::iterator_category
+iterator_traits<vector<double>*>::pointer
+iterator_traits<vector<double>*>::reference
+iterator_traits<vector<double>*>::value_type
+iterator_traits<vector<pair<double,double> >*>::difference_type
+iterator_traits<vector<pair<double,double> >*>::iterator_category
+iterator_traits<vector<pair<double,double> >*>::pointer
+iterator_traits<vector<pair<double,double> >*>::reference
+iterator_traits<vector<pair<double,double> >*>::value_type
+jmp_buf
+KeySym_t
+Krb5Auth_t
+ldiv_t
+list<basic_string<char> >::allocator_type
+list<basic_string<char> >::const_iterator
+list<basic_string<char> >::const_pointer
+list<basic_string<char> >::const_reference
+list<basic_string<char> >::const_reverse_iterator
+list<basic_string<char> >::difference_type
+list<basic_string<char> >::iterator
+list<basic_string<char> >::pointer
+list<basic_string<char> >::reference
+list<basic_string<char> >::reverse_iterator
+list<basic_string<char> >::size_type
+list<basic_string<char> >::value_type
+list<pair<TDSetElement*,TString> >::allocator_type
+list<pair<TDSetElement*,TString> >::const_iterator
+list<pair<TDSetElement*,TString> >::const_pointer
+list<pair<TDSetElement*,TString> >::const_reference
+list<pair<TDSetElement*,TString> >::const_reverse_iterator
+list<pair<TDSetElement*,TString> >::difference_type
+list<pair<TDSetElement*,TString> >::iterator
+list<pair<TDSetElement*,TString> >::pointer
+list<pair<TDSetElement*,TString> >::reference
+list<pair<TDSetElement*,TString> >::reverse_iterator
+list<pair<TDSetElement*,TString> >::size_type
+list<pair<TDSetElement*,TString> >::value_type
+list<ROOT::Detail::TBranchProxy*>::allocator_type
+list<ROOT::Detail::TBranchProxy*>::const_iterator
+list<ROOT::Detail::TBranchProxy*>::const_pointer
+list<ROOT::Detail::TBranchProxy*>::const_reference
+list<ROOT::Detail::TBranchProxy*>::const_reverse_iterator
+list<ROOT::Detail::TBranchProxy*>::difference_type
+list<ROOT::Detail::TBranchProxy*>::iterator
+list<ROOT::Detail::TBranchProxy*>::pointer
+list<ROOT::Detail::TBranchProxy*>::reference
+list<ROOT::Detail::TBranchProxy*>::reverse_iterator
+list<ROOT::Detail::TBranchProxy*>::size_type
+list<ROOT::Detail::TBranchProxy*>::value_type
+list<ROOT::Internal::TFriendProxy*>::allocator_type
+list<ROOT::Internal::TFriendProxy*>::const_iterator
+list<ROOT::Internal::TFriendProxy*>::const_pointer
+list<ROOT::Internal::TFriendProxy*>::const_reference
+list<ROOT::Internal::TFriendProxy*>::const_reverse_iterator
+list<ROOT::Internal::TFriendProxy*>::difference_type
+list<ROOT::Internal::TFriendProxy*>::iterator
+list<ROOT::Internal::TFriendProxy*>::pointer
+list<ROOT::Internal::TFriendProxy*>::reference
+list<ROOT::Internal::TFriendProxy*>::reverse_iterator
+list<ROOT::Internal::TFriendProxy*>::size_type
+list<ROOT::Internal::TFriendProxy*>::value_type
+list<TGListTreeItem*>::allocator_type
+list<TGListTreeItem*>::const_iterator
+list<TGListTreeItem*>::const_pointer
+list<TGListTreeItem*>::const_reference
+list<TGListTreeItem*>::const_reverse_iterator
+list<TGListTreeItem*>::difference_type
+list<TGListTreeItem*>::iterator
+list<TGListTreeItem*>::pointer
+list<TGListTreeItem*>::reference
+list<TGListTreeItem*>::reverse_iterator
+list<TGListTreeItem*>::size_type
+list<TGListTreeItem*>::value_type
+list<unsigned int>::allocator_type
+list<unsigned int>::const_iterator
+list<unsigned int>::const_pointer
+list<unsigned int>::const_reference
+list<unsigned int>::const_reverse_iterator
+list<unsigned int>::difference_type
+list<unsigned int>::iterator
+list<unsigned int>::pointer
+list<unsigned int>::reference
+list<unsigned int>::reverse_iterator
+list<unsigned int>::size_type
+list<unsigned int>::value_type
+lldiv_t
+long
+Long64_t
+long long
+Long_t
+Marker_t
+Mask_t
+mbstate_t
+MemberStreamerFunc_t
+multimap<TObject*,TF1*>::allocator_type
+multimap<TObject*,TF1*>::const_iterator
+multimap<TObject*,TF1*>::const_pointer
+multimap<TObject*,TF1*>::const_reference
+multimap<TObject*,TF1*>::const_reverse_iterator
+multimap<TObject*,TF1*>::difference_type
+multimap<TObject*,TF1*>::iterator
+multimap<TObject*,TF1*>::key_compare
+multimap<TObject*,TF1*>::key_type
+multimap<TObject*,TF1*>::mapped_type
+multimap<TObject*,TF1*>::pointer
+multimap<TObject*,TF1*>::reference
+multimap<TObject*,TF1*>::reverse_iterator
+multimap<TObject*,TF1*>::size_type
+multimap<TObject*,TF1*>::value_type
+new_handler
+off_t
+ofstream
+Option_t
+ostringstream
+pair<basic_string<char>,double>::first_type
+pair<basic_string<char>,double>::second_type
+pair<basic_string<char>,float>::first_type
+pair<basic_string<char>,float>::second_type
+pair<basic_string<char>,int>::first_type
+pair<basic_string<char>,int>::second_type
+pair<basic_string<char>,long>::first_type
+pair<basic_string<char>,long>::second_type
+pair<basic_string<char>,void*>::first_type
+pair<basic_string<char>,void*>::second_type
+pair<char*,char*>::first_type
+pair<char*,char*>::second_type
+pair<char*,double>::first_type
+pair<char*,double>::second_type
+pair<char*,float>::first_type
+pair<char*,float>::second_type
+pair<char*,int>::first_type
+pair<char*,int>::second_type
+pair<char*,long>::first_type
+pair<char*,long>::second_type
+pair<char*,void*>::first_type
+pair<char*,void*>::second_type
+pair<const char*,char*>::first_type
+pair<const char*,char*>::second_type
+pair<const char*,double>::first_type
+pair<const char*,double>::second_type
+pair<const char*,float>::first_type
+pair<const char*,float>::second_type
+pair<const char*,int>::first_type
+pair<const char*,int>::second_type
+pair<const char*,long>::first_type
+pair<const char*,long>::second_type
+pair<const char*,void*>::first_type
+pair<const char*,void*>::second_type
+pair<const const basic_string<char>,float>::first_type
+pair<const const basic_string<char>,float>::second_type
+pair<const const basic_string<char>,long>::first_type
+pair<const const basic_string<char>,long>::second_type
+pair<const const basic_string<char>,void*>::first_type
+pair<const const basic_string<char>,void*>::second_type
+pair<const double,char*>::first_type
+pair<const double,char*>::second_type
+pair<const double,double>::first_type
+pair<const double,double>::second_type
+pair<const double,float>::first_type
+pair<const double,float>::second_type
+pair<const double,int>::first_type
+pair<const double,int>::second_type
+pair<const double,long>::first_type
+pair<const double,long>::second_type
+pair<const double,void*>::first_type
+pair<const double,void*>::second_type
+pair<const float,char*>::first_type
+pair<const float,char*>::second_type
+pair<const float,double>::first_type
+pair<const float,double>::second_type
+pair<const float,float>::first_type
+pair<const float,float>::second_type
+pair<const float,int>::first_type
+pair<const float,int>::second_type
+pair<const float,long>::first_type
+pair<const float,long>::second_type
+pair<const float,void*>::first_type
+pair<const float,void*>::second_type
+pair<const int,char*>::first_type
+pair<const int,char*>::second_type
+pair<const int,double>::first_type
+pair<const int,double>::second_type
+pair<const int,float>::first_type
+pair<const int,float>::second_type
+pair<const int,int>::first_type
+pair<const int,int>::second_type
+pair<const int,long>::first_type
+pair<const int,long>::second_type
+pair<const int,void*>::first_type
+pair<const int,void*>::second_type
+pair<const long,char*>::first_type
+pair<const long,char*>::second_type
+pair<const long,double>::first_type
+pair<const long,double>::second_type
+pair<const long,float>::first_type
+pair<const long,float>::second_type
+pair<const long,long>::first_type
+pair<const long,long>::second_type
+pair<const long,void*>::first_type
+pair<const long,void*>::second_type
+pair<double,char*>::first_type
+pair<double,char*>::second_type
+pair<double,float>::first_type
+pair<double,float>::second_type
+pair<double,int>::first_type
+pair<double,int>::second_type
+pair<double,long>::first_type
+pair<double,long>::second_type
+pair<double,void*>::first_type
+pair<double,void*>::second_type
+pair<float,char*>::first_type
+pair<float,char*>::second_type
+pair<float,double>::first_type
+pair<float,double>::second_type
+pair<float,float>::first_type
+pair<float,float>::second_type
+pair<float,int>::first_type
+pair<float,int>::second_type
+pair<float,long>::first_type
+pair<float,long>::second_type
+pair<float,void*>::first_type
+pair<float,void*>::second_type
+pair<int,char*>::first_type
+pair<int,char*>::second_type
+pair<int,double>::first_type
+pair<int,double>::second_type
+pair<int,float>::first_type
+pair<int,float>::second_type
+pair<int,int>::first_type
+pair<int,int>::second_type
+pair<int,long>::first_type
+pair<int,long>::second_type
+pair<int,void*>::first_type
+pair<int,void*>::second_type
+pair<long,char*>::first_type
+pair<long,char*>::second_type
+pair<long,double>::first_type
+pair<long,double>::second_type
+pair<long,float>::first_type
+pair<long,float>::second_type
+pair<long,int>::first_type
+pair<long,int>::second_type
+pair<long,long>::first_type
+pair<long,long>::second_type
+pair<long,TGeoNavigatorArray*>::first_type
+pair<long,TGeoNavigatorArray*>::second_type
+pair<long,void*>::first_type
+pair<long,void*>::second_type
+pair<TDSetElement*,TString>::first_type
+pair<TDSetElement*,TString>::second_type
+Pattern_t
+Pixel_t
+Pixmap_t
+ptrdiff_t
+queue<int,deque<int> >::const_reference
+queue<int,deque<int> >::container_type
+queue<int,deque<int> >::reference
+queue<int,deque<int> >::size_type
+queue<int,deque<int> >::value_type
+ReAllocCFun_t
+ReAllocCharFun_t
+ReAllocFun_t
+Real_t
+Region_t
+ROOT::DelArrFunc_t
+ROOT::DelFunc_t
+ROOT::DesFunc_t
+ROOT::DirAutoAdd_t
+ROOT::Math::FitMethodFunction
+ROOT::Math::FitMethodGradFunction
+ROOT::Math::FreeFunctionPtr
+ROOT::Math::TDataPoint<1,double>::value_type
+ROOT::MergeFunc_t
+ROOT::NewArrFunc_t
+ROOT::NewFunc_t
+ROOT::ResetAfterMergeFunc_t
+ROOT::Internal::TArrayBoolProxy
+ROOT::Internal::TArrayDouble32Proxy
+ROOT::Internal::TArrayDoubleProxy
+ROOT::Internal::TArrayFloat16Proxy
+ROOT::Internal::TArrayFloatProxy
+ROOT::Internal::TArrayIntProxy
+ROOT::Internal::TArrayLong64Proxy
+ROOT::Internal::TArrayLongProxy
+ROOT::Internal::TArrayShortProxy
+ROOT::Internal::TArrayUCharProxy
+ROOT::Internal::TArrayUIntProxy
+ROOT::Internal::TArrayULong64Proxy
+ROOT::Internal::TArrayULongProxy
+ROOT::Internal::TArrayUShortProxy
+ROOT::Internal::TBoolProxy
+ROOT::Internal::TCharProxy
+ROOT::Internal::TClaArrayBoolProxy
+ROOT::Internal::TClaArrayCharProxy
+ROOT::Internal::TClaArrayDouble32Proxy
+ROOT::Internal::TClaArrayDoubleProxy
+ROOT::Internal::TClaArrayFloat16Proxy
+ROOT::Internal::TClaArrayFloatProxy
+ROOT::Internal::TClaArrayIntProxy
+ROOT::Internal::TClaArrayLong64Proxy
+ROOT::Internal::TClaArrayLongProxy
+ROOT::Internal::TClaArrayShortProxy
+ROOT::Internal::TClaArrayUCharProxy
+ROOT::Internal::TClaArrayUIntProxy
+ROOT::Internal::TClaArrayULong64Proxy
+ROOT::Internal::TClaArrayULongProxy
+ROOT::Internal::TClaArrayUShortProxy
+ROOT::Internal::TClaBoolProxy
+ROOT::Internal::TClaCharProxy
+ROOT::Internal::TClaDouble32Proxy
+ROOT::Internal::TClaDoubleProxy
+ROOT::Internal::TClaFloat16Proxy
+ROOT::Internal::TClaFloatProxy
+ROOT::Internal::TClaIntProxy
+ROOT::Internal::TClaLong64Proxy
+ROOT::Internal::TClaLongProxy
+ROOT::Internal::TClaShortProxy
+ROOT::Internal::TClaUCharProxy
+ROOT::Internal::TClaUIntProxy
+ROOT::Internal::TClaULong64Proxy
+ROOT::Internal::TClaULongProxy
+ROOT::Internal::TClaUShortProxy
+ROOT::Internal::TDouble32Proxy
+ROOT::Internal::TDoubleProxy
+ROOT::Internal::TFloat16Proxy
+ROOT::Internal::TFloatProxy
+ROOT::Internal::TIntProxy
+ROOT::Internal::TLong64Proxy
+ROOT::Internal::TLongProxy
+ROOT::Internal::TShortProxy
+ROOT::Internal::TStlArrayBoolProxy
+ROOT::Internal::TStlArrayCharProxy
+ROOT::Internal::TStlArrayDouble32Proxy
+ROOT::Internal::TStlArrayDoubleProxy
+ROOT::Internal::TStlArrayFloat16Proxy
+ROOT::Internal::TStlArrayFloatProxy
+ROOT::Internal::TStlArrayIntProxy
+ROOT::Internal::TStlArrayLong64Proxy
+ROOT::Internal::TStlArrayLongProxy
+ROOT::Internal::TStlArrayShortProxy
+ROOT::Internal::TStlArrayUCharProxy
+ROOT::Internal::TStlArrayUIntProxy
+ROOT::Internal::TStlArrayULong64Proxy
+ROOT::Internal::TStlArrayULongProxy
+ROOT::Internal::TStlArrayUShortProxy
+ROOT::Internal::TStlBoolProxy
+ROOT::Internal::TStlCharProxy
+ROOT::Internal::TStlDouble32Proxy
+ROOT::Internal::TStlDoubleProxy
+ROOT::Internal::TStlFloat16Proxy
+ROOT::Internal::TStlFloatProxy
+ROOT::Internal::TStlIntProxy
+ROOT::Internal::TStlLong64Proxy
+ROOT::Internal::TStlLongProxy
+ROOT::Internal::TStlShortProxy
+ROOT::Internal::TStlUCharProxy
+ROOT::Internal::TStlUIntProxy
+ROOT::Internal::TStlULong64Proxy
+ROOT::Internal::TStlULongProxy
+ROOT::Internal::TStlUShortProxy
+ROOT::Internal::TUCharProxy
+ROOT::Internal::TUIntProxy
+ROOT::Internal::TULong64Proxy
+ROOT::Internal::TULongProxy
+ROOT::Internal::TUShortProxy
+SCoord_t
+SecureAuth_t
+Seek_t
+set<basic_string<char> >::allocator_type
+set<basic_string<char> >::const_iterator
+set<basic_string<char> >::const_pointer
+set<basic_string<char> >::const_reference
+set<basic_string<char> >::const_reverse_iterator
+set<basic_string<char> >::difference_type
+set<basic_string<char> >::iterator
+set<basic_string<char> >::key_compare
+set<basic_string<char> >::key_type
+set<basic_string<char> >::pointer
+set<basic_string<char> >::reference
+set<basic_string<char> >::reverse_iterator
+set<basic_string<char> >::size_type
+set<basic_string<char> >::value_compare
+set<basic_string<char> >::value_type
+set<unsigned int>::allocator_type
+set<unsigned int>::const_iterator
+set<unsigned int>::const_pointer
+set<unsigned int>::const_reference
+set<unsigned int>::const_reverse_iterator
+set<unsigned int>::difference_type
+set<unsigned int>::iterator
+set<unsigned int>::key_compare
+set<unsigned int>::key_type
+set<unsigned int>::pointer
+set<unsigned int>::reference
+set<unsigned int>::reverse_iterator
+set<unsigned int>::size_type
+set<unsigned int>::value_compare
+set<unsigned int>::value_type
+short
+Short_t
+ShowMembersFunc_t
+Size3D
+size_t
+Size_t
+SrvAuth_t
+SrvClup_t
+Ssiz_t
+Stat_t
+streambuf
+stringbuf
+stringstream
+Style_t
+TAssoc
+TBranchSTL::BranchMap_t
+TBtree::Iterator_t
+TBufferFile::InfoList_t
+TColorGradient::SizeType_t
+TElementActionD
+TElementActionF
+TElementPosActionD
+TElementPosActionF
+terminate_handler
+Text_t
+TFitEditor::FuncParams_t
+TFormLeafInfoReference::Proxy
+TGenCollectionProxy::ArrIterfunc_t
+TGenCollectionProxy::Collectfunc_t
+TGenCollectionProxy::EnvironBase_t
+TGenCollectionProxy::Env_t
+TGenCollectionProxy::Feedfunc_t
+TGenCollectionProxy::Info_t
+TGenCollectionProxy::Method0::Call_t
+TGenCollectionProxy::Method::Call_t
+TGenCollectionProxy::Proxies_t
+TGenCollectionProxy::Sizing_t
+TGenCollectionProxy::Staged_t
+TGenMapStreamer
+TGFileBrowser::mFiltered_t
+TGFileBrowser::sLTI_i
+TGFileBrowser::sLTI_ri
+TGFileBrowser::sLTI_t
+THaarMatrixD
+THaarMatrixF
+THilbertMatrixD
+THilbertMatrixDSym
+THilbertMatrixF
+THilbertMatrixFSym
+THnC
+THnD
+THnF
+THnI
+THnL
+THnL64
+THnS
+THnSparseC
+THnSparseD
+THnSparseF
+THnSparseI
+THnSparseL
+THnSparseS
+timespec_t
+time_t
+Time_t
+TKDE::KernelFunction_Ptr
+TKDTreeID
+TKDTreeIF
+TMatrix
+TMatrixD
+TMatrixDBase
+TMatrixDColumn
+TMatrixDColumn_const
+TMatrixDDiag
+TMatrixDDiag_const
+TMatrixDFlat
+TMatrixDFlat_const
+TMatrixDLazy
+TMatrixDRow
+TMatrixDRow_const
+TMatrixDSparse
+TMatrixDSparseDiag
+TMatrixDSparseDiag_const
+TMatrixDSparseRow
+TMatrixDSparseRow_const
+TMatrixDSub
+TMatrixDSub_const
+TMatrixDSym
+TMatrixDSymLazy
+TMatrixF
+TMatrixFBase
+TMatrixFColumn
+TMatrixFColumn_const
+TMatrixFDiag
+TMatrixFDiag_const
+TMatrixFFlat
+TMatrixFFlat_const
+TMatrixFLazy
+TMatrixFRow
+TMatrixFRow_const
+TMatrixFSparse
+TMatrixFSparseDiag
+TMatrixFSparseDiag_const
+TMatrixFSparseRow
+TMatrixFSparseRow_const
+TMatrixFSub
+TMatrixFSub_const
+TMatrixFSym
+TMatrixFSymLazy
+tm_t
+TStreamerInfoActions::TStreamerInfoAction_t
+TStreamerInfoActions::TStreamerInfoLoopAction_t
+TStreamerInfoActions::TStreamerInfoVecPtrLoopAction_t
+TTabCom::TContainer
+TTabCom::TContIter
+TVector
+TVectorD
+TVectorF
+TVirtualBranchBrowsable::MethodCreateListOfBrowsables_t
+TVirtualFitter::FCNFunc_t
+TVirtualVectorIterators::CreateIterators_t
+UChar_t
+uint16_t
+uint32_t
+uint64_t
+uint8_t
+uint_fast16_t
+uint_fast32_t
+uint_fast64_t
+uint_fast8_t
+uint_least16_t
+uint_least32_t
+uint_least64_t
+uint_least8_t
+uintmax_t
+uintptr_t
+UInt_t
+ULong64_t
+ULong_t
+unsigned
+unsigned char
+unsigned int
+unsigned long
+unsigned long long
+unsigned short
+Short_t
+va_list
+vector<char>::allocator_type
+vector<char>::const_iterator
+vector<char>::const_pointer
+vector<char>::const_reference
+vector<char>::const_reverse_iterator
+vector<char>::difference_type
+vector<char>::iterator
+vector<char>::pointer
+vector<char>::reference
+vector<char>::reverse_iterator
+vector<char>::size_type
+vector<char>::value_type
+vector<const double*>::allocator_type
+vector<const double*>::const_iterator
+vector<const double*>::const_pointer
+vector<const double*>::const_reference
+vector<const double*>::const_reverse_iterator
+vector<const double*>::difference_type
+vector<const double*>::iterator
+vector<const double*>::pointer
+vector<const double*>::reference
+vector<const double*>::reverse_iterator
+vector<const double*>::size_type
+vector<const double*>::value_type
+vector<TBranchSTL::ElementBranchHelper_t>::allocator_type
+vector<TBranchSTL::ElementBranchHelper_t>::const_iterator
+vector<TBranchSTL::ElementBranchHelper_t>::const_pointer
+vector<TBranchSTL::ElementBranchHelper_t>::const_reference
+vector<TBranchSTL::ElementBranchHelper_t>::const_reverse_iterator
+vector<TBranchSTL::ElementBranchHelper_t>::difference_type
+vector<TBranchSTL::ElementBranchHelper_t>::iterator
+vector<TBranchSTL::ElementBranchHelper_t>::pointer
+vector<TBranchSTL::ElementBranchHelper_t>::reference
+vector<TBranchSTL::ElementBranchHelper_t>::reverse_iterator
+vector<TBranchSTL::ElementBranchHelper_t>::size_type
+vector<TBranchSTL::ElementBranchHelper_t>::value_type
+vector<ROOT::TCollectionProxyInfo::EnvironBase*>::allocator_type
+vector<ROOT::TCollectionProxyInfo::EnvironBase*>::const_iterator
+vector<ROOT::TCollectionProxyInfo::EnvironBase*>::const_pointer
+vector<ROOT::TCollectionProxyInfo::EnvironBase*>::const_reference
+vector<ROOT::TCollectionProxyInfo::EnvironBase*>::const_reverse_iterator
+vector<ROOT::TCollectionProxyInfo::EnvironBase*>::difference_type
+vector<ROOT::TCollectionProxyInfo::EnvironBase*>::iterator
+vector<ROOT::TCollectionProxyInfo::EnvironBase*>::pointer
+vector<ROOT::TCollectionProxyInfo::EnvironBase*>::reference
+vector<ROOT::TCollectionProxyInfo::EnvironBase*>::reverse_iterator
+vector<ROOT::TCollectionProxyInfo::EnvironBase*>::size_type
+vector<ROOT::TCollectionProxyInfo::EnvironBase*>::value_type
+vector<float>::allocator_type
+vector<float>::const_iterator
+vector<float>::const_pointer
+vector<float>::const_reference
+vector<float>::const_reverse_iterator
+vector<float>::difference_type
+vector<float>::iterator
+vector<float>::pointer
+vector<float>::reference
+vector<float>::reverse_iterator
+vector<float>::size_type
+vector<float>::value_type
+vector<TFitEditor::FuncParamData_t>::allocator_type
+vector<TFitEditor::FuncParamData_t>::const_iterator
+vector<TFitEditor::FuncParamData_t>::const_pointer
+vector<TFitEditor::FuncParamData_t>::const_reference
+vector<TFitEditor::FuncParamData_t>::const_reverse_iterator
+vector<TFitEditor::FuncParamData_t>::difference_type
+vector<TFitEditor::FuncParamData_t>::iterator
+vector<TFitEditor::FuncParamData_t>::pointer
+vector<TFitEditor::FuncParamData_t>::reference
+vector<TFitEditor::FuncParamData_t>::reverse_iterator
+vector<TFitEditor::FuncParamData_t>::size_type
+vector<TFitEditor::FuncParamData_t>::value_type
+vector<int>::allocator_type
+vector<int>::const_iterator
+vector<int>::const_pointer
+vector<int>::const_reference
+vector<int>::const_reverse_iterator
+vector<int>::difference_type
+vector<int>::iterator
+vector<int>::pointer
+vector<int>::reference
+vector<int>::reverse_iterator
+vector<int>::size_type
+vector<int>::value_type
+vector<Long64_t>::allocator_type
+vector<Long64_t>::const_iterator
+vector<Long64_t>::const_pointer
+vector<Long64_t>::const_reference
+vector<Long64_t>::const_reverse_iterator
+vector<Long64_t>::difference_type
+vector<Long64_t>::iterator
+vector<Long64_t>::pointer
+vector<Long64_t>::reference
+vector<Long64_t>::reverse_iterator
+vector<Long64_t>::size_type
+vector<Long64_t>::value_type
+vector<long>::allocator_type
+vector<long>::const_iterator
+vector<long>::const_pointer
+vector<long>::const_reference
+vector<long>::const_reverse_iterator
+vector<long>::difference_type
+vector<long>::iterator
+vector<long>::pointer
+vector<long>::reference
+vector<long>::reverse_iterator
+vector<long>::size_type
+vector<long>::value_type
+vector<map<double,vector<unsigned int> > >::allocator_type
+vector<map<double,vector<unsigned int> > >::const_iterator
+vector<map<double,vector<unsigned int> > >::const_pointer
+vector<map<double,vector<unsigned int> > >::const_reference
+vector<map<double,vector<unsigned int> > >::const_reverse_iterator
+vector<map<double,vector<unsigned int> > >::difference_type
+vector<map<double,vector<unsigned int> > >::iterator
+vector<map<double,vector<unsigned int> > >::pointer
+vector<map<double,vector<unsigned int> > >::reference
+vector<map<double,vector<unsigned int> > >::reverse_iterator
+vector<map<double,vector<unsigned int> > >::size_type
+vector<map<double,vector<unsigned int> > >::value_type
+vector<pair<int,int> >::allocator_type
+vector<pair<int,int> >::const_iterator
+vector<pair<int,int> >::const_pointer
+vector<pair<int,int> >::const_reference
+vector<pair<int,int> >::const_reverse_iterator
+vector<pair<int,int> >::difference_type
+vector<pair<int,int> >::iterator
+vector<pair<int,int> >::pointer
+vector<pair<int,int> >::reference
+vector<pair<int,int> >::reverse_iterator
+vector<pair<int,int> >::size_type
+vector<pair<int,int> >::value_type
+vector<ROOT::Fit::ParameterSettings>::allocator_type
+vector<ROOT::Fit::ParameterSettings>::const_iterator
+vector<ROOT::Fit::ParameterSettings>::const_pointer
+vector<ROOT::Fit::ParameterSettings>::const_reference
+vector<ROOT::Fit::ParameterSettings>::const_reverse_iterator
+vector<ROOT::Fit::ParameterSettings>::difference_type
+vector<ROOT::Fit::ParameterSettings>::iterator
+vector<ROOT::Fit::ParameterSettings>::pointer
+vector<ROOT::Fit::ParameterSettings>::reference
+vector<ROOT::Fit::ParameterSettings>::reverse_iterator
+vector<ROOT::Fit::ParameterSettings>::size_type
+vector<ROOT::Fit::ParameterSettings>::value_type
+vector<TProofDrawListOfGraphs::Point3D_t>::allocator_type
+vector<TProofDrawListOfGraphs::Point3D_t>::const_iterator
+vector<TProofDrawListOfGraphs::Point3D_t>::const_pointer
+vector<TProofDrawListOfGraphs::Point3D_t>::const_reference
+vector<TProofDrawListOfGraphs::Point3D_t>::const_reverse_iterator
+vector<TProofDrawListOfGraphs::Point3D_t>::difference_type
+vector<TProofDrawListOfGraphs::Point3D_t>::iterator
+vector<TProofDrawListOfGraphs::Point3D_t>::pointer
+vector<TProofDrawListOfGraphs::Point3D_t>::reference
+vector<TProofDrawListOfGraphs::Point3D_t>::reverse_iterator
+vector<TProofDrawListOfGraphs::Point3D_t>::size_type
+vector<TProofDrawListOfGraphs::Point3D_t>::value_type
+vector<TProofDrawListOfPolyMarkers3D::Point4D_t>::allocator_type
+vector<TProofDrawListOfPolyMarkers3D::Point4D_t>::const_iterator
+vector<TProofDrawListOfPolyMarkers3D::Point4D_t>::const_pointer
+vector<TProofDrawListOfPolyMarkers3D::Point4D_t>::const_reference
+vector<TProofDrawListOfPolyMarkers3D::Point4D_t>::const_reverse_iterator
+vector<TProofDrawListOfPolyMarkers3D::Point4D_t>::difference_type
+vector<TProofDrawListOfPolyMarkers3D::Point4D_t>::iterator
+vector<TProofDrawListOfPolyMarkers3D::Point4D_t>::pointer
+vector<TProofDrawListOfPolyMarkers3D::Point4D_t>::reference
+vector<TProofDrawListOfPolyMarkers3D::Point4D_t>::reverse_iterator
+vector<TProofDrawListOfPolyMarkers3D::Point4D_t>::size_type
+vector<TProofDrawListOfPolyMarkers3D::Point4D_t>::value_type
+vector<short>::allocator_type
+vector<short>::const_iterator
+vector<short>::const_pointer
+vector<short>::const_reference
+vector<short>::const_reverse_iterator
+vector<short>::difference_type
+vector<short>::iterator
+vector<short>::pointer
+vector<short>::reference
+vector<short>::reverse_iterator
+vector<short>::size_type
+vector<short>::value_type
+vector<TChainIndex::TChainIndexEntry>::allocator_type
+vector<TChainIndex::TChainIndexEntry>::const_iterator
+vector<TChainIndex::TChainIndexEntry>::const_pointer
+vector<TChainIndex::TChainIndexEntry>::const_reference
+vector<TChainIndex::TChainIndexEntry>::const_reverse_iterator
+vector<TChainIndex::TChainIndexEntry>::difference_type
+vector<TChainIndex::TChainIndexEntry>::iterator
+vector<TChainIndex::TChainIndexEntry>::pointer
+vector<TChainIndex::TChainIndexEntry>::reference
+vector<TChainIndex::TChainIndexEntry>::reverse_iterator
+vector<TChainIndex::TChainIndexEntry>::size_type
+vector<TChainIndex::TChainIndexEntry>::value_type
+vector<TStreamerInfoActions::TConfiguredAction>::allocator_type
+vector<TStreamerInfoActions::TConfiguredAction>::const_iterator
+vector<TStreamerInfoActions::TConfiguredAction>::const_pointer
+vector<TStreamerInfoActions::TConfiguredAction>::const_reference
+vector<TStreamerInfoActions::TConfiguredAction>::const_reverse_iterator
+vector<TStreamerInfoActions::TConfiguredAction>::difference_type
+vector<TStreamerInfoActions::TConfiguredAction>::iterator
+vector<TStreamerInfoActions::TConfiguredAction>::pointer
+vector<TStreamerInfoActions::TConfiguredAction>::reference
+vector<TStreamerInfoActions::TConfiguredAction>::reverse_iterator
+vector<TStreamerInfoActions::TConfiguredAction>::size_type
+vector<TStreamerInfoActions::TConfiguredAction>::value_type
+vector<TF1*>::allocator_type
+vector<TF1*>::const_iterator
+vector<TF1*>::const_pointer
+vector<TF1*>::const_reference
+vector<TF1*>::const_reverse_iterator
+vector<TF1*>::difference_type
+vector<TF1*>::iterator
+vector<TF1*>::pointer
+vector<TF1*>::reference
+vector<TF1*>::reverse_iterator
+vector<TF1*>::size_type
+vector<TF1*>::value_type
+vector<TGeoBoolNode::ThreadData_t*>::allocator_type
+vector<TGeoBoolNode::ThreadData_t*>::const_iterator
+vector<TGeoBoolNode::ThreadData_t*>::const_pointer
+vector<TGeoBoolNode::ThreadData_t*>::const_reference
+vector<TGeoBoolNode::ThreadData_t*>::const_reverse_iterator
+vector<TGeoBoolNode::ThreadData_t*>::difference_type
+vector<TGeoBoolNode::ThreadData_t*>::iterator
+vector<TGeoBoolNode::ThreadData_t*>::pointer
+vector<TGeoBoolNode::ThreadData_t*>::reference
+vector<TGeoBoolNode::ThreadData_t*>::reverse_iterator
+vector<TGeoBoolNode::ThreadData_t*>::size_type
+vector<TGeoBoolNode::ThreadData_t*>::value_type
+vector<ROOT::Internal::TSchemaHelper>::allocator_type
+vector<ROOT::Internal::TSchemaHelper>::const_iterator
+vector<ROOT::Internal::TSchemaHelper>::const_pointer
+vector<ROOT::Internal::TSchemaHelper>::const_reference
+vector<ROOT::Internal::TSchemaHelper>::const_reverse_iterator
+vector<ROOT::Internal::TSchemaHelper>::difference_type
+vector<ROOT::Internal::TSchemaHelper>::iterator
+vector<ROOT::Internal::TSchemaHelper>::pointer
+vector<ROOT::Internal::TSchemaHelper>::reference
+vector<ROOT::Internal::TSchemaHelper>::reverse_iterator
+vector<ROOT::Internal::TSchemaHelper>::size_type
+vector<ROOT::Internal::TSchemaHelper>::value_type
+vector<TGenCollectionProxy::TStaging*>::allocator_type
+vector<TGenCollectionProxy::TStaging*>::const_iterator
+vector<TGenCollectionProxy::TStaging*>::const_pointer
+vector<TGenCollectionProxy::TStaging*>::const_reference
+vector<TGenCollectionProxy::TStaging*>::const_reverse_iterator
+vector<TGenCollectionProxy::TStaging*>::difference_type
+vector<TGenCollectionProxy::TStaging*>::iterator
+vector<TGenCollectionProxy::TStaging*>::pointer
+vector<TGenCollectionProxy::TStaging*>::reference
+vector<TGenCollectionProxy::TStaging*>::reverse_iterator
+vector<TGenCollectionProxy::TStaging*>::size_type
+vector<TGenCollectionProxy::TStaging*>::value_type
+vector<TStreamerInfo*>::allocator_type
+vector<TStreamerInfo*>::const_iterator
+vector<TStreamerInfo*>::const_pointer
+vector<TStreamerInfo*>::const_reference
+vector<TStreamerInfo*>::const_reverse_iterator
+vector<TStreamerInfo*>::difference_type
+vector<TStreamerInfo*>::iterator
+vector<TStreamerInfo*>::pointer
+vector<TStreamerInfo*>::reference
+vector<TStreamerInfo*>::reverse_iterator
+vector<TStreamerInfo*>::size_type
+vector<TStreamerInfo*>::value_type
+vector<TString>::allocator_type
+vector<TString>::const_iterator
+vector<TString>::const_pointer
+vector<TString>::const_reference
+vector<TString>::const_reverse_iterator
+vector<TString>::difference_type
+vector<TString>::iterator
+vector<TString>::pointer
+vector<TString>::reference
+vector<TString>::reverse_iterator
+vector<TString>::size_type
+vector<TString>::value_type
+vector<TThread*>::allocator_type
+vector<TThread*>::const_iterator
+vector<TThread*>::const_pointer
+vector<TThread*>::const_reference
+vector<TThread*>::const_reverse_iterator
+vector<TThread*>::difference_type
+vector<TThread*>::iterator
+vector<TThread*>::pointer
+vector<TThread*>::reference
+vector<TThread*>::reverse_iterator
+vector<TThread*>::size_type
+vector<TThread*>::value_type
+vector<ULong64_t>::allocator_type
+vector<ULong64_t>::const_iterator
+vector<ULong64_t>::const_pointer
+vector<ULong64_t>::const_reference
+vector<ULong64_t>::const_reverse_iterator
+vector<ULong64_t>::difference_type
+vector<ULong64_t>::iterator
+vector<ULong64_t>::pointer
+vector<ULong64_t>::reference
+vector<ULong64_t>::reverse_iterator
+vector<ULong64_t>::size_type
+vector<ULong64_t>::value_type
+vector<unsigned char>::allocator_type
+vector<unsigned char>::const_iterator
+vector<unsigned char>::const_pointer
+vector<unsigned char>::const_reference
+vector<unsigned char>::const_reverse_iterator
+vector<unsigned char>::difference_type
+vector<unsigned char>::iterator
+vector<unsigned char>::pointer
+vector<unsigned char>::reference
+vector<unsigned char>::reverse_iterator
+vector<unsigned char>::size_type
+vector<unsigned char>::value_type
+vector<vector<double> >::allocator_type
+vector<vector<double> >::const_iterator
+vector<vector<double> >::const_pointer
+vector<vector<double> >::const_reference
+vector<vector<double> >::const_reverse_iterator
+vector<vector<double> >::difference_type
+vector<vector<double> >::iterator
+vector<vector<double> >::pointer
+vector<vector<double> >::reference
+vector<vector<double> >::reverse_iterator
+vector<vector<double> >::size_type
+vector<vector<double> >::value_type
+vector<vector<pair<bool,bool> > >::allocator_type
+vector<vector<pair<bool,bool> > >::const_iterator
+vector<vector<pair<bool,bool> > >::const_pointer
+vector<vector<pair<bool,bool> > >::const_reference
+vector<vector<pair<bool,bool> > >::const_reverse_iterator
+vector<vector<pair<bool,bool> > >::difference_type
+vector<vector<pair<bool,bool> > >::iterator
+vector<vector<pair<bool,bool> > >::pointer
+vector<vector<pair<bool,bool> > >::reference
+vector<vector<pair<bool,bool> > >::reverse_iterator
+vector<vector<pair<bool,bool> > >::size_type
+vector<vector<pair<bool,bool> > >::value_type
+Version_t
+Visual_t
+void
+VoidFuncPtr_t
+wctrans_t
+wctype_t
+wfilebuf
+wfstream
+Width_t
+wifstream
+Window_t
+wint_t
+wios
+wiostream
+wistream
+wistringstream
+wofstream
+wostream
+wostringstream
+wstreambuf
+wstring
+wstringbuf
+wstringstream
+X3DBuffer
+XMLAttrPointer_t
+XMLDocPointer_t
+XMLNodePointer_t
+XMLNsPointer_t


### PR DESCRIPTION
Fix errors due to the removal of `unary_function` and `binary_function` functions (deprecated in C++11, removed in C++17)