### PR TITLE
[py-cpp] Force address to be unsigned:

### DIFF
--- a/python/cpp/PointerPassing.C
+++ b/python/cpp/PointerPassing.C
@@ -4,30 +4,30 @@ public:
       static Z z[2];
       return &(z[idx]);
    }
-   static long GimeAddressPtr( void* obj ) {
-      return reinterpret_cast< long >( obj );
+   static unsigned long GimeAddressPtr( void* obj ) {
+      return reinterpret_cast< unsigned long >( obj );
    }
 
-   static long GimeAddressPtrRef( void*& obj ) {
-      return reinterpret_cast< long >( obj );
+   static unsigned long GimeAddressPtrRef( void*& obj ) {
+      return reinterpret_cast< unsigned long >( obj );
    }
 
-   static long SetAddressPtrRef( void*& obj ) {
+   static unsigned long SetAddressPtrRef( void*& obj ) {
       obj = (void*)0x1234;
       return 21;
    }
 
-   static long GimeAddressPtrPtr( void** obj ) {
-      return reinterpret_cast< long >( obj );
+   static unsigned long GimeAddressPtrPtr( void** obj ) {
+      return reinterpret_cast< unsigned long >( obj );
    }
 
-   static long SetAddressPtrPtr( void** obj ) {
+   static unsigned long SetAddressPtrPtr( void** obj ) {
       (*(long**)obj) = (long*)0x4321;
       return 42;
    }
 
-   static long GimeAddressObject( TObject* obj ) {
-      return reinterpret_cast< long >( obj );
+   static unsigned long GimeAddressObject( TObject* obj ) {
+      return reinterpret_cast< unsigned long >( obj );
    }
 
    static bool checkAddressOfZ(Z*& pZ) {


### PR DESCRIPTION
This matches `array.array("L",...` and fixes a signedness mismatch on 32bit:
```
FAIL: Test passing of variants of void pointer arguments
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/sftnight/build/AXEL/src/roottest/python/cpp/PyROOT_cpptests.py", line 62, in test12VoidPointerPassing
    self.assertEqual( addressofo.buffer_info()[0], Z.GimeAddressPtrPtr( addressofo ) )
AssertionError: 3079933240 != -1215034056
```