### PR TITLE
Link libEvent against dependent libs:

### DIFF
--- a/scripts/Event.mk
+++ b/scripts/Event.mk
@@ -48,9 +48,6 @@ else
 ifeq ($(ARCH),aix5)
 		$(CMDECHO) /usr/vacpp/bin/makeC++SharedLib $(OutPutOpt) $@ $(LIBS) -p 0 $^
 else
-ifeq ($(PLATFORM),macosx)
-		$(CMDECHO) $(LD) $(SOFLAGS) $(EVENTO) $(OutPutOpt) $(EVENTLIB) $(EXPLLINKLIBS)
-else
 ifeq ($(PLATFORM),win32)
 		$(CMDECHO) bindexplib $* $(EVENTO) > $*.def
 		$(CMDECHO) lib -nologo -MACHINE:IX86 $(EVENTO) -def:$*.def \
@@ -59,7 +56,6 @@ ifeq ($(PLATFORM),win32)
 		   $(OutPutOpt)$@
 else
 		$(CMDECHO) $(LD) $(SOFLAGS) $(LDFLAGS) $^ $(OutPutOpt) $@ $(EXPLLINKLIBS)
-endif
 endif
 endif
 endif


### PR DESCRIPTION
in the old Makefile, many of the old variables are unset when running
from ctest. One of those is EXPLLINKLIBS. Instead, the dependent libraries
are linked through $^ - but only on Linux, not on macOS.

Fix roottest/root/treeformula/sync failing in Simple with
```
cling::DynamicLibraryManager::loadLibrary(): dlopen(/Users/sftnight/build/jenkins/night/LABEL/mac12/SPEC/soversion/V/master/roottest/root/treeformula/sync/libEvent.so, 0x0009): symbol not found in flat namespace '__ZN4TH1FC1EPKcS1_idd'
Processing Run.C(1)...
...
```
due to the missing dependent libraries (libHist).

That's fixed simply by using the default case for both Linux and macOS. Yay!