### PR TITLE
[skip-ci] Disable test if PyROOT is not available

### DIFF
--- a/root/meta/enumPayloadManipulation/CMakeLists.txt
+++ b/root/meta/enumPayloadManipulation/CMakeLists.txt
@@ -9,11 +9,13 @@
 ROOTTEST_GENERATE_REFLEX_DICTIONARY(checkEnumFwdDeclxDict x.h SELECTION selection_x.xml)
 ROOTTEST_GENERATE_REFLEX_DICTIONARY(checkEnumFwdDeclyDict y.h SELECTION selection_y.xml)
 
-ROOTTEST_ADD_TEST(checkEnumFwdDecl
-                  MACRO checkEnumFwdDecl.py
-                  OUTREF empty.ref
-                  ERRREF empty.ref
-                  DEPENDS checkEnumFwdDeclyDict-libgen-build checkEnumFwdDeclxDict-libgen-build)
+if(ROOT_pyroot_FOUND)
+  ROOTTEST_ADD_TEST(checkEnumFwdDecl
+                    MACRO checkEnumFwdDecl.py
+                    OUTREF empty.ref
+                    ERRREF empty.ref
+                    DEPENDS checkEnumFwdDeclyDict-libgen-build checkEnumFwdDeclxDict-libgen-build)
+endif()
 
 ROOTTEST_ADD_TESTDIRS()
 


### PR DESCRIPTION
Prevent the following error when ROOT has been built without PyROOT:
```
test 1416
    Start 1416: roottest-root-meta-enumPayloadManipulation-checkEnumFwdDecl

1416: Test command: "C:\Program Files\CMake\bin\cmake.exe" "-DCMD=C:/Users/bellenot/AppData/Local/Continuum/miniconda3/python.exe^C:/Users/bellenot/git/roottest/root/meta/enumPayloadManipulation/checkEnumFwdDecl.py^--fixcling" "-DOUT=C:/Users/bellenot/build/x64/release/roottest/root/meta/enumPayloadManipulation/checkEnumFwdDecl.log" "-DOUTREF=C:/Users/bellenot/git/roottest/root/meta/enumPayloadManipulation/empty.ref" "-DERRREF=C:/Users/bellenot/git/roottest/root/meta/enumPayloadManipulation/empty.ref" "-DERR=C:/Users/bellenot/build/x64/release/roottest/root/meta/enumPayloadManipulation/checkEnumFwdDecl.err" "-DCWD=C:/Users/bellenot/build/x64/release/roottest/root/meta/enumPayloadManipulation" "-DDIFFCMD=C:/Users/bellenot/AppData/Local/Continuum/miniconda3/python.exe^C:/Users/bellenot/git/roottest/scripts/custom_diff.py" "-DCHECKOUT=true" "-DCHECKERR=true" "-DSYS=C:/Users/bellenot/build/x64/release" "-DENV=ROOTSYS=C:/Users/bellenot/build/x64/release#PYTHONPATH=C:/Users/bellenot/build/x64/release/bin" "-P" "C:/Users/bellenot/build/x64/release/RootTestDriver.cmake"
1416: Environment variables:
1416:  ROOT_HIST=0
1416: Test timeout computed to be: 300
1416: -- TEST COMMAND --
1416: cd C:/Users/bellenot/build/x64/release/roottest/root/meta/enumPayloadManipulation
1416: C:/Users/bellenot/AppData/Local/Continuum/miniconda3/python.exe C:/Users/bellenot/git/roottest/root/meta/enumPayloadManipulation/checkEnumFwdDecl.py --fixcling
1416: -- BEGIN TEST OUTPUT --
1416:
1416: -- END TEST OUTPUT --
1416: -- BEGIN TEST ERROR --
1416: Traceback (most recent call last):
1416:   File "C:/Users/bellenot/git/roottest/root/meta/enumPayloadManipulation/checkEnumFwdDecl.py", line 1, in <module>
1416:     import ROOT
1416: ModuleNotFoundError: No module named 'ROOT'
1416:
1416: -- END TEST ERROR --
1416: CMake Error at C:/Users/bellenot/build/x64/release/RootTestDriver.cmake:181 (message):
1416:   got exit code 1 but expected 0
1416:
1416:
3/3 Test #1416: roottest-root-meta-enumPayloadManipulation-checkEnumFwdDecl .....................***Failed    0.14 sec
```
