### PR TITLE
Add requirements.txt for roottest Python requirements. [skip-ci]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@
 IPython
 jupyter
 pytest
+
+# Needed by tutorials (run as part of roottest)
+pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# roottest requirements for third-party Python packages
+# These are in addition to ROOT's requirements.txt!
+
+IPython
+jupyter
+pytest


### PR DESCRIPTION
This helps us configure the new CI agents and is a nice way to document what's needed.