### PR TITLE
Adapt for CMP0113

### DIFF
--- a/cling/stl/dicts/CMakeLists.txt
+++ b/cling/stl/dicts/CMakeLists.txt
@@ -6,5 +6,8 @@ ROOT_LINKER_LIBRARY(stldictTest TEST MyClass1.cpp MyClass2.cpp MyClass3.cpp
                                      MyDict1.cxx MyDict2.cxx MyDict3.cxx
                                 LIBRARIES ${ROOT_LIBRARIES})
 
+# Right now, this target doesn't seems subject to CMP0113. If this changes in
+# the future, add "MyDict1${fast} MyDict2${fast} MyDict3${fast}" to the list
+# of targets. Doing so right now would build the dictionaries twice.
 ROOT_ADD_TEST(roottest-cling-stl-dicts-build 
-              COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config $<CONFIG> --target stldictTest${fast})
+              COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config $<CONFIG> --target stldictTest${fast} -- ${always-make})

--- a/root/tree/cache/CMakeLists.txt
+++ b/root/tree/cache/CMakeLists.txt
@@ -57,7 +57,7 @@ ROOTTEST_ADD_TEST(LastCluster
 ROOT_GENERATE_DICTIONARY(G__TheEvent ${CMAKE_CURRENT_SOURCE_DIR}/Event.h LINKDEF EventLinkDef.h)
 ROOT_LINKER_LIBRARY(TheEvent TEST Event.cxx G__TheEvent.cxx LIBRARIES ${ROOT_LIBRARIES})
 ROOTTEST_ADD_TEST(perfstattest-libevent-build 
-                  COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config $<CONFIG> --target TheEvent${fast})
+                  COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config $<CONFIG> --target TheEvent${fast} -- ${always-make})
 if(MSVC)
       add_custom_command(TARGET TheEvent POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/libTheEvent.dll ${CMAKE_CURRENT_BINARY_DIR})

--- a/root/tree/cache/CMakeLists.txt
+++ b/root/tree/cache/CMakeLists.txt
@@ -57,7 +57,7 @@ ROOTTEST_ADD_TEST(LastCluster
 ROOT_GENERATE_DICTIONARY(G__TheEvent ${CMAKE_CURRENT_SOURCE_DIR}/Event.h LINKDEF EventLinkDef.h)
 ROOT_LINKER_LIBRARY(TheEvent TEST Event.cxx G__TheEvent.cxx LIBRARIES ${ROOT_LIBRARIES})
 ROOTTEST_ADD_TEST(perfstattest-libevent-build 
-                  COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config $<CONFIG> --target TheEvent${fast} -- ${always-make})
+                  COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config $<CONFIG> --target G__TheEvent${fast} TheEvent${fast} -- ${always-make})
 if(MSVC)
       add_custom_command(TARGET TheEvent POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/libTheEvent.dll ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
On macOS, ROOT now requires CMake 3.19 which gets us the `NEW` behavior of [CMP0113](https://cmake.org/cmake/help/latest/policy/CMP0113.html) aka "Makefile Generators do not repeat custom commands from target dependencies." This causes problems for `perfstattest-libevent-build` because the `build.make` file for `TheEvent` doesn't know how to build `G__TheEvent`. Manually list it as the targets to build, add `always-make` to `cling-stl-dicts-build` for consistency and a comment for when `CMP0113` makes problems in the future.