### PR TITLE
On Apple M1, TTreeIndex cannot handle values that large [6.26]

### DIFF
--- a/root/tree/index/runindex64.C
+++ b/root/tree/index/runindex64.C
@@ -5,12 +5,12 @@
 bool test(TTree*);
 
 const char* fname = "index64.root";
-  // Apple M1 has long double == double; these values exceed its range
-  // and cannot be represented as (even temporary) expression results.
-  // There would be a warning if you'd try.
-  static constexpr bool shortlongdouble = sizeof(longdouble) < 16; // was true for __APPLE__ and __arm64__
-  const Long64_t bigval   = shortlongdouble ? 0xFFFFFFFFFFFF : 0xFFFFFFFFFFFFFFF; // still positive number
-  const ULong64_t biguval = shortlongdouble ?  0xFFFFFFFFFFFF0 : 0xFFFFFFFFFFFFFFF0; // "negative" number
+// Apple M1 has long double == double; these values exceed its range
+// and cannot be represented as (even temporary) expression results.
+// There would be a warning if you'd try.
+static constexpr bool shortlongdouble = sizeof(long double) < 16; // was true for __APPLE__ and __arm64__
+const Long64_t bigval   = shortlongdouble ? 0xFFFFFFFFFFFF : 0xFFFFFFFFFFFFFFF; // still positive number
+const ULong64_t biguval = shortlongdouble ?  0xFFFFFFFFFFFF0 : 0xFFFFFFFFFFFFFFF0; // "negative" number
 
 int runindex64(){
 

--- a/root/tree/index/runindex64.C
+++ b/root/tree/index/runindex64.C
@@ -5,16 +5,12 @@
 bool test(TTree*);
 
 const char* fname = "index64.root";
-#if __APPLE__ and __arm64__
   // Apple M1 has long double == double; these values exceed its range
   // and cannot be represented as (even temporary) expression results.
   // There would be a warning if you'd try.
-  const Long64_t bigval   = 0xFFFFFFFFFFFF;
-  const ULong64_t biguval = 0xFFFFFFFFFFFF0;
-#else
-  const Long64_t bigval   = 0xFFFFFFFFFFFFFFF;  // still positive number
-  const ULong64_t biguval = 0xFFFFFFFFFFFFFFF0;  // "negative" number
-#endif
+  static constexpr bool shortlongdouble = sizeof(longdouble) < 16; // was true for __APPLE__ and __arm64__
+  const Long64_t bigval   = shortlongdouble ? 0xFFFFFFFFFFFF : 0xFFFFFFFFFFFFFFF; // still positive number
+  const ULong64_t biguval = shortlongdouble ?  0xFFFFFFFFFFFF0 : 0xFFFFFFFFFFFFFFF0; // "negative" number
 
 int runindex64(){
 

--- a/root/tree/index/runindex64.C
+++ b/root/tree/index/runindex64.C
@@ -5,6 +5,16 @@
 bool test(TTree*);
 
 const char* fname = "index64.root";
+#if __APPLE__ and __arm64__
+  // Apple M1 has long double == double; these values exceed its range
+  // and cannot be represented as (even temporary) expression results.
+  // There would be a warning if you'd try.
+  const Long64_t bigval   = 0xFFFFFFFFFFFF;
+  const ULong64_t biguval = 0xFFFFFFFFFFFF0;
+#else
+  const Long64_t bigval   = 0xFFFFFFFFFFFFFFF;  // still positive number
+  const ULong64_t biguval = 0xFFFFFFFFFFFFFFF0;  // "negative" number
+#endif
 
 int runindex64(){
 
@@ -19,8 +29,6 @@ int runindex64(){
   tree->Branch("run", &run, "run/l");
   tree->Branch("event", &event, "event/l");
 
-  const Long64_t bigval = 0xFFFFFFFFFFFFFFF;  // still positive number
-  const ULong64_t biguval = 0xFFFFFFFFFFFFFFF0;  // "negative" number
   ULong64_t events[] = { 1,2,3, bigval, biguval, 5 };
   run = 5;
   for(int i=0; i<sizeof(events)/sizeof(*events); i++){
@@ -35,7 +43,7 @@ int runindex64(){
   cout<<"Tree BuildIndex returns "<<tree->BuildIndex("run", "event")<<endl;
   cout << "Entry should be 3: " << tree->GetEntryNumberWithIndex(5,bigval) << endl;
   cout << "Entry should be 6: " << tree->GetEntryNumberWithIndex(4,bigval) << endl;
-  
+
   test(tree);
   file.Close();
 
@@ -58,6 +66,6 @@ bool test(TTree *chain)
   cout<<"BuildIndex returns "<<chain->BuildIndex("run", "event")<<endl;
   cout<<"Try to get value that is not in the chain, this should return a -1:"<<endl;
   cout<<chain->GetEntryWithIndex(500)<<endl;
-  cout<<(int)chain->GetEntryNumberWithIndex(5,0xFFFFFFFFFFFFFFF)<<endl;
+  cout<<(int)chain->GetEntryNumberWithIndex(5, bigval)<<endl;
   return (chain->GetEntryNumberWithIndex(500)==-1);
 }


### PR DESCRIPTION
As on M1, long double == double, doing the tree formula math in double
will not have sufficient precision to keep the least significant bits
around, causing the minor value not to be found back.

Instead, reduce the number such that a M1 `long double` can still represent
it. There is a new warning in TTreeIndex() that should be triggered by
providing the original value; the test should be extended to check for
said warning to be emitted on M1 in this case.

(cherry picked from commit f3c9780)