### PR TITLE
[RF] Avoid using RunContext in roottest

### DIFF
--- a/root/roofitstats/vectorisedPDFs/VectorisedPDFTests.h
+++ b/root/roofitstats/vectorisedPDFs/VectorisedPDFTests.h
@@ -14,7 +14,6 @@
  * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
  *****************************************************************************/
 
-#include "RunContext.h"
 #include "RooArgSet.h"
 #include "RooRealVar.h"
 #include "RooDataSet.h"


### PR DESCRIPTION
The retrieving of batches is an implementation detail of the RooFit batch mode that is already thoroughly testes by all the unit tests in the main ROOT repository that cover the batch mode (e.g. stressRooFit). It's not convenient to test this also in `roottest` because that makes it more cumbersome to change the interface.