### PR TITLE
Increase PROCESSORS by one for distributed tests

### DIFF
--- a/python/distrdf/common/CMakeLists.txt
+++ b/python/distrdf/common/CMakeLists.txt
@@ -25,6 +25,7 @@ if (ROOT_test_distrdf_pyspark_FOUND AND ROOT_test_distrdf_dask_FOUND)
     ROOTTEST_ADD_TEST(test_all
                       MACRO test_all.py
                       ENVIRONMENT ${PYSPARK_ENV_VARS}
-                      PROPERTIES PROCESSORS 5)
+                      PROPERTIES PROCESSORS 5
+                      RUN_SERIAL)
 
 endif()

--- a/python/distrdf/common/CMakeLists.txt
+++ b/python/distrdf/common/CMakeLists.txt
@@ -25,6 +25,6 @@ if (ROOT_test_distrdf_pyspark_FOUND AND ROOT_test_distrdf_dask_FOUND)
     ROOTTEST_ADD_TEST(test_all
                       MACRO test_all.py
                       ENVIRONMENT ${PYSPARK_ENV_VARS}
-                      PROPERTIES PROCESSORS 4)
+                      PROPERTIES PROCESSORS 5)
 
 endif()

--- a/python/distrdf/dask/CMakeLists.txt
+++ b/python/distrdf/dask/CMakeLists.txt
@@ -9,6 +9,6 @@ if (ROOT_test_distrdf_dask_FOUND)
     ROOTTEST_ADD_TEST(test_all
                       MACRO test_all.py
                       TIMEOUT 420
-                      PROPERTIES PROCESSORS 2)
+                      PROPERTIES PROCESSORS 3)
 
 endif()

--- a/python/distrdf/spark/CMakeLists.txt
+++ b/python/distrdf/spark/CMakeLists.txt
@@ -25,6 +25,6 @@ if (ROOT_test_distrdf_pyspark_FOUND)
                       MACRO test_all.py
                       ENVIRONMENT ${PYSPARK_ENV_VARS}
                       TIMEOUT 420
-                      PROPERTIES PROCESSORS 2)
+                      PROPERTIES PROCESSORS 3)
 
 endif()


### PR DESCRIPTION
Attempt to help the CI on particularly slow nodes (namely Mac ones), which usually take around 4-5 min to run the distributed tests (either with Spark or Dask). It seems like as soon as a Mac node has a slightly higher CPU load the test times out (currently after 7 minutes). One approach is increasing the timeout, another approach is increasing the number of cores signalled to ctest for running the tests.

Overall, this is looks still better than going back to the previous approach where each distributed RDF test was running separately, but also had to create a cluster object (Dask/Spark) from scratch leading to a much higher overall runtime