### PR TITLE
[core][DF] Fix `-Wreturn-type` in tests

### DIFF
--- a/root/core/execStatusBitsCheck.C
+++ b/root/core/execStatusBitsCheck.C
@@ -1,7 +1,7 @@
 void SkipLibrary(const char *libskip)
 {
    TEnv* mapfile = gInterpreter->GetMapfile();
-   if (!mapfile || !mapfile->GetTable()) return 0;
+   if (!mapfile || !mapfile->GetTable()) return;
 
    for(auto rec : TRangeDynCast<TEnvRec>(mapfile->GetTable())) {
       if (!rec) continue;

--- a/root/dataframe/test_ROOT9975.C
+++ b/root/dataframe/test_ROOT9975.C
@@ -11,6 +11,4 @@ void test_ROOT9975()
    const std::vector<std::string> expected_types = {"A", "Int_t", "B", "A", "Int_t", "Int_t", "Int_t", "Int_t"};
 
    R__ASSERT(types == expected_types);
-
-   return 0;
 }


### PR DESCRIPTION
As of PR https://github.com/root-project/root/pull/12654, returning a non-`void` expression from `void`-returning function is only valid in an unnamed macro (in which case the diagnostic is filtered).

This is a backport of PR #951.