### PR TITLE
[DF] Remove useless include

### DIFF
--- a/root/dataframe/test_norootextension.cxx
+++ b/root/dataframe/test_norootextension.cxx
@@ -1,5 +1,4 @@
 #include <ROOT/RDataFrame.hxx>
-#include <ROOTUnitTestSupport.h>
 #include <TROOT.h>
 #include <TSystem.h>
 


### PR DESCRIPTION
Not only it's not needed, but it breaks standalone roottest builds.