### PR TITLE
Fix perfstattest-libevent-build on macOS

### DIFF
--- a/root/tree/cache/CMakeLists.txt
+++ b/root/tree/cache/CMakeLists.txt
@@ -57,7 +57,7 @@ ROOTTEST_ADD_TEST(LastCluster
 ROOT_GENERATE_DICTIONARY(G__TheEvent ${CMAKE_CURRENT_SOURCE_DIR}/Event.h LINKDEF EventLinkDef.h)
 ROOT_LINKER_LIBRARY(TheEvent TEST Event.cxx G__TheEvent.cxx LIBRARIES ${ROOT_LIBRARIES})
 ROOTTEST_ADD_TEST(perfstattest-libevent-build 
-                  COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config $<CONFIG> --target TheEvent${fast} -- ${always-make})
+                  COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config $<CONFIG> --target TheEvent${fast})
 if(MSVC)
       add_custom_command(TARGET TheEvent POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/libTheEvent.dll ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
Remove the flag to always rebuild with Unix Makefiles to match what we do in `cling-stl-dicts`, which also has a library depending on a generated dictionary file (actually multiple). The reason this does not work is that `/fast` ignores dependencies, and in conjunction with `--always-make` it results in the build system not finding the generated files.