### PR TITLE
[cling] fix `.Class` vs `.class` command

### DIFF
--- a/cling/operator/EqualTest.ref-cling
+++ b/cling/operator/EqualTest.ref-cling
@@ -3,7 +3,7 @@ Processing runEqualTest.C...
 ===========================================================================
 class privateOp2
 SIZE: 4 FILE: equal.C LINE: N/A
-List of member variables --------------------------------------------------
-List of member functions :---------------------------------------------------
+List of member variables: -------------------------------------------------
+List of member functions: -------------------------------------------------
 filename     line:size busy function type and name
 (compiled)     (NA):(NA) 0 private: class privateOp2 &operator=(const int &);

--- a/cling/operator/runEqualTest.C
+++ b/cling/operator/runEqualTest.C
@@ -1,5 +1,5 @@
 {
 gSystem->Setenv("LINES","-1");
 gROOT->ProcessLine(".L equal.C+");
-gROOT->ProcessLine(".class privateOp2");
+gROOT->ProcessLine(".Class privateOp2");
 }

--- a/cling/template/separateDict/run.C
+++ b/cling/template/separateDict/run.C
@@ -1,9 +1,9 @@
 {
 gSystem->Setenv("LINES","-1");
 gSystem->Load("libmaster");
-gROOT->ProcessLine(".class Name::MyClass");
+gROOT->ProcessLine(".Class Name::MyClass");
 gSystem->Load("libslave1");
-gROOT->ProcessLine(".class Name::MyClass");
+gROOT->ProcessLine(".Class Name::MyClass");
 gSystem->Load("libslave2");
-gROOT->ProcessLine(".class Name::MyClass");
+gROOT->ProcessLine(".Class Name::MyClass");
 }

--- a/cling/template/separateDict/sepDictLibs.ref
+++ b/cling/template/separateDict/sepDictLibs.ref
@@ -3,7 +3,7 @@ Processing run.C...
 ===========================================================================
 class Name::MyClass
 SIZE: 16 FILE: MyClass.hh LINE: 10
-Base classes: --------------------------------------------------------
+Base classes: -------------------------------------------------------------
 0x0        public TObject
 filename     line:size busy function type and name
 (compiled)     (NA):(NA) 0 public: MyClass();
@@ -25,7 +25,7 @@ filename     line:size busy function type and name
 ===========================================================================
 class Name::MyClass
 SIZE: 16 FILE: MyClass.hh LINE: 10
-Base classes: --------------------------------------------------------
+Base classes: -------------------------------------------------------------
 0x0        public TObject
 filename     line:size busy function type and name
 (compiled)     (NA):(NA) 0 public: MyClass();
@@ -47,7 +47,7 @@ filename     line:size busy function type and name
 ===========================================================================
 class Name::MyClass
 SIZE: 16 FILE: MyClass.hh LINE: 10
-Base classes: --------------------------------------------------------
+Base classes: -------------------------------------------------------------
 0x0        public TObject
 filename     line:size busy function type and name
 (compiled)     (NA):(NA) 0 public: MyClass();

--- a/cling/template/separateDict/sepDictLibs.ref32
+++ b/cling/template/separateDict/sepDictLibs.ref32
@@ -3,7 +3,7 @@ Processing run.C...
 ===========================================================================
 class Name::MyClass
 SIZE: 12 FILE: MyClass.hh LINE: 10
-Base classes: --------------------------------------------------------
+Base classes: -------------------------------------------------------------
 0x0        public TObject
 filename     line:size busy function type and name
 (compiled)     (NA):(NA) 0 public: MyClass();
@@ -25,7 +25,7 @@ filename     line:size busy function type and name
 ===========================================================================
 class Name::MyClass
 SIZE: 12 FILE: MyClass.hh LINE: 10
-Base classes: --------------------------------------------------------
+Base classes: -------------------------------------------------------------
 0x0        public TObject
 filename     line:size busy function type and name
 (compiled)     (NA):(NA) 0 public: MyClass();
@@ -47,7 +47,7 @@ filename     line:size busy function type and name
 ===========================================================================
 class Name::MyClass
 SIZE: 12 FILE: MyClass.hh LINE: 10
-Base classes: --------------------------------------------------------
+Base classes: -------------------------------------------------------------
 0x0        public TObject
 filename     line:size busy function type and name
 (compiled)     (NA):(NA) 0 public: MyClass();

--- a/cling/template/separateDictNamespace/run.C
+++ b/cling/template/separateDictNamespace/run.C
@@ -1,9 +1,9 @@
 { 
 gSystem->Setenv("LINES","-1");
 gSystem->Load("libmaster");
-gROOT->ProcessLine(".class Master::Container");
+gROOT->ProcessLine(".Class Master::Container");
 gSystem->Load("libslave1");
-gROOT->ProcessLine(".class Master::Container");
+gROOT->ProcessLine(".Class Master::Container");
 gSystem->Load("libslave2");
-gROOT->ProcessLine(".class Master::Container");
+gROOT->ProcessLine(".Class Master::Container");
 }

--- a/cling/template/separateDictNamespace/run.good.output
+++ b/cling/template/separateDictNamespace/run.good.output
@@ -3,11 +3,11 @@ Processing run.C...
 ===========================================================================
 class Master::Container
 SIZE: 16 FILE: Master.hh LINE: 8
-Base classes: --------------------------------------------------------
+Base classes: -------------------------------------------------------------
 0x0        public TObject
-List of member variables --------------------------------------------------
+List of member variables: -------------------------------------------------
 Master.hh        18 0x0      private: static class TClass *fgIsA
-List of member functions :---------------------------------------------------
+List of member functions: -------------------------------------------------
 filename     line:size busy function type and name
 (compiled)     (NA):(NA) 0 public: Container();
 (compiled)     (NA):(NA) 0 public: void Print(Option_t *) const;
@@ -27,11 +27,11 @@ filename     line:size busy function type and name
 ===========================================================================
 class Master::Container
 SIZE: 16 FILE: Master.hh LINE: 8
-Base classes: --------------------------------------------------------
+Base classes: -------------------------------------------------------------
 0x0        public TObject
-List of member variables --------------------------------------------------
+List of member variables: -------------------------------------------------
 Master.hh        18 0x0      private: static class TClass *fgIsA
-List of member functions :---------------------------------------------------
+List of member functions: -------------------------------------------------
 filename     line:size busy function type and name
 (compiled)     (NA):(NA) 0 public: Container();
 (compiled)     (NA):(NA) 0 public: void Print(Option_t *) const;
@@ -51,11 +51,11 @@ filename     line:size busy function type and name
 ===========================================================================
 class Master::Container
 SIZE: 16 FILE: Master.hh LINE: 8
-Base classes: --------------------------------------------------------
+Base classes: -------------------------------------------------------------
 0x0        public TObject
-List of member variables --------------------------------------------------
+List of member variables: -------------------------------------------------
 Master.hh        18 0x0      private: static class TClass *fgIsA
-List of member functions :---------------------------------------------------
+List of member functions: -------------------------------------------------
 filename     line:size busy function type and name
 (compiled)     (NA):(NA) 0 public: Container();
 (compiled)     (NA):(NA) 0 public: void Print(Option_t *) const;

--- a/cling/template/separateDictNamespace/sepDictLibs.ref
+++ b/cling/template/separateDictNamespace/sepDictLibs.ref
@@ -3,7 +3,7 @@ Processing run.C...
 ===========================================================================
 class Master::Container
 SIZE: 16 FILE: Master.hh LINE: 8
-Base classes: --------------------------------------------------------
+Base classes: -------------------------------------------------------------
 0x0        public TObject
 filename     line:size busy function type and name
 (compiled)     (NA):(NA) 0 public: Container();
@@ -25,7 +25,7 @@ filename     line:size busy function type and name
 ===========================================================================
 class Master::Container
 SIZE: 16 FILE: Master.hh LINE: 8
-Base classes: --------------------------------------------------------
+Base classes: -------------------------------------------------------------
 0x0        public TObject
 filename     line:size busy function type and name
 (compiled)     (NA):(NA) 0 public: Container();
@@ -47,7 +47,7 @@ filename     line:size busy function type and name
 ===========================================================================
 class Master::Container
 SIZE: 16 FILE: Master.hh LINE: 8
-Base classes: --------------------------------------------------------
+Base classes: -------------------------------------------------------------
 0x0        public TObject
 filename     line:size busy function type and name
 (compiled)     (NA):(NA) 0 public: Container();

--- a/cling/template/separateDictNamespace/sepDictLibs.ref32
+++ b/cling/template/separateDictNamespace/sepDictLibs.ref32
@@ -3,7 +3,7 @@ Processing run.C...
 ===========================================================================
 class Master::Container
 SIZE: 12 FILE: Master.hh LINE: 8
-Base classes: --------------------------------------------------------
+Base classes: -------------------------------------------------------------
 0x0        public TObject
 filename     line:size busy function type and name
 (compiled)     (NA):(NA) 0 public: Container();
@@ -25,7 +25,7 @@ filename     line:size busy function type and name
 ===========================================================================
 class Master::Container
 SIZE: 12 FILE: Master.hh LINE: 8
-Base classes: --------------------------------------------------------
+Base classes: -------------------------------------------------------------
 0x0        public TObject
 filename     line:size busy function type and name
 (compiled)     (NA):(NA) 0 public: Container();
@@ -47,7 +47,7 @@ filename     line:size busy function type and name
 ===========================================================================
 class Master::Container
 SIZE: 12 FILE: Master.hh LINE: 8
-Base classes: --------------------------------------------------------
+Base classes: -------------------------------------------------------------
 0x0        public TObject
 filename     line:size busy function type and name
 (compiled)     (NA):(NA) 0 public: Container();

--- a/cling/templateMembers/operatorEqual.ref
+++ b/cling/templateMembers/operatorEqual.ref
@@ -2,8 +2,8 @@
 Processing runoperatorEqual.C...
 ===========================================================================
 class StThreeVector<double>
-List of member variables --------------------------------------------------
-List of member functions :---------------------------------------------------
+List of member variables: -------------------------------------------------
+List of member functions: -------------------------------------------------
 filename     line:size busy function type and name
 (compiled)     (NA):(NA) 0 public: template <class X> StThreeVector<double> func(X);
 (compiled)     (NA):(NA) 0 public: template <class X> StThreeVector<double> operator-=(const StThreeVector<X> &);

--- a/cling/templateMembers/runoperatorEqual.C
+++ b/cling/templateMembers/runoperatorEqual.C
@@ -4,6 +4,6 @@ gROOT->ProcessLine(".L operatorEqual.C+");
 #ifdef __CINT__
 gROOT->ProcessLine(".class StThreeVector");
 #else
-gROOT->ProcessLine(".class StThreeVector<>");
+gROOT->ProcessLine(".Class StThreeVector<>");
 #endif
 }

--- a/root/io/double32/longExample.h
+++ b/root/io/double32/longExample.h
@@ -69,9 +69,9 @@ This is what clang sees:
 ===========================================================================
 class m02<double>
 SIZE: 160 FILE: test01.cxx LINE: 15
-Base classes: --------------------------------------------------------
+Base classes: -------------------------------------------------------------
 0x0        private map2<double, double, struct alloc<struct std::__1::pair<double, double> > >
-List of member variables --------------------------------------------------
+List of member variables: -------------------------------------------------
 test01.cxx       17 0x0        public: int fN
 test01.cxx       19 0x8        public: vector<Double32_t> ff1, size = 24
 test01.cxx       20 0x20       public: Double32_t ff2[3]
@@ -92,7 +92,7 @@ test01.cxx       36 0x95       public: map2<Int_t, double> fv13, size = 1
 test01.cxx       37 0x96       public: map2<Int_t, vec<double> > fv14, size = 1
 test01.cxx       38 0x97       public: map2<Int_t, map2<double, double> > fv15, size = 1
 test01.cxx       39 0x98       public: map2<Int_t, map2<double, vec<double> > > fv16, size = 1
-List of member functions :---------------------------------------------------
+List of member functions: -------------------------------------------------
 filename     line:size busy function type and name
 
 and this is what StreamerInfo need to see:


### PR DESCRIPTION
To match https://github.com/root-project/root/pull/10350

* Update runEqualTest.C

* match verbosity

* match verbosity

* update output

* fix output

* fix output

* fix example

* fix hyphens

* fix hyphens