### PR TITLE
[tcling] Added test for `TCling::ReportDiagnosticsToErrorHandler()`

### DIFF
--- a/root/meta/CMakeLists.txt
+++ b/root/meta/CMakeLists.txt
@@ -14,6 +14,10 @@ ROOTTEST_ADD_TEST(expressiveErrorMessages
                   OUTCNV expressiveErrorMessages_filter.sh
                   DEPENDS ${GENERATE_REFLEX_TEST})
 
+ROOTTEST_ADD_TEST(clingTErrorDiagnostics
+                  MACRO clingTErrorDiagnostics.C
+                  OUTREF clingTErrorDiagnostics.ref)
+
 ROOTTEST_ADD_TEST(rlibmap
                   COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/rlibmapLauncher.py
                   PASSRC 1

--- a/root/meta/clingTErrorDiagnostics.C
+++ b/root/meta/clingTErrorDiagnostics.C
@@ -1,0 +1,18 @@
+namespace {
+   void TestErrHdlr(int level, Bool_t abort, const char *location,
+                    const char *msg)
+   { fprintf(stderr, "%s: %d: %s\n", __func__, level, msg); }
+}
+
+void clingTErrorDiagnostics() {
+   ::SetErrorHandler(TestErrHdlr);
+
+   gInterpreter->ProcessLine("int f1() { return; }");
+
+   gInterpreter->ReportDiagnosticsToErrorHandler();
+   gInterpreter->ProcessLine("int f2() { return; }");
+
+   gInterpreter->ReportDiagnosticsToErrorHandler(/*enable=*/false);
+   // This should revert to regular cling diagnostics
+   gInterpreter->ProcessLine("int f3() { return; }");
+}

--- a/root/meta/clingTErrorDiagnostics.ref
+++ b/root/meta/clingTErrorDiagnostics.ref
@@ -1,0 +1,11 @@
+
+input_line_26:1:12: error: non-void function 'f1' should return a value [-Wreturn-type]
+int f1() { return; }
+           ^
+TestErrHdlr: 3000: input_line_27:1:12: error: non-void function 'f2' should return a value [-Wreturn-type]
+int f2() { return; }
+           ^
+
+input_line_28:1:12: error: non-void function 'f3' should return a value [-Wreturn-type]
+int f3() { return; }
+           ^


### PR DESCRIPTION
`TCling::ReportDiagnosticsToErrorHandler()` enables reporting cling diagnostics via the ROOT
error handler, as required by the experiments.

For more information, see the sibling PR: https://github.com/root-project/root/pull/8737.