### PR TITLE
[6.26] Disable distributed tests on M1 ARM

### DIFF
--- a/python/distrdf/CMakeLists.txt
+++ b/python/distrdf/CMakeLists.txt
@@ -4,7 +4,8 @@
 # * The Python version is greater than 3.7
 if (ROOT_dataframe_FOUND AND
     ROOT_pyroot_FOUND AND
-    PYTHON_VERSION_STRING_Development_Main VERSION_GREATER_EQUAL 3.7)
+    PYTHON_VERSION_STRING_Development_Main VERSION_GREATER_EQUAL 3.7
+    AND NOT (APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES arm64))
 
     file(COPY test_headers DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
     file(COPY test_shared_libraries DESTINATION ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
Due to JIT relocation errors. Re-enable when fixed. Backport of #839 