### PR TITLE
stl_makeproject_test: Add dependency on Hist (if available)

### DIFF
--- a/root/meta/MakeProject/CMakeLists.txt
+++ b/root/meta/MakeProject/CMakeLists.txt
@@ -1,4 +1,9 @@
 ROOTTEST_GENERATE_DICTIONARY(stl_makeproject_test stl_makeproject_test.h LINKDEF stl_makeproject_test_linkdef.h)
+# If we build roottest in-tree, add a dependecy on Hist because the header
+# includes TH1D.
+if(TARGET Hist)
+  add_dependencies(stl_makeproject_test Hist)
+endif()
 
 if(ROOT_runtime_cxxmodules_FOUND)
   # FIXME: For C++ modules builds, module.modulemap is generated during configuration time 


### PR DESCRIPTION
This resolves issues with in-tree builds of roottest where the build system would try to generate the dictionary before Hist is built and then fails because `TH1D.h` is included, but `Hist.pcm` not specified as a by-product.

Closes https://github.com/root-project/root/issues/9600