### PR TITLE
Avoid clash with std::identity from C++20:

### DIFF
--- a/root/meta/naming/execClassEditNormalize.C
+++ b/root/meta/naming/execClassEditNormalize.C
@@ -27,14 +27,14 @@ template <typename KeyFromValue, typename Compare =std::less<typename KeyFromVal
 //template <typename KeyFromValue, typename Compare /* =std::less<typename KeyFromValue::result_type> */ > class ordered_unique<DefaultTag,KeyFromValue,Compare> {};
 //template <typename KeyFromValue> class ordered_unique<DefaultTag,KeyFromValue,std::less<typename KeyFromValue::result_type> > {};
 
-template <typename A> class identity { public: typedef A result_type; };
+template <typename A> class TheIdentity { public: typedef A result_type; };
 template <typename A> class tag {};
 template <typename A, typename B> class composite_key {};
 template<class Class, typename Type, Type (Class::*PtrToMemberFunction)()const> struct const_mem_fun {};
 
 /// Base class for our complex class
 typedef multi_index_container< ComplexElement*,
-                               indexed_by< ordered_unique< identity< ComplexElement > >,
+                               indexed_by< ordered_unique< TheIdentity< ComplexElement > >,
                                            ordered_unique< tag< DummyCounter >,
                                                            composite_key< ComplexElement*,
                                                                           const_mem_fun< ComplexElement,
@@ -176,13 +176,13 @@ int execClassEditNormalize() {
    std::string input2 = "boost::multi_index::ordered_unique<boost::multi_index::tag<DummyCounter,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na>,boost::multi_index::composite_key<ComplexElement*,boost::multi_index::const_mem_fun<ComplexElement,int,&ComplexElement::level>,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type>,mpl_::na>";
    if (!test(input2)) return 4;
 
-   std::string input1 = "boost::multi_index::ordered_unique<boost::multi_index::identity<ComplexElement>,mpl_::na,mpl_::na>";
+   std::string input1 = "boost::multi_index::ordered_unique<boost::multi_index::TheIdentity<ComplexElement>,mpl_::na,mpl_::na>";
    if (!test(input1)) return 3;
 
-   std::string input0 = "boost::multi_index::indexed_by<boost::multi_index::ordered_unique<boost::multi_index::identity<ComplexElement>,mpl_::na,mpl_::na>,boost::multi_index::ordered_unique<boost::multi_index::tag<DummyCounter,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na>,boost::multi_index::composite_key<ComplexElement*,boost::multi_index::const_mem_fun<ComplexElement,int,&ComplexElement::level>,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type>,mpl_::na>,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na>";
+   std::string input0 = "boost::multi_index::indexed_by<boost::multi_index::ordered_unique<boost::multi_index::TheIdentity<ComplexElement>,mpl_::na,mpl_::na>,boost::multi_index::ordered_unique<boost::multi_index::tag<DummyCounter,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na>,boost::multi_index::composite_key<ComplexElement*,boost::multi_index::const_mem_fun<ComplexElement,int,&ComplexElement::level>,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type>,mpl_::na>,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na>";
    if (!test(input0)) return 2;
 
-   std::string input_full = "boost::multi_index::multi_index_container<ComplexElement*,boost::multi_index::indexed_by<boost::multi_index::ordered_unique<boost::multi_index::identity<ComplexElement>,mpl_::na,mpl_::na>,boost::multi_index::ordered_unique<boost::multi_index::tag<DummyCounter,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na>,boost::multi_index::composite_key<ComplexElement*,boost::multi_index::const_mem_fun<ComplexElement,int,&ComplexElement::level>,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type>,mpl_::na>,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na>,allocator<ComplexElement*> >";
+   std::string input_full = "boost::multi_index::multi_index_container<ComplexElement*,boost::multi_index::indexed_by<boost::multi_index::ordered_unique<boost::multi_index::TheIdentity<ComplexElement>,mpl_::na,mpl_::na>,boost::multi_index::ordered_unique<boost::multi_index::tag<DummyCounter,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na>,boost::multi_index::composite_key<ComplexElement*,boost::multi_index::const_mem_fun<ComplexElement,int,&ComplexElement::level>,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type,boost::tuples::null_type>,mpl_::na>,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na,mpl_::na>,allocator<ComplexElement*> >";
 
    if (!test(input_full)) return 1;
    return 0;

--- a/root/meta/tclass/runpairs.C
+++ b/root/meta/tclass/runpairs.C
@@ -47,20 +47,20 @@ public:
    T value;
 };
 
-class regular {
+class MyRegular {
    Int_t val1;
    tp<Int_t> val2;
    vector<Int_t> val3;
    std::vector<std::pair<Char_t, UChar_t> > val4;
 public:
-   regular() : val1(0) {}
+   MyRegular() : val1(0) {}
    int get() { return val1*sizeof(val2)*val3.size()*val4.size(); }
 };
 
 #ifdef __MAKECINT__
 #pragma link C++ class std::vector<std::pair<Char_t, UChar_t> >+;
 #pragma link C++ class std::pair<Char_t, UChar_t>+;
-#pragma link C++ class regular+;
+#pragma link C++ class MyRegular+;
 #pragma link C++ class tp<Int_t>+;
 #pragma link C++ class tp<Long_t>+;
 #endif
@@ -69,7 +69,7 @@ public:
 
 void write2file(const char*filename="pairs.root",int debug =0) {
    TFile *f = new TFile(filename,"RECREATE");
-   regular r;
+   MyRegular r;
    f->WriteObject(&r,"myr");
    f->Write();
    if (debug) cout << "wrote " << filename << endl;
@@ -85,7 +85,7 @@ void readfile(const char*filename="pairs.root",int debug = 0) {
    checkRegular(TClass::GetClass("tp<Int_t>"),"tp<int>");
    check(TClass::GetClass("vector<Int_t>"));
    check(TClass::GetClass("vector<std::pair<Char_t, UChar_t> >"));
-   regular *r;
+   MyRegular *r;
    f->GetObject("myr",r);
 }
  


### PR DESCRIPTION
```
In file included from input_line_24:1:
/private/tmp/workspace/src/roottest/root/meta/naming/execClassEditNormalize.C:37:60: error: reference to 'identity' is ambiguous
                               indexed_by< ordered_unique< identity< ComplexElement > >,
                                                           ^
/private/tmp/workspace/src/roottest/root/meta/naming/execClassEditNormalize.C:30:29: note: candidate found by name lookup is 'identity'
template <typename A> class identity { public: typedef A result_type; };
                            ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__functional/identity.h:24:8: note: candidate found by name lookup is 'std::identity'
struct identity {
       ^
```