### PR TITLE
[Rint] Test for issue #8772 (backslash-newline not working in Rint)

### DIFF
--- a/CTestCustom.cmake
+++ b/CTestCustom.cmake
@@ -20,6 +20,13 @@ if(CTEST_BUILD_NAME MATCHES slc6|centos7)
               roottest-root-multicore-fork)
 endif()
 
+if(WIN32)
+  # driveTabCom.py: `import pty` is not supported on Windows
+  list(APPEND CTEST_CUSTOM_TESTS_IGNORE
+              roottest-root-rint-TabCom
+              roottest-root-rint-BackslashNewline)
+endif()
+
 if(CTEST_BUILD_NAME MATCHES fst)
   list(APPEND CTEST_CUSTOM_TESTS_IGNORE roottest-python-JsMVA-NewMethods)
 endif()

--- a/root/rint/BackslashNewline_input.txt
+++ b/root/rint/BackslashNewline_input.txt
@@ -1,0 +1,7 @@
+#include <cstdlib>
+
+#define exit_if_backslash_newline_works() \
+   exit(EXIT_SUCCESS)
+
+exit_if_backslash_newline_works();
+exit(EXIT_FAILURE);

--- a/root/rint/CMakeLists.txt
+++ b/root/rint/CMakeLists.txt
@@ -7,4 +7,8 @@ if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64.*|x86.*|amd64.*|AMD64.*|i686.*|i386
                     OUTREF TabCom.oref
                     ERRREF TabCom.eref
                     COPY_TO_BUILDDIR MyClass.h)
+
+  ROOTTEST_ADD_TEST(BackslashNewline
+                    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/driveTabCom.py
+                    INPUT BackslashNewline_input.txt)
 endif()


### PR DESCRIPTION
Test that backslash-newline works in Rint (issue #8772).  See the complete discussion at https://github.com/root-project/root/pull/8772.

The matching PR for `root` was already merged.