### PR TITLE
[DF] Increase timeout for distributed tests to 10 minutes

### DIFF
--- a/python/distrdf/dask/CMakeLists.txt
+++ b/python/distrdf/dask/CMakeLists.txt
@@ -8,7 +8,7 @@ if (ROOT_test_distrdf_dask_FOUND)
     # multiprocessing, so the property is set to 2 in this case.
     ROOTTEST_ADD_TEST(test_all
                       MACRO test_all.py
-                      TIMEOUT 420
+                      TIMEOUT 600
                       PROPERTIES PROCESSORS 2)
 
 endif()

--- a/python/distrdf/spark/CMakeLists.txt
+++ b/python/distrdf/spark/CMakeLists.txt
@@ -24,7 +24,7 @@ if (ROOT_test_distrdf_pyspark_FOUND)
     ROOTTEST_ADD_TEST(test_all
                       MACRO test_all.py
                       ENVIRONMENT ${PYSPARK_ENV_VARS}
-                      TIMEOUT 420
+                      TIMEOUT 600
                       PROPERTIES PROCESSORS 2)
 
 endif()


### PR DESCRIPTION
Some CI nodes are quite slower than others and their behaviour is
unpredictable. Rarely it can happen that even the 7 minutes timeout is
reached, not because the test is not working but just due to overload on
the node. It should be fine to increase it to 10 minutes, given that
other tests labeled with 'longtest' have a higher timeout.