### PR TITLE
[PyROOT][9846] Succeed when comparing integer types of the same size …

### DIFF
--- a/python/basic/PyROOT_datatypetest.py
+++ b/python/basic/PyROOT_datatypetest.py
@@ -19,6 +19,8 @@ from pytest import raises
 
 PYTEST_MIGRATION = True
 
+is_64bit = sys.maxsize > 2**32
+
 def setup_module(mod):
     import sys, os
     if not os.path.exists('DataTypes.C'):
@@ -301,7 +303,12 @@ class TestClassDATATYPES:
 
             # typed passing
             ca = c.pass_array(b)
-            assert ca.typecode == b.typecode
+            if is_64bit:
+                assert ca.typecode == b.typecode
+            else:
+                # 'i','l' and 'I','L' are the same size in 32 bits
+                if t == 'l':   assert ca.typecode in ['i','l']
+                elif t == 'L': assert ca.typecode in ['I','L']
             assert len(b) == self.N
             for i in range(self.N):
                 assert ca[i] == b[i]


### PR DESCRIPTION
…in 32 bits

We allow to match arrays of type 'l' with an overload that expects
'i', since both types have the same size in 32 bits (same applies
to 'L' and 'I'). The reason why we allow this is that, in 32 bits,
NumPy assigns the typecode 'l' to int32 arrays and 'L' to uint32
arrays (see sibling PR 9889 in ROOT for more details).

This PR goes together with https://github.com/root-project/root/pull/9889