### PR TITLE
Fix cling-bytecode-runhenry on Windows 64

### DIFF
--- a/cling/bytecode/runhenry.C
+++ b/cling/bytecode/runhenry.C
@@ -35,8 +35,11 @@ void runhenry(){
   FILE *data;
   char datafname[]="henry.dat";
   
-  data = fopen(datafname,"r");
-  while (fscanf(data, "%lf %lf %lf %lf",&x,&xE,&y,&yE) != EOF) {
+  std::ifstream in(datafname);
+  while (in.is_open() && !in.eof()) {
+    in >> x >> xE >> y >> yE;
+    if (!in.good())
+      break;
     xVec.push_back(x);
     yVec.push_back(y);
     xEVec.push_back(xE);

--- a/cling/bytecode/runhenry.C
+++ b/cling/bytecode/runhenry.C
@@ -32,7 +32,6 @@ void runhenry(){
   vector<double> yEVec;
   double x(0),y(0),xE(0), yE(0);
   double output[3];
-  FILE *data;
   char datafname[]="henry.dat";
   
   std::ifstream in(datafname);


### PR DESCRIPTION
Fix an error when using fscanf on Windows 64 bit:
```
1141: Processing C:/Users/sftnight/git/roottest/cling/bytecode/runhenry.C...
1141:
1141: -- END TEST OUTPUT --
1141: CMake Error at C:/Users/sftnight/build/release/RootTestDriver.cmake:181 (message):
1141:   got exit code Exit code 0xc0000409
1141:
1141:    but expected 0
1141:
1141:
1/1 Test #1141: roottest-cling-bytecode-runhenry ...***Failed    2.13 sec
```