### PR TITLE
Increase the timeout for root-io-transient-base-WriteFile

### DIFF
--- a/root/io/transient/base/CMakeLists.txt
+++ b/root/io/transient/base/CMakeLists.txt
@@ -10,7 +10,8 @@ ROOTTEST_ADD_TEST(WriteFile
                   COPY_TO_BUILDDIR testobject.h testobjectderived.h
                   PRECMD ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config $<CONFIG> --target base${fast}
                   MACRO execWriteFile.cxx+
-                  OUTREF execWriteFile${ref_suffix})
+                  OUTREF execWriteFile${ref_suffix}
+                  TIMEOUT 600)
 
 if(${compression_default} STREQUAL "lz4")
   set(outref_suffix "LZ4")


### PR DESCRIPTION
Increase the timeout from 300 (5 min.) to 600 (10 min.). This should fix the following test failures on Window 64 bit:
```
04:01:26 	1519 - roottest-root-io-transient-base-WriteFile (Timeout)
04:01:26 	1520 - roottest-root-io-transient-base-hadd_autoload (Failed)
```
(`hadd_autoload` depends on `WriteFile`)