### PR TITLE
Custom allocator fixes

### DIFF
--- a/root/collection/execMissing.C
+++ b/root/collection/execMissing.C
@@ -4,6 +4,11 @@
 template <typename T>
 class CustomAlloc : public std::allocator<T>
 {
+public:
+   template <typename U>
+   struct rebind {
+      using other = CustomAlloc<U>;
+   };
 };
 
 class Track {

--- a/root/io/cpp11Containers/auxCode.h
+++ b/root/io/cpp11Containers/auxCode.h
@@ -48,7 +48,13 @@ namespace std{
 //------------------------------------------------------------------------------
 
 template <class T>
-class myAlloc : public std::allocator<T> {};
+class myAlloc : public std::allocator<T> {
+public:
+   template <typename U>
+   struct rebind {
+      using other = myAlloc<U>;
+   };
+};
 
 //------------------------------------------------------------------------------
 

--- a/root/io/cpp11Containers/auxCode.h
+++ b/root/io/cpp11Containers/auxCode.h
@@ -50,6 +50,13 @@ namespace std{
 template <class T>
 class myAlloc : public std::allocator<T> {
 public:
+   myAlloc() = default;
+
+   template <class U>
+   myAlloc(const allocator<U> &other) noexcept
+   {
+   }
+
    template <typename U>
    struct rebind {
       using other = myAlloc<U>;


### PR DESCRIPTION
Required to pass tests with newer versions of `libstdc++`.