### PR TITLE
Improvements on resource restrictions for distributed tests

### DIFF
--- a/python/distrdf/common/CMakeLists.txt
+++ b/python/distrdf/common/CMakeLists.txt
@@ -21,10 +21,24 @@ if (ROOT_test_distrdf_pyspark_FOUND AND ROOT_test_distrdf_dask_FOUND)
     # We use the PROCESSORS property to tell cmake how many cores we will be
     # using in the following test. In this folder, both a Dask and a Spark
     # cluster objects are created on the local machine. Each object will use 2
-    # cores with multiprocessing, so the property is set to 4 in this case.
+    # cores with multiprocessing, 4 in total. We give it more room by setting
+    # the property to 6.
+    # The test also locks all resources related to creation of cluster objects,
+    # which are shared also with the respective folders of this project and the
+    # tutorials of the root repository.
     ROOTTEST_ADD_TEST(test_all
                       MACRO test_all.py
-                      ENVIRONMENT ${PYSPARK_ENV_VARS}
-                      PROPERTIES PROCESSORS 6)
+                      ENVIRONMENT ${PYSPARK_ENV_VARS})
 
+    # This test has to take multiple resource locks. This means that they should
+    # be passed as a cmake list (semi-colon separated strings) after the
+    # RESOURCE_LOCK argument to `set_tests_properties`. The issue lies in
+    # forwarding this argument to ROOTTEST_ADD_TEST and then ROOT_ADD_TEST.
+    # Argument forwarding and list parsing in cmake is utterly broken.
+    # The safest and most reliable thing to do is to call the final cmake
+    # function directly here, so we can be sure that the PROPERTIES argument
+    # will be properly parsed.
+    set_tests_properties(roottest-python-distrdf-common-test_all PROPERTIES
+                                                                 RESOURCE_LOCK "dask_resource_lock;spark_resource_lock"
+                                                                 PROCESSORS 6)
 endif()

--- a/python/distrdf/common/CMakeLists.txt
+++ b/python/distrdf/common/CMakeLists.txt
@@ -25,6 +25,6 @@ if (ROOT_test_distrdf_pyspark_FOUND AND ROOT_test_distrdf_dask_FOUND)
     ROOTTEST_ADD_TEST(test_all
                       MACRO test_all.py
                       ENVIRONMENT ${PYSPARK_ENV_VARS}
-                      PROPERTIES PROCESSORS 4)
+                      PROPERTIES PROCESSORS 6)
 
 endif()

--- a/python/distrdf/dask/CMakeLists.txt
+++ b/python/distrdf/dask/CMakeLists.txt
@@ -5,10 +5,13 @@ if (ROOT_test_distrdf_dask_FOUND)
     # We use the PROCESSORS property to tell cmake how many cores we will be
     # using in the following test. In this folder, a Dask cluster object is
     # created on the local machine. It is going to use 2 cores with
-    # multiprocessing, so the property is set to 2 in this case.
+    # multiprocessing, we give it more room by setting the property to 4.
+    # The test also locks a resource for the creation of a Dask cluster, which
+    # is shared with the "common" folder and the tutorials of the root
+    # repository.
     ROOTTEST_ADD_TEST(test_all
                       MACRO test_all.py
                       TIMEOUT 420
-                      PROPERTIES PROCESSORS 4)
+                      PROPERTIES PROCESSORS 4 RESOURCE_LOCK dask_resource_lock)
 
 endif()

--- a/python/distrdf/dask/CMakeLists.txt
+++ b/python/distrdf/dask/CMakeLists.txt
@@ -9,6 +9,6 @@ if (ROOT_test_distrdf_dask_FOUND)
     ROOTTEST_ADD_TEST(test_all
                       MACRO test_all.py
                       TIMEOUT 420
-                      PROPERTIES PROCESSORS 2)
+                      PROPERTIES PROCESSORS 4)
 
 endif()

--- a/python/distrdf/spark/CMakeLists.txt
+++ b/python/distrdf/spark/CMakeLists.txt
@@ -20,11 +20,14 @@ if (ROOT_test_distrdf_pyspark_FOUND)
     # We use the PROCESSORS property to tell cmake how many cores we will be
     # using in the following test. In this folder, a Dask cluster object is
     # created on the local machine. It is going to use 2 cores with
-    # multiprocessing, so the property is set to 2 in this case.
+    # multiprocessing, we give it a more room by setting the property to 4.
+    # The test also locks a resource for the creation of a Spark cluster, which
+    # is shared with the "common" folder and the tutorials of the root
+    # repository.
     ROOTTEST_ADD_TEST(test_all
                       MACRO test_all.py
                       ENVIRONMENT ${PYSPARK_ENV_VARS}
                       TIMEOUT 420
-                      PROPERTIES PROCESSORS 4)
+                      PROPERTIES PROCESSORS 4 RESOURCE_LOCK spark_resource_lock)
 
 endif()

--- a/python/distrdf/spark/CMakeLists.txt
+++ b/python/distrdf/spark/CMakeLists.txt
@@ -25,6 +25,6 @@ if (ROOT_test_distrdf_pyspark_FOUND)
                       MACRO test_all.py
                       ENVIRONMENT ${PYSPARK_ENV_VARS}
                       TIMEOUT 420
-                      PROPERTIES PROCESSORS 2)
+                      PROPERTIES PROCESSORS 4)
 
 endif()


### PR DESCRIPTION
Sibling PR of https://github.com/root-project/root/pull/11439

The distributed RDataFrame tutorials/tests have to create cluster objects, which take up resources on the machine. This is another step towards a clearer resource usage for both tutorials and tests. Whenever a cluster object is created, it now uses RESOURCE_LOCK test property to signal that no other cluster object should be created while the previous one is still running.