### PR TITLE
[win64] fix python-basic-operator error on Windows 64 bit

### DIFF
--- a/python/basic/Operators.C
+++ b/python/basic/Operators.C
@@ -74,8 +74,8 @@ struct OperatorInt {
 };
 
 struct OperatorLong {
-   operator long() { return m_long; }
-   long m_long;
+   operator intptr_t() { return m_long; }
+   intptr_t m_long;
 };
 
 struct OperatorDouble {
@@ -94,8 +94,8 @@ struct OperatorUnsignedInt {
 };
 
 struct OperatorUnsignedLong {
-   operator unsigned long() { return m_ulong; }
-   unsigned long m_ulong;
+   operator uintptr_t() { return m_ulong; }
+   uintptr_t m_ulong;
 };
 
 struct OperatorFloat {

--- a/python/basic/Operators.C
+++ b/python/basic/Operators.C
@@ -74,8 +74,13 @@ struct OperatorInt {
 };
 
 struct OperatorLong {
+#ifdef _WIN64
    operator intptr_t() { return m_long; }
    intptr_t m_long;
+#else
+   operator long() { return m_long; }
+   long m_long;
+#endif
 };
 
 struct OperatorDouble {
@@ -94,8 +99,13 @@ struct OperatorUnsignedInt {
 };
 
 struct OperatorUnsignedLong {
+#ifdef _WIN64
    operator uintptr_t() { return m_ulong; }
    uintptr_t m_ulong;
+#else
+   operator unsigned long() { return m_ulong; }
+   unsigned long m_ulong;
+#endif
 };
 
 struct OperatorFloat {

--- a/python/basic/Operators.C
+++ b/python/basic/Operators.C
@@ -75,8 +75,8 @@ struct OperatorInt {
 
 struct OperatorLong {
 #ifdef _WIN64
-   operator intptr_t() { return m_long; }
-   intptr_t m_long;
+   operator int64_t() { return m_long; }
+   int64_t m_long;
 #else
    operator long() { return m_long; }
    long m_long;
@@ -100,8 +100,8 @@ struct OperatorUnsignedInt {
 
 struct OperatorUnsignedLong {
 #ifdef _WIN64
-   operator uintptr_t() { return m_ulong; }
-   uintptr_t m_ulong;
+   operator uint64_t() { return m_ulong; }
+   uint64_t m_ulong;
 #else
    operator unsigned long() { return m_ulong; }
    unsigned long m_ulong;


### PR DESCRIPTION
Fix the following error on Windows 64 bit:
```
1299: Test implementation of operator bool ... ok
1299: Test converter operators of exact types ... ok
1299: Test converter operators of approximate types ... ERROR
1299: Templated method operator+/- ... ok
1299:
1299: ======================================================================
1299: ERROR: Test converter operators of approximate types
1299: ----------------------------------------------------------------------
1299: Traceback (most recent call last):
1299:   File "C:/Users/sftnight/git/roottest/python/basic/PyROOT_operatortests.py", line 127, in test2ApproximateTypes
1299:     o = OperatorUnsignedLong(); o.m_ulong = maxvalue + 128
1299: ValueError: can't convert negative value to unsigned long
1299:
1299: ----------------------------------------------------------------------
1299:
1299: FAILED (errors=1)
1299:
1299: -- END TEST OUTPUT --
1299: CMake Error at C:/Users/sftnight/build/release/RootTestDriver.cmake:181 (message):
1299:   got exit code 1 but expected 0
1299:
1299:
1/1 Test #1299: roottest-python-basic-operator ...***Failed   12.59 sec
```
The `long` and `unsigned long` types are 32 bit on Win64