### PR TITLE
testTThreadedObjectAutoMemManagement tries to return an int: let it.

### DIFF
--- a/root/multicore/CMakeLists.txt
+++ b/root/multicore/CMakeLists.txt
@@ -5,8 +5,15 @@ if(ROOTTEST_OS_ID MATCHES Ubuntu)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-as-needed")
 endif()
 
-ROOTTEST_ADD_TEST(TThreadedObjectAutoMemManagement
-                 MACRO  testTThreadedObjectAutoMemManagement.C)
+if(UNIX AND 32BIT)
+  # linux32 llvm-JIT ABI issue constructing the pair of map<tthread::id, uint>.
+  # Compile instead.
+  ROOTTEST_ADD_TEST(TThreadedObjectAutoMemManagement
+                    MACRO  testTThreadedObjectAutoMemManagement.C+)
+else()
+  ROOTTEST_ADD_TEST(TThreadedObjectAutoMemManagement
+                    MACRO  testTThreadedObjectAutoMemManagement.C)
+endif()
 
 if(ROOT_imt_FOUND)
 

--- a/root/multicore/testTThreadedObjectAutoMemManagement.C
+++ b/root/multicore/testTThreadedObjectAutoMemManagement.C
@@ -1,5 +1,4 @@
-
-void testTThreadedObjectAutoMemManagement() {
+int testTThreadedObjectAutoMemManagement() {
    ROOT::EnableThreadSafety();
    const auto filename = "testTThreadedObjectAutoMemManagement.root";
    const auto nentries = 5000;

--- a/root/multicore/testTThreadedObjectAutoMemManagement.C
+++ b/root/multicore/testTThreadedObjectAutoMemManagement.C
@@ -1,3 +1,11 @@
+#ifdef __ACLIC__
+#include <ROOT/TThreadedObject.hxx>
+#include <TFile.h>
+#include <TH1.h>
+#include <TROOT.h>
+#include <iostream>
+#endif
+
 int testTThreadedObjectAutoMemManagement() {
    ROOT::EnableThreadSafety();
    const auto filename = "testTThreadedObjectAutoMemManagement.root";


### PR DESCRIPTION
This causes failures with
```
 #0  0xb6e5c7e3 in std::_Head_base<0u, std:🧵:id const&, false>::_M_head (__b=...) at /usr/include/c++/8/tuple:160
 #1  0xb6e5c7cb in std::_Tuple_impl<0u, std:🧵:id const&>::_M_head (__t=...) at /usr/include/c++/8/tuple:351
 #2  0xb6e5d488 in std::__get_helper<0u, std:🧵:id const&> (__t=...) at /usr/include/c++/8/tuple:1304
 #3  0xb6e5d462 in std::get<0u, std:🧵:id const&> (__t=std::tuple containing = {...}) at /usr/include/c++/8/tuple:1315
 #4  0xb6e5d4ad in std::pair<std:🧵:id const, unsigned int>::pair<std:🧵:id const&, 0u>(std::tuple<std:🧵:id const&>&, std::tuple<>&, std::_Index_tuple<0u>, std::_Index_tuple<>) (this=0xa48005e0, __tuple1=std::tuple containing = {...}, __tuple2=empty std::tuple) at /usr/include/c++/8/tuple:1667
 #5  0xb6e5c863 in std::pair<std:🧵:id const, unsigned int>::pair<std:🧵:id const&>(std::piecewise_construct_t, std::tuple<std:🧵:id const&>, std::tuple<>) (this=0xa48005e0, __first=<error reading variable: Cannot access memory at address 0x7c>, __second=empty std::tuple) at /usr/include/c++/8/tuple:1657
 #6  0xaf853abc in ?? ()
 #7  0xb7722fd2 in start_thread (arg=<optimized out>) at pthread_create.c:486
 #8  0xb76386d6 in clone () at ../sysdeps/unix/sysv/linux/i386/clone.S:108
```

Note esp the JIT frame, and the broken parameter address 0x7c, signaling an ABI issue.
When running this test compiled (root.exe ....C+) the test passes.