### PR TITLE
Fix roottest being configured without pyroot

### DIFF
--- a/cling/functionTemplate/CMakeLists.txt
+++ b/cling/functionTemplate/CMakeLists.txt
@@ -10,18 +10,20 @@ ROOTTEST_ADD_TEST(runreferenceuse
                   DEPENDS MyClassReferenceUse.C
                   LABELS roottest regression cling)
 
-ROOTTEST_ADD_TEST(testcint
-                  MACRO testcint.py
-                  PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ t.h+
-                  OUTREF pythoncintrun.ref
-                  OUTCNVCMD grep -v "just a comment"
-                  WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-                  LABELS roottest regression cling)
-
-if(ROOT_cintex_FOUND)
-  ROOTTEST_ADD_TEST(testreflex
-                    MACRO testreflex.py
-                    OUTREF pythonreflexrun.ref
+if(ROOT_pyroot_FOUND)
+  ROOTTEST_ADD_TEST(testcint
+                    MACRO testcint.py
+                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ t.h+
+                    OUTREF pythoncintrun.ref
                     OUTCNVCMD grep -v "just a comment"
+                    WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
                     LABELS roottest regression cling)
+
+  if(ROOT_cintex_FOUND)
+    ROOTTEST_ADD_TEST(testreflex
+                      MACRO testreflex.py
+                      OUTREF pythonreflexrun.ref
+                      OUTCNVCMD grep -v "just a comment"
+                      LABELS roottest regression cling)
+  endif()
 endif()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -11,7 +11,7 @@ if(ROOT_pyroot_FOUND)
     set(roofit False)
   endif(ROOT_roofit_FOUND)
 
-  find_python_module(pytest REQUIRED)
+  find_python_module(pytest OPTIONAL)
 
   if (PY_PYTEST_FOUND)
     ROOTTEST_ADD_TESTDIRS()

--- a/root/io/uniquePointer/rwconst.C
+++ b/root/io/uniquePointer/rwconst.C
@@ -1,3 +1,5 @@
+#include "classes.h"
+
 #include "memory"
 #include "TFile.h"
 #include "TH1F.h"

--- a/root/roofitstats/CMakeLists.txt
+++ b/root/roofitstats/CMakeLists.txt
@@ -1,8 +1,10 @@
 if(ROOT_roofit_FOUND)
-  ROOTTEST_ADD_TEST(read-scientificnotation
-                    MACRO read_scientific_notation.py
-                    OUTCNVCMD grep -v -e "Wouter"
-                    OUTREF read_scientific_notation.ref)
+  if(ROOT_pyroot_FOUND)
+    ROOTTEST_ADD_TEST(read-scientificnotation
+                      MACRO read_scientific_notation.py
+                      OUTCNVCMD grep -v -e "Wouter"
+                      OUTREF read_scientific_notation.ref)
+  endif()
 
   ROOTTEST_ADD_TEST(RooDataSet_ASCII_in
                     MACRO ${CMAKE_CURRENT_SOURCE_DIR}/ASCII-in-out.C


### PR DESCRIPTION
Accidentally, I configured root without pyroot. This leads to a few test failures because of missing `if`s in roottest's cmake config.