### PR TITLE
[DF] Specify cores of SparkContext in tests

### DIFF
--- a/python/distrdf/test_definepersample.py
+++ b/python/distrdf/test_definepersample.py
@@ -43,7 +43,8 @@ class DefinePerSampleTest(unittest.TestCase):
         for filename in cls.filenames:
             write_tree(cls.maintreename, filename)
 
-        cls.sc = pyspark.SparkContext()
+        sparkconf = pyspark.SparkConf().setMaster("local[2]")
+        cls.sc = pyspark.SparkContext(conf=sparkconf)
 
     @classmethod
     def tearDownClass(cls):

--- a/python/distrdf/test_reducer_merge.py
+++ b/python/distrdf/test_reducer_merge.py
@@ -31,7 +31,8 @@ class ReducerMergeTest(unittest.TestCase):
         if sys.version_info.major >= 3:
             warnings.simplefilter("ignore", ResourceWarning)
 
-        cls.sc = pyspark.SparkContext()
+        sparkconf = pyspark.SparkConf().setMaster("local[2]")
+        cls.sc = pyspark.SparkContext(conf=sparkconf)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Sibling PR to https://github.com/root-project/root/pull/9216 . Make sure we know how many cores the SparkContext is using in each test and thus adapt the distributed Snapshot test