### PR TITLE
Minor fix to `meta/tclass/execState.C`

### DIFF
--- a/root/meta/tclass/execState.C
+++ b/root/meta/tclass/execState.C
@@ -6,7 +6,7 @@ void writeState() {
 int execState() {
    int result = 0;
 
-   gROOT->ProcessLine("class Event;");
+   gInterpreter->Declare("class Event;");
    TClass *c = TClass::GetClass("Event"); 
    if (TClass::kForwardDeclared != c->GetState()) {
       Error("execState","State is %d instead of %d (TClass::kForwardDeclared)",


### PR DESCRIPTION
Use `gInterpreter->Declare()`, instead of `gROOT->ProcessLine()`, to introduce a forward declaration.  By design, `ProcessLine()` cannot guarantee that the user-provided code is not internally modified by cling.

See https://github.com/root-project/root/pull/9782.