### PR TITLE
Fix a missing include.

### DIFF
--- a/root/io/uniquePointer/rwconst.C
+++ b/root/io/uniquePointer/rwconst.C
@@ -1,3 +1,5 @@
+#include "classes.h"
+
 #include "memory"
 #include "TFile.h"
 #include "TH1F.h"


### PR DESCRIPTION
For an unknown reason, cling managed to compile a test that's missing an include directive. The include is added here, since it provoked a failure in a branch that's still WIP.