### PR TITLE
[DF] Actually run roottest distrdf tests of distributed RunGraphs

### DIFF
--- a/python/distrdf/common/test_rungraphs.py
+++ b/python/distrdf/common/test_rungraphs.py
@@ -66,20 +66,20 @@ class RunGraphsTests(unittest.TestCase):
         nentries = 10000
         opts = ROOT.RDF.RSnapshotOptions()
         opts.fAutoFlush = 5000
-        ROOT.RDataFrame(nentries).Define("b1", "gRandom->Gaus(10, 1)")\
-                                 .Define("b2", "gRandom->Gaus(10, 1)")\
-                                 .Define("b3", "gRandom->Gaus(10, 1)")\
+        ROOT.RDataFrame(nentries).Define("b1", "42")\
+                                 .Define("b2", "42")\
+                                 .Define("b3", "42")\
                                  .Snapshot(treename, filename, ["b1", "b2", "b3"], opts)
 
         histoproxies_spark = [
             Spark.RDataFrame(treename, filename, sparkcontext=self.sc, npartitions=2)
-                 .Histo1D((col, col, 100, 0, 20), col)
+                 .Histo1D((col, col, 1, 40, 45), col)
             for col in ["b1", "b2", "b3"]
         ]
 
         histoproxies_dask = [
             Dask.RDataFrame(treename, filename, daskclient=self.client, npartitions=2)
-                .Histo1D((col, col, 100, 0, 20), col)
+                .Histo1D((col, col, 1, 40, 45), col)
             for col in ["b1", "b2", "b3"]
         ]
 
@@ -97,7 +97,7 @@ class RunGraphsTests(unittest.TestCase):
             histo = proxy.proxied_node.value
             self.assertIsInstance(histo, ROOT.TH1D)
             self.assertEqual(histo.GetEntries(), nentries)
-            self.assertAlmostEqual(histo.GetMean(), 10)
+            self.assertAlmostEqual(histo.GetMean(), 42)
 
         os.remove(filename)
 

--- a/python/distrdf/common/test_rungraphs.py
+++ b/python/distrdf/common/test_rungraphs.py
@@ -100,3 +100,7 @@ class RunGraphsTests(unittest.TestCase):
             self.assertAlmostEqual(histo.GetMean(), 10)
 
         os.remove(filename)
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[__file__])

--- a/python/distrdf/dask/test_rungraphs.py
+++ b/python/distrdf/dask/test_rungraphs.py
@@ -64,3 +64,7 @@ class RunGraphsTests(unittest.TestCase):
             self.assertAlmostEqual(histo.GetMean(), 10)
 
         os.remove(filename)
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[__file__])

--- a/python/distrdf/dask/test_rungraphs.py
+++ b/python/distrdf/dask/test_rungraphs.py
@@ -38,14 +38,14 @@ class RunGraphsTests(unittest.TestCase):
         nentries = 10000
         opts = ROOT.RDF.RSnapshotOptions()
         opts.fAutoFlush = 5000
-        ROOT.RDataFrame(nentries).Define("b1", "gRandom->Gaus(10, 1)")\
-                                 .Define("b2", "gRandom->Gaus(10, 1)")\
-                                 .Define("b3", "gRandom->Gaus(10, 1)")\
+        ROOT.RDataFrame(nentries).Define("b1", "42")\
+                                 .Define("b2", "42")\
+                                 .Define("b3", "42")\
                                  .Snapshot(treename, filename, ["b1", "b2", "b3"], opts)
 
         histoproxies = [
             Dask.RDataFrame(treename, filename, daskclient=self.client, npartitions=2)
-                .Histo1D((col, col, 100, 0, 20), col)
+                .Histo1D((col, col, 1, 40, 45), col)
             for col in ["b1", "b2", "b3"]
         ]
 
@@ -61,7 +61,7 @@ class RunGraphsTests(unittest.TestCase):
             histo = proxy.proxied_node.value
             self.assertIsInstance(histo, ROOT.TH1D)
             self.assertEqual(histo.GetEntries(), nentries)
-            self.assertAlmostEqual(histo.GetMean(), 10)
+            self.assertAlmostEqual(histo.GetMean(), 42)
 
         os.remove(filename)
 

--- a/python/distrdf/spark/test_rungraphs.py
+++ b/python/distrdf/spark/test_rungraphs.py
@@ -56,14 +56,14 @@ class RunGraphsTests(unittest.TestCase):
         nentries = 10000
         opts = ROOT.RDF.RSnapshotOptions()
         opts.fAutoFlush = 5000
-        ROOT.RDataFrame(nentries).Define("b1", "gRandom->Gaus(10, 1)")\
-                                 .Define("b2", "gRandom->Gaus(10, 1)")\
-                                 .Define("b3", "gRandom->Gaus(10, 1)")\
+        ROOT.RDataFrame(nentries).Define("b1", "42")\
+                                 .Define("b2", "42")\
+                                 .Define("b3", "42")\
                                  .Snapshot(treename, filename, ["b1", "b2", "b3"], opts)
 
         histoproxies = [
             Spark.RDataFrame(treename, filename, sparkcontext=self.sc, npartitions=2)
-                 .Histo1D((col, col, 100, 0, 20), col)
+                 .Histo1D((col, col, 1, 40, 45), col)
             for col in ["b1", "b2", "b3"]
         ]
 
@@ -79,7 +79,7 @@ class RunGraphsTests(unittest.TestCase):
             histo = proxy.proxied_node.value
             self.assertIsInstance(histo, ROOT.TH1D)
             self.assertEqual(histo.GetEntries(), nentries)
-            self.assertAlmostEqual(histo.GetMean(), 10)
+            self.assertAlmostEqual(histo.GetMean(), 42)
 
         os.remove(filename)
 

--- a/python/distrdf/spark/test_rungraphs.py
+++ b/python/distrdf/spark/test_rungraphs.py
@@ -82,3 +82,7 @@ class RunGraphsTests(unittest.TestCase):
             self.assertAlmostEqual(histo.GetMean(), 10)
 
         os.remove(filename)
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[__file__])


### PR DESCRIPTION
In roottest, python tests need to include a call to actually start the
test, unlike plain pytest tests that would just run without it.

When introducing distributed RunGraphs tests, this call was omitted,
effectively preventing CI tests of the feature.