### PR TITLE
Tighten FAILREGEX for stressVdt

### DIFF
--- a/root/math/vdt/CMakeLists.txt
+++ b/root/math/vdt/CMakeLists.txt
@@ -12,7 +12,7 @@ ROOTTEST_GENERATE_EXECUTABLE(${testname}
 
 ROOTTEST_ADD_TEST(${testname}
                   EXEC ./${testname}
-                  FAILREGEX "too" # for "too slow" and "too inaccurate" :)
+                  FAILREGEX "too inaccurate"
                   DEPENDS ${GENERATE_EXECUTABLE_TEST}
                   LABELS longtest)
 endif()


### PR DESCRIPTION
"too" is too general and may also match the build path. I could not find "too slow" being printed anywhere, so just check the output for "too inaccurate".