### PR TITLE
[DF] Replace deprecated call to `ROOT::RDF::MakeCsvDataFrame()`

### DIFF
--- a/root/dataframe/test_progressiveCSV.cxx
+++ b/root/dataframe/test_progressiveCSV.cxx
@@ -10,13 +10,13 @@ int test_progressiveCSV()
 
    // Create a CSV data source that reads in chunks of 2000 lines
    const auto chunkSize = 2000LL;
-   auto rdf = ROOT::RDF::MakeCsvDataFrame(fileName, true, ',', chunkSize);
+   auto rdf = ROOT::RDF::FromCSV(fileName, true, ',', chunkSize);
 
    auto rdflines = *rdf.Count();
    std::cout << "Total num lines: " << rdflines << std::endl;
 
    // Now create a CSV data source that reads the entire file into memory at once
-   auto rdf2 = ROOT::RDF::MakeCsvDataFrame(fileName);
+   auto rdf2 = ROOT::RDF::FromCSV(fileName);
 
    rdflines = *rdf2.Count();
    std::cout << "Total num lines: " << rdflines << std::endl;


### PR DESCRIPTION
Replace deprecated call to `ROOT::RDF::MakeCsvDataFrame()` by `ROOT:RDF::FromCSV()`, as the former is deprecated and marked for removal in ROOT v6.30.