### PR TITLE
[DF] Check C++ exception is correctly propagated in Dask 

### DIFF
--- a/python/distrdf/dask/check_backend.py
+++ b/python/distrdf/dask/check_backend.py
@@ -79,7 +79,8 @@ class TestInitialization:
         # Finally, Histo1D returns a histogram filled with one value. The mean
         # of this single value has to be the value itself, independently of
         # the number of spawned workers.
-        df = Dask.RDataFrame(1, daskclient=connection).Define("u", "userValue").Histo1D(("name", "title", 1, 100, 130), "u")
+        df = Dask.RDataFrame(1, daskclient=connection).Define(
+            "u", "userValue").Histo1D(("name", "title", 1, 100, 130), "u")
         h = df.GetValue()
         assert h.GetMean() == 123
 


### PR DESCRIPTION
Test that C++ runtime_error is propagated correctly as a Python
RuntimeError with the original message from RDF. This is only needed in
Dask, Spark does not try to serialize the error instance.

More details at https://github.com/root-project/root/issues/11050