### PR TITLE
[DF] Run distributed tests in sequence

### DIFF
--- a/python/distrdf/common/CMakeLists.txt
+++ b/python/distrdf/common/CMakeLists.txt
@@ -20,6 +20,7 @@ if (ROOT_test_distrdf_pyspark_FOUND AND ROOT_test_distrdf_dask_FOUND)
 
     ROOTTEST_ADD_TEST(common_test_rungraphs
                     MACRO test_rungraphs.py
-                    ENVIRONMENT ${PYSPARK_ENV_VARS})
+                    ENVIRONMENT ${PYSPARK_ENV_VARS}
+                    RUN_SERIAL)
 
 endif()

--- a/python/distrdf/dask/CMakeLists.txt
+++ b/python/distrdf/dask/CMakeLists.txt
@@ -3,27 +3,35 @@
 if (ROOT_test_distrdf_dask_FOUND)
 
 ROOTTEST_ADD_TEST(dask_test_backend
-                  MACRO test_backend.py)
+                  MACRO test_backend.py
+                  RUN_SERIAL)
 
 ROOTTEST_ADD_TEST(dask_test_definepersample 
-                  MACRO test_definepersample.py)
+                  MACRO test_definepersample.py
+                  RUN_SERIAL)
 
 ROOTTEST_ADD_TEST(dask_test_friend_trees
-                  MACRO test_friend_trees.py)
+                  MACRO test_friend_trees.py
+                  RUN_SERIAL)
 
 ROOTTEST_ADD_TEST(dask_test_histo_write 
-                  MACRO test_histo_write.py)
+                  MACRO test_histo_write.py
+                  RUN_SERIAL)
 
 ROOTTEST_ADD_TEST(dask_test_include_headers 
-                  MACRO test_include_headers.py)
+                  MACRO test_include_headers.py
+                  RUN_SERIAL)
 
 ROOTTEST_ADD_TEST(dask_test_inv_mass 
-                  MACRO test_inv_mass.py)
+                  MACRO test_inv_mass.py
+                  RUN_SERIAL)
 
 ROOTTEST_ADD_TEST(dask_test_rungraphs
-                  MACRO test_rungraphs.py)
+                  MACRO test_rungraphs.py
+                  RUN_SERIAL)
 
 ROOTTEST_ADD_TEST(dask_test_reducer_merge 
-                  MACRO test_reducer_merge.py)
+                  MACRO test_reducer_merge.py
+                  RUN_SERIAL)
 
 endif()

--- a/python/distrdf/spark/CMakeLists.txt
+++ b/python/distrdf/spark/CMakeLists.txt
@@ -19,34 +19,42 @@ if (ROOT_test_distrdf_pyspark_FOUND)
 
     ROOTTEST_ADD_TEST(spark_test_backend
                     MACRO test_backend.py
-                    ENVIRONMENT ${PYSPARK_ENV_VARS})
+                    ENVIRONMENT ${PYSPARK_ENV_VARS}
+                    RUN_SERIAL)
 
     ROOTTEST_ADD_TEST(spark_test_definepersample
                     MACRO test_definepersample.py
-                    ENVIRONMENT ${PYSPARK_ENV_VARS})
+                    ENVIRONMENT ${PYSPARK_ENV_VARS}
+                    RUN_SERIAL)
 
     ROOTTEST_ADD_TEST(spark_test_friend_trees
                     MACRO test_friend_trees.py
-                    ENVIRONMENT ${PYSPARK_ENV_VARS})
+                    ENVIRONMENT ${PYSPARK_ENV_VARS}
+                    RUN_SERIAL)
 
     ROOTTEST_ADD_TEST(spark_test_histo_write
                     MACRO test_histo_write.py
-                    ENVIRONMENT ${PYSPARK_ENV_VARS})
+                    ENVIRONMENT ${PYSPARK_ENV_VARS}
+                    RUN_SERIAL)
 
     ROOTTEST_ADD_TEST(spark_test_include_headers
                     MACRO test_include_headers.py
-                    ENVIRONMENT ${PYSPARK_ENV_VARS})
+                    ENVIRONMENT ${PYSPARK_ENV_VARS}
+                    RUN_SERIAL)
 
     ROOTTEST_ADD_TEST(spark_test_inv_mass
                     MACRO test_inv_mass.py
-                    ENVIRONMENT ${PYSPARK_ENV_VARS})
+                    ENVIRONMENT ${PYSPARK_ENV_VARS}
+                    RUN_SERIAL)
 
     ROOTTEST_ADD_TEST(spark_test_rungraphs
                     MACRO test_rungraphs.py
-                    ENVIRONMENT ${PYSPARK_ENV_VARS})
+                    ENVIRONMENT ${PYSPARK_ENV_VARS}
+                    RUN_SERIAL)
 
     ROOTTEST_ADD_TEST(spark_test_reducer_merge
                     MACRO test_reducer_merge.py
-                    ENVIRONMENT ${PYSPARK_ENV_VARS})
+                    ENVIRONMENT ${PYSPARK_ENV_VARS}
+                    RUN_SERIAL)
 
 endif()


### PR DESCRIPTION
CTest by default runs tests in parallel. Distributed tests need more
resources by default, plus they all need to create instances of mock
local clusters that may need to reserve ports. On some nodes this leads
to timeouts when running in parallel.