### PR TITLE
[6.24] Pyspark MacOs fork issue

### DIFF
--- a/python/distrdf/CMakeLists.txt
+++ b/python/distrdf/CMakeLists.txt
@@ -12,6 +12,18 @@ file(COPY test_shared_libraries DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 # Define environment variables needed in all pyspark tests
 set(PYSPARK_ENV_VARS PYSPARK_PYTHON=${PYTHON_EXECUTABLE_Development_Main})
 
+if(MACOSX_VERSION VERSION_GREATER_EQUAL 10.13)
+    # MacOS has changed rules about forking processes after 10.13
+    # Running pyspark tests with XCode Python3 throws crashes with errors like:
+    # `objc[17271]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.`
+    # This issue should have been fixed after Python 3.8 (see https://bugs.python.org/issue33725)
+    # Indeed, any other Python 3.8+ executable does not show this crash. It is
+    # specifically the XCode Python executable that triggers this.
+    # For now, there seems no other way than this workaround,
+    # which effectively sets the behaviour of `fork` back to MacOS 10.12
+    list(APPEND PYSPARK_ENV_VARS OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES)
+endif()
+
 ROOTTEST_ADD_TEST(spark_test_friend_trees
                   MACRO test_friend_trees.py
                   ENVIRONMENT ${PYSPARK_ENV_VARS})

--- a/python/distrdf/CMakeLists.txt
+++ b/python/distrdf/CMakeLists.txt
@@ -9,19 +9,27 @@ if (ROOT_dataframe_FOUND AND
 file(COPY test_headers DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY test_shared_libraries DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
+# Define environment variables needed in all pyspark tests
+set(PYSPARK_ENV_VARS PYSPARK_PYTHON=${PYTHON_EXECUTABLE_Development_Main})
+
 ROOTTEST_ADD_TEST(spark_test_friend_trees
-                  MACRO test_friend_trees.py)
+                  MACRO test_friend_trees.py
+                  ENVIRONMENT ${PYSPARK_ENV_VARS})
 
 ROOTTEST_ADD_TEST(spark_test_histo_write 
-                  MACRO test_histo_write.py)
+                  MACRO test_histo_write.py
+                  ENVIRONMENT ${PYSPARK_ENV_VARS})
 
 ROOTTEST_ADD_TEST(spark_test_include_headers 
-                  MACRO test_include_headers.py)
+                  MACRO test_include_headers.py
+                  ENVIRONMENT ${PYSPARK_ENV_VARS})
 
 ROOTTEST_ADD_TEST(spark_test_inv_mass 
-                  MACRO test_inv_mass.py)
+                  MACRO test_inv_mass.py
+                  ENVIRONMENT ${PYSPARK_ENV_VARS})
 
 ROOTTEST_ADD_TEST(spark_test_reducer_merge 
-                  MACRO test_reducer_merge.py)
+                  MACRO test_reducer_merge.py
+                  ENVIRONMENT ${PYSPARK_ENV_VARS})
 
 endif()

--- a/python/distrdf/test_friend_trees.py
+++ b/python/distrdf/test_friend_trees.py
@@ -12,22 +12,11 @@ class SparkFriendTreesTest(unittest.TestCase):
     """Integration tests to check the working of DistRDF with friend trees"""
 
     @classmethod
-    def setUpClass(cls):
-        """
-        Synchronize PYSPARK_PYTHON variable to the current Python executable.
-
-        Needed to avoid mismatch between python versions on driver and on
-        the fake executor on the same machine.
-        """
-        os.environ["PYSPARK_PYTHON"] = sys.executable
-
-    @classmethod
     def tearDownClass(cls):
         """
-        Stop the SparkContext and reset environment variable.
+        Stop the SparkContext
         """
         pyspark.SparkContext.getOrCreate().stop()
-        os.environ["PYSPARK_PYTHON"] = ""
 
     def create_parent_tree(self):
         """Creates a .root file with the parent TTree"""

--- a/python/distrdf/test_histo_write.py
+++ b/python/distrdf/test_histo_write.py
@@ -20,23 +20,15 @@ class SparkHistoWriteTest(unittest.TestCase):
 
         Set class parameters related to the histogram.
 
-        Synchronize PYSPARK_PYTHON variable to the current Python executable.
         """
         cls.nentries = 10000  # Number of fills
         cls.gaus_mean = 10  # Mean of the gaussian distribution
         cls.gaus_stdev = 1  # Standard deviation of the gaussian distribution
         cls.delta_equal = 0.01  # Delta to check for float equality
 
-        os.environ["PYSPARK_PYTHON"] = sys.executable
-
     def tearDown(self):
         """Clean up the `SparkContext` object that was created."""
         pyspark.SparkContext.getOrCreate().stop()
-
-    @classmethod
-    def tearDownClass(cls):
-        """Reset environment variable."""
-        os.environ["PYSPARK_PYTHON"] = ""
 
     def create_tree_with_data(self):
         """Creates a .root file with some data"""

--- a/python/distrdf/test_include_headers.py
+++ b/python/distrdf/test_include_headers.py
@@ -13,26 +13,9 @@ class IncludesSparkTest(unittest.TestCase):
     environment.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Synchronize PYSPARK_PYTHON variable to the current Python executable.
-
-        Needed to avoid mismatch between python versions on driver and on
-        the fake executor on the same machine.
-        """
-        os.environ["PYSPARK_PYTHON"] = sys.executable
-
     def tearDown(self):
         """Stop any created SparkContext"""
         pyspark.SparkContext.getOrCreate().stop()
-
-    @classmethod
-    def tearDownClass(cls):
-        """
-        Stop the SparkContext and reset environment variable.
-        """
-        os.environ["PYSPARK_PYTHON"] = ""
 
     def test_includes_function_with_filter_and_histo(self):
         """

--- a/python/distrdf/test_inv_mass.py
+++ b/python/distrdf/test_inv_mass.py
@@ -11,26 +11,9 @@ from DistRDF.Backends import Spark
 class SparkHistogramsTest(unittest.TestCase):
     """Integration tests to check the working of DistRDF."""
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Synchronize PYSPARK_PYTHON variable to the current Python executable.
-
-        Needed to avoid mismatch between python versions on driver and on
-        the fake executor on the same machine.
-        """
-        os.environ["PYSPARK_PYTHON"] = sys.executable
-
     def tearDown(self):
         """Stop any created SparkContext"""
         pyspark.SparkContext.getOrCreate().stop()
-
-    @classmethod
-    def tearDownClass(cls):
-        """
-        Stop the SparkContext and reset environment variable.
-        """
-        os.environ["PYSPARK_PYTHON"] = ""
 
     def build_pyrdf_graph(self):
         """

--- a/python/distrdf/test_reducer_merge.py
+++ b/python/distrdf/test_reducer_merge.py
@@ -11,26 +11,9 @@ from DistRDF.Backends import Spark
 class ReducerMergeTest(unittest.TestCase):
     """Check the working of merge operations in the reducer function."""
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Synchronize PYSPARK_PYTHON variable to the current Python executable.
-
-        Needed to avoid mismatch between python versions on driver and on
-        the fake executor on the same machine.
-        """
-        os.environ["PYSPARK_PYTHON"] = sys.executable
-
     def tearDown(self):
         """Stop any created SparkContext"""
         pyspark.SparkContext.getOrCreate().stop()
-
-    @classmethod
-    def tearDownClass(cls):
-        """
-        Stop the SparkContext and reset environment variable.
-        """
-        os.environ["PYSPARK_PYTHON"] = ""
 
     def assertHistoOrProfile(self, obj_1, obj_2):
         """Asserts equality between two 'ROOT.TH1' or 'ROOT.TH2' objects."""


### PR DESCRIPTION
Logical backport of https://github.com/root-project/roottest/pull/817 but adjusted to the status of the tests in 6.24