### PR TITLE
Fix newClassDef tests with C++20

### DIFF
--- a/root/io/newClassDef/current/template.h
+++ b/root/io/newClassDef/current/template.h
@@ -28,8 +28,8 @@ class MyTemplate <const double*> : public TObject {
   std::vector<int> vars;
 #endif
   
-  MyTemplate<const double*>(const double* a) { variable = *a; };
-  MyTemplate<const double*>() {};
+  MyTemplate(const double* a) { variable = *a; };
+  MyTemplate() {};
   
 #ifdef R__WIN32
   typedef MyTemplate<const double*> type;

--- a/root/io/newClassDef/new/nstemplate.h
+++ b/root/io/newClassDef/new/nstemplate.h
@@ -30,9 +30,9 @@ namespace MySpace {
     std::vector<int> vars;
 #endif
   
-    MyTemplate<const double*>(const double* a) { 
+    MyTemplate(const double* a) { 
       variable = *a; variable2 = 2* *a; };
-    MyTemplate<const double*>() {};
+    MyTemplate() {};
   
     ClassDef(MyTemplate<const double*>,1)
   };

--- a/root/io/newClassDef/new/template.h
+++ b/root/io/newClassDef/new/template.h
@@ -53,9 +53,7 @@ class MyPairTemplate<int, double> : public TObject {
   
   MyPairTemplate(int a, double b) : var1(a), var2(b) {};
   MyPairTemplate() {};
-#if (__GNUC__>=3 || __GNUC_MINOR__>=95)
   ~MyPairTemplate() {};
-#endif
 
   typedef MyPairTemplate<int, double> type;
   ClassDef(type,2)

--- a/root/io/newClassDef/new/template.h
+++ b/root/io/newClassDef/new/template.h
@@ -27,8 +27,8 @@ class MyTemplate <const double*> : public TObject {
   std::vector<int> vars;
 #endif
   
-  MyTemplate<const double*>(const double* a) { variable = *a; };
-  MyTemplate<const double*>() {};
+  MyTemplate(const double* a) { variable = *a; };
+  MyTemplate() {};
   
   ClassDefT(MyTemplate<const double*>,2)
 };
@@ -51,8 +51,8 @@ class MyPairTemplate<int, double> : public TObject {
   float var1;
   float var2;
   
-  MyPairTemplate<int,double>(int a, double b) : var1(a), var2(b) {};
-  MyPairTemplate<int,double>() {};
+  MyPairTemplate(int a, double b) : var1(a), var2(b) {};
+  MyPairTemplate() {};
 #if (__GNUC__>=3 || __GNUC_MINOR__>=95)
   ~MyPairTemplate() {};
 #endif


### PR DESCRIPTION
C++20 made it invalid to use simple-template-ids for constructors and destructors: https://eel.is/c++draft/diff.cpp17.class#2
GCC 11 and later throw an error on this, with the unhelpful message `expected unqualified-id before '<some>' token`.