### PR TITLE
[math] Replace preprocessor define with constexpr in testInversion.cxx

### DIFF
--- a/root/math/smatrix/testInversion.cxx
+++ b/root/math/smatrix/testInversion.cxx
@@ -14,9 +14,7 @@
 #include "TStopwatch.h"
 
 // matrix size
-#ifndef N
-#define N 5
-#endif
+constexpr unsigned int N = 5;
 
 bool doSelfTest = true;
 


### PR DESCRIPTION
This is to fix build errors with https://github.com/root-project/root/pull/8769. Preprocessor defines are dangerous.