### PR TITLE
[tcling,v6-24] Remove `WILLFAIL_ON_WIN32` for roottest_root_meta_tclass_execSharedPtr

### DIFF
--- a/root/meta/tclass/CMakeLists.txt
+++ b/root/meta/tclass/CMakeLists.txt
@@ -37,8 +37,7 @@ ROOTTEST_ADD_TEST(execState
 
 ROOTTEST_ADD_TEST(execSharedPtr
                   MACRO execSharedPtr.C
-                  ERRREF execSharedPtr.eref
-                  ${WILLFAIL_ON_WIN32})
+                  ERRREF execSharedPtr.eref)
 
 ROOTTEST_ADD_TEST(execMTInit
                   MACRO execMTInit.C


### PR DESCRIPTION
Backport of PR https://github.com/root-project/roottest/pull/791.

Sibling PR here: https://github.com/root-project/root/pull/10120.