### PR TITLE
Automatically add missing `override` to root/meta/genreflex tests

### DIFF
--- a/root/meta/genreflex/MyClass_v1.h
+++ b/root/meta/genreflex/MyClass_v1.h
@@ -13,7 +13,7 @@ public:
       // fArray.push_back(123);
       // fArray.push_back(456);
    }
-   void Print(Option_t * /*option*/ ="") const {
+   void Print(Option_t * /*option*/ ="") const override {
       std::cout << "MyClass::Print ver: " << ver << "\n";
    }
 
@@ -23,5 +23,5 @@ private:
    int ver;
    std::vector<int> fArray;
 
-   ClassDef(MyClass, 1)
+   ClassDefOverride(MyClass, 1)
 };

--- a/root/meta/genreflex/MyClass_v2.h
+++ b/root/meta/genreflex/MyClass_v2.h
@@ -10,7 +10,7 @@ public:
    }
 
    void addSomeData() {}
-   void Print(Option_t* /*option=""*/) const {
+   void Print(Option_t* /*option=""*/) const override {
       std::cout << "MyClass::Print ver: " << ver << "\n";
       //std::cout << "arr[0]: " << fArray[0] << "\n";
       //std::cout << "arr[1]: " << fArray[1] << "\n";
@@ -21,5 +21,5 @@ private:
    int ver;
    int fArray[2];
 
-   ClassDef(MyClass, 2)
+   ClassDefOverride(MyClass, 2)
 };

--- a/root/meta/genreflex/ROOT-5594/AliAODPid.h
+++ b/root/meta/genreflex/ROOT-5594/AliAODPid.h
@@ -18,7 +18,7 @@ class AliAODPid : public TObject {
 
  public:
   AliAODPid();
-  virtual ~AliAODPid();
+  ~AliAODPid() override;
   AliAODPid(const AliAODPid& pid); 
   AliAODPid& operator=(const AliAODPid& pid);
   
@@ -90,7 +90,7 @@ class AliAODPid : public TObject {
  
   AliTPCdEdxInfo * fTPCdEdxInfo; // object containing dE/dx information for different pad regions
 
-  ClassDef(AliAODPid, 15);
+  ClassDefOverride(AliAODPid, 15);
 };
 
 //_____________________________________________________________

--- a/root/meta/genreflex/ROOT-5627/TH2Analyzer.h
+++ b/root/meta/genreflex/ROOT-5627/TH2Analyzer.h
@@ -41,7 +41,7 @@ class TH2Analyzer : public TObject {
     Eval(rebin, binxmin, binxmax, cst_binning);
   } 
 
-  ~TH2Analyzer() {Reset(); }
+  ~TH2Analyzer() override {Reset(); }
 
   void Reset() {}
 
@@ -75,7 +75,7 @@ class TH2Analyzer : public TObject {
   TH1D*      meanXslice_;
 
   //std::vector< TH1D* > parameters_; // if we are not fitting with a gauss function
-  ClassDef(TH2Analyzer, 1);
+  ClassDefOverride(TH2Analyzer, 1);
 
 };
 

--- a/root/meta/genreflex/ROOT-5768/CoralBase/AttributeException.h
+++ b/root/meta/genreflex/ROOT-5768/CoralBase/AttributeException.h
@@ -17,7 +17,7 @@ namespace coral
     {
     }
 
-    virtual ~AttributeException() throw()
+    ~AttributeException() throw() override
     {
     }
   };

--- a/root/meta/genreflex/ROOT-5768/CoralBase/AttributeList.h
+++ b/root/meta/genreflex/ROOT-5768/CoralBase/AttributeList.h
@@ -114,7 +114,7 @@ namespace coral
     class iterator : public iterator_base
     {
     public:
-      ~iterator() {};
+      ~iterator() override {};
       iterator( const iterator_base& rhs ) : iterator_base( rhs ) {}
       iterator& operator=( const iterator_base& rhs ) { iterator_base::operator=( rhs ); return *this; }
     private:
@@ -134,7 +134,7 @@ namespace coral
     class const_iterator : public iterator_base
     {
     public:
-      ~const_iterator() {};
+      ~const_iterator() override {};
       const_iterator( const iterator_base& rhs ) : iterator_base( rhs ) {}
       const_iterator& operator=( const iterator_base& rhs ) { iterator_base::operator=( rhs ); return *this; }
     private:

--- a/root/meta/genreflex/ROOT-5768/CoralBase/AttributeListException.h
+++ b/root/meta/genreflex/ROOT-5768/CoralBase/AttributeListException.h
@@ -16,7 +16,7 @@ namespace coral {
                  "CoralBase" )
     {}
 
-    virtual ~AttributeListException() throw() {}
+    ~AttributeListException() throw() override {}
   };
 
 }

--- a/root/meta/genreflex/ROOT-5768/CoralBase/Exception.h
+++ b/root/meta/genreflex/ROOT-5768/CoralBase/Exception.h
@@ -21,13 +21,13 @@ namespace coral
     Exception() {};
 
     /// Destructor
-    virtual ~Exception() throw() {}
+    ~Exception() throw() override {}
 
     /// Set (or reset) the execption message
     void setMessage(const std::string& message);
 
     /// The error reporting method
-    virtual const char* what() const throw() { return m_message.c_str(); }
+    const char* what() const throw() override { return m_message.c_str(); }
 
   private:
 

--- a/root/meta/genreflex/ROOT-5768/CoralBase/MessageStream.h
+++ b/root/meta/genreflex/ROOT-5768/CoralBase/MessageStream.h
@@ -203,15 +203,15 @@ namespace coral
     /// Default constructor
     MsgReporter();
     /// Destructor
-    virtual ~MsgReporter() {}
+    ~MsgReporter() override {}
     /// Release reference to reporter
-    virtual void release() { delete this; }
+    void release() override { delete this; }
     /// Access output level
-    virtual coral::MsgLevel outputLevel() const;
+    coral::MsgLevel outputLevel() const override;
     /// Modify output level
-    virtual void setOutputLevel(coral::MsgLevel lvl);
+    void setOutputLevel(coral::MsgLevel lvl) override;
     /// Report a message
-    virtual void report(int lvl, const std::string& src, const std::string& msg);
+    void report(int lvl, const std::string& src, const std::string& msg) override;
 
   private:
     /// The current message level threshold

--- a/root/meta/genreflex/ROOT-5768/CoralKernel/CoralPluginDef.h
+++ b/root/meta/genreflex/ROOT-5768/CoralKernel/CoralPluginDef.h
@@ -13,10 +13,10 @@ namespace coral {
   {
   public:
     CoralPluginFactory( const std::string& name ) : m_name( name ) {}
-    virtual ~CoralPluginFactory() {}
-    coral::ILoadableComponent* component() const
+    ~CoralPluginFactory() override {}
+    coral::ILoadableComponent* component() const override
     { return static_cast< coral::ILoadableComponent* >( new T( m_name ) ); }
-    std::string name() const { return m_name; }
+    std::string name() const override { return m_name; }
   private:
     std::string m_name;
   };

--- a/root/meta/genreflex/ROOT-5768/CoralKernel/ILoadableComponent.h
+++ b/root/meta/genreflex/ROOT-5768/CoralKernel/ILoadableComponent.h
@@ -18,7 +18,7 @@ namespace coral {
     explicit ILoadableComponent( const std::string& name ) : RefCounted(), m_name( name ) {}
 
     /// Destructor
-    virtual ~ILoadableComponent() {}
+    ~ILoadableComponent() override {}
 
   private:
     /// No copy constructor

--- a/root/meta/genreflex/ROOT-5768/CoralKernel/Property.h
+++ b/root/meta/genreflex/ROOT-5768/CoralKernel/Property.h
@@ -46,9 +46,9 @@ namespace coral
   public:
 
     Property();
-    virtual ~Property();
-    virtual bool set(const std::string&);
-    virtual const std::string& get() const;
+    ~Property() override;
+    bool set(const std::string&) override;
+    const std::string& get() const override;
 
     /**
      * Callback functor type.

--- a/root/meta/genreflex/ROOT-5768/CoralKernel/Service.h
+++ b/root/meta/genreflex/ROOT-5768/CoralKernel/Service.h
@@ -23,7 +23,7 @@ namespace coral
     explicit Service( const std::string& name );
 
     /// Destructor
-    virtual ~Service();
+    ~Service() override;
 
     /// Returns the underlying message stream object
     MessageStream& log()

--- a/root/meta/genreflex/ROOT-5768/RelationalAccess/AuthenticationCredentials.h
+++ b/root/meta/genreflex/ROOT-5768/RelationalAccess/AuthenticationCredentials.h
@@ -18,7 +18,7 @@ namespace coral {
     explicit AuthenticationCredentials( const std::string& implementationName );
 
     /// Destructor
-    virtual ~AuthenticationCredentials();
+    ~AuthenticationCredentials() override;
 
     /// Registers a new item name-value pair. Returns false if an item with the same name already exists.
     bool registerItem( const std::string& name,
@@ -27,17 +27,17 @@ namespace coral {
     /**
      * Returns the value for a given credential item. If the item name is not valid an InvalidCredentialItemException is thrown.
      */
-    std::string valueForItem( const std::string& itemName ) const;
+    std::string valueForItem( const std::string& itemName ) const override;
 
     /**
      * Returns the number of credential items
      */
-    int numberOfItems() const;
+    int numberOfItems() const override;
 
     /**
      * Returns the name of a crential item for a given index. If the index is out of range a CredentialItemIndexOutOfRangeException is thrown.
      */
-    std::string itemName( int itemIndex ) const;
+    std::string itemName( int itemIndex ) const override;
 
   private:
     /// The authentication service implementation name

--- a/root/meta/genreflex/ROOT-5768/RelationalAccess/AuthenticationServiceException.h
+++ b/root/meta/genreflex/ROOT-5768/RelationalAccess/AuthenticationServiceException.h
@@ -23,7 +23,7 @@ namespace coral {
     {}
 
     /// Destructor
-    virtual ~AuthenticationServiceException() throw() {}
+    ~AuthenticationServiceException() throw() override {}
   };
 
 
@@ -41,7 +41,7 @@ namespace coral {
     {}
 
     /// Destructor
-    virtual ~UnknownConnectionException() throw() {}
+    ~UnknownConnectionException() throw() override {}
   };
 
 
@@ -60,7 +60,7 @@ namespace coral {
     {}
 
     /// Destructor
-    virtual ~UnknownRoleException() throw() {}
+    ~UnknownRoleException() throw() override {}
   };
 
 
@@ -78,7 +78,7 @@ namespace coral {
     {}
 
     /// Destructor
-    virtual ~InvalidCredentialItemException() throw() {}
+    ~InvalidCredentialItemException() throw() override {}
   };
 
 
@@ -95,7 +95,7 @@ namespace coral {
     {}
 
     /// Destructor
-    virtual ~CredentialItemIndexOutOfRangeException() throw() {}
+    ~CredentialItemIndexOutOfRangeException() throw() override {}
   };
 
 }

--- a/root/meta/genreflex/ROOT-5768/RelationalAccess/ConnectionService.h
+++ b/root/meta/genreflex/ROOT-5768/RelationalAccess/ConnectionService.h
@@ -23,14 +23,14 @@ namespace coral
     ConnectionService();
 
     /// Destructor
-    virtual ~ConnectionService();
+    ~ConnectionService() override;
 
     /**
      * Returns a session proxy object for the specified connection string
      * and access mode.
      */
     ISessionProxy* connect( const std::string& connectionName,
-                            AccessMode accessMode = Update );
+                            AccessMode accessMode = Update ) override;
 
     /**
      * Returns a session proxy object for the specified connection string, role
@@ -38,27 +38,27 @@ namespace coral
      */
     ISessionProxy* connect( const std::string& connectionName,
                             const std::string& asRole,
-                            AccessMode accessMode = Update );
+                            AccessMode accessMode = Update ) override;
     /**
      * Returns the configuration object for the service.
      */
-    IConnectionServiceConfiguration& configuration();
+    IConnectionServiceConfiguration& configuration() override;
 
     /**
      * Cleans up the connection pool from the unused connection, according to
      * the policy defined in the configuration.
      */
-    void purgeConnectionPool();
+    void purgeConnectionPool() override;
 
     /**
      * Returns the monitoring reporter
      */
-    const IMonitoringReporter& monitoringReporter() const;
+    const IMonitoringReporter& monitoringReporter() const override;
 
     /**
      * Returns the object which controls the web cache
      */
-    IWebCacheControl& webCacheControl();
+    IWebCacheControl& webCacheControl() override;
 
     // Set the user defined verbosity level
     void setMessageVerbosityLevel( coral::MsgLevel level );

--- a/root/meta/genreflex/ROOT-5768/RelationalAccess/ConnectionServiceException.h
+++ b/root/meta/genreflex/ROOT-5768/RelationalAccess/ConnectionServiceException.h
@@ -24,7 +24,7 @@ namespace coral {
     {}
 
     /// Destructor
-    virtual ~ConnectionServiceException() throw() {}
+    ~ConnectionServiceException() throw() override {}
   };
 
 
@@ -41,7 +41,7 @@ namespace coral {
                                   methodName, moduleName ){}
 
     /// Destructor
-    virtual ~ConnectionNotAvailableException() throw() {}
+    ~ConnectionNotAvailableException() throw() override {}
   };
 
 
@@ -59,7 +59,7 @@ namespace coral {
                                   methodName, moduleName ){}
 
     /// Destructor
-    virtual ~ReplicaNotAvailableException() throw() {}
+    ~ReplicaNotAvailableException() throw() override {}
   };
 
 }

--- a/root/meta/genreflex/ROOT-5768/RelationalAccess/IBulkOperationWithQuery.h
+++ b/root/meta/genreflex/ROOT-5768/RelationalAccess/IBulkOperationWithQuery.h
@@ -15,7 +15,7 @@ namespace coral {
   class IBulkOperationWithQuery : virtual public IBulkOperation {
   public:
     /// Destructor
-    virtual ~IBulkOperationWithQuery() {}
+    ~IBulkOperationWithQuery() override {}
 
     /**
      * Returns a reference to the underlying query definition,

--- a/root/meta/genreflex/ROOT-5768/RelationalAccess/IQuery.h
+++ b/root/meta/genreflex/ROOT-5768/RelationalAccess/IQuery.h
@@ -20,7 +20,7 @@ namespace coral {
   class IQuery : virtual public IQueryDefinition {
   public:
     /// Destructor
-    virtual ~IQuery() {}
+    ~IQuery() override {}
 
     /**
      * Instructs the server to lock the rows involved in the result set.

--- a/root/meta/genreflex/ROOT-5768/RelationalAccess/IViewFactory.h
+++ b/root/meta/genreflex/ROOT-5768/RelationalAccess/IViewFactory.h
@@ -16,7 +16,7 @@ namespace coral {
   class IViewFactory : virtual public IQueryDefinition {
   public:
     /// Destructor
-    virtual ~IViewFactory() {}
+    ~IViewFactory() override {}
 
     /**
      * Creates a new view with the specified

--- a/root/meta/genreflex/ROOT-5768/RelationalAccess/LookupServiceException.h
+++ b/root/meta/genreflex/ROOT-5768/RelationalAccess/LookupServiceException.h
@@ -19,7 +19,7 @@ namespace coral {
     LookupServiceException() : Exception() {}
 
     /// Destructor
-    virtual ~LookupServiceException() throw() {}
+    ~LookupServiceException() throw() override {}
   };
 
 
@@ -38,7 +38,7 @@ namespace coral {
     InvalidReplicaIdentifierException() : LookupServiceException() {}
 
     /// Destructor
-    virtual ~InvalidReplicaIdentifierException() throw() {}
+    ~InvalidReplicaIdentifierException() throw() override {}
   };
 
 }

--- a/root/meta/genreflex/ROOT-5768/RelationalAccess/MonitoringException.h
+++ b/root/meta/genreflex/ROOT-5768/RelationalAccess/MonitoringException.h
@@ -25,7 +25,7 @@ namespace coral {
     MonitoringException() {}
 
     /// Destructor
-    virtual ~MonitoringException() throw() {}
+    ~MonitoringException() throw() override {}
   };
 
 }

--- a/root/meta/genreflex/ROOT-5768/RelationalAccess/RelationalServiceException.h
+++ b/root/meta/genreflex/ROOT-5768/RelationalAccess/RelationalServiceException.h
@@ -23,7 +23,7 @@ namespace coral {
     RelationalServiceException() {}
 
     /// Destructor
-    virtual ~RelationalServiceException() throw() {}
+    ~RelationalServiceException() throw() override {}
   };
 
   /// Exception thrown when an invalid replica identifier is specified
@@ -40,7 +40,7 @@ namespace coral {
 
     NonExistingDomainException() {}
     /// Destructor
-    virtual ~NonExistingDomainException() throw() {}
+    ~NonExistingDomainException() throw() override {}
   };
 
   /// Exception thrown when an invalid operation is requested by the CORAL client
@@ -55,7 +55,7 @@ namespace coral {
     InvalidOperationException() {}
 
     /// Destructor
-    virtual ~InvalidOperationException() throw() {}
+    ~InvalidOperationException() throw() override {}
   };
 
 }

--- a/root/meta/genreflex/ROOT-5768/RelationalAccess/SchemaException.h
+++ b/root/meta/genreflex/ROOT-5768/RelationalAccess/SchemaException.h
@@ -19,7 +19,7 @@ namespace coral {
     SchemaException() {}
 
     /// Destructor
-    virtual ~SchemaException() throw() {}
+    ~SchemaException() throw() override {}
   };
 
 
@@ -38,7 +38,7 @@ namespace coral {
     TableAlreadyExistingException() {}
 
     /// Destructor
-    virtual ~TableAlreadyExistingException() throw() {}
+    ~TableAlreadyExistingException() throw() override {}
   };
 
 
@@ -58,7 +58,7 @@ namespace coral {
     TableNotExistingException() {}
 
     /// Destructor
-    virtual ~TableNotExistingException() throw() {}
+    ~TableNotExistingException() throw() override {}
   };
 
 
@@ -77,7 +77,7 @@ namespace coral {
     ViewAlreadyExistingException() {}
 
     /// Destructor
-    virtual ~ViewAlreadyExistingException() throw() {}
+    ~ViewAlreadyExistingException() throw() override {}
   };
 
 
@@ -97,7 +97,7 @@ namespace coral {
     ViewNotExistingException() {}
 
     /// Destructor
-    virtual ~ViewNotExistingException() throw() {}
+    ~ViewNotExistingException() throw() override {}
   };
 
 
@@ -117,7 +117,7 @@ namespace coral {
     QueryException() {}
 
     /// Destructor
-    virtual ~QueryException() throw() {}
+    ~QueryException() throw() override {}
   };
 
 
@@ -136,7 +136,7 @@ namespace coral {
     QueryExecutedException() {}
 
     /// Destructor
-    virtual ~QueryExecutedException() throw() {}
+    ~QueryExecutedException() throw() override {}
   };
 
 
@@ -155,7 +155,7 @@ namespace coral {
     InvalidUniqueConstraintIdentifierException() {}
 
     /// Destructor
-    virtual ~InvalidUniqueConstraintIdentifierException() throw() {}
+    ~InvalidUniqueConstraintIdentifierException() throw() override {}
   };
 
 
@@ -174,7 +174,7 @@ namespace coral {
     InvalidForeignKeyIdentifierException() {}
 
     /// Destructor
-    virtual ~InvalidForeignKeyIdentifierException() throw() {}
+    ~InvalidForeignKeyIdentifierException() throw() override {}
   };
 
 
@@ -193,7 +193,7 @@ namespace coral {
     InvalidIndexIdentifierException() {}
 
     /// Destructor
-    virtual ~InvalidIndexIdentifierException() throw() {}
+    ~InvalidIndexIdentifierException() throw() override {}
   };
 
 
@@ -212,7 +212,7 @@ namespace coral {
     InvalidColumnIndexException() {}
 
     /// Destructor
-    virtual ~InvalidColumnIndexException() throw() {}
+    ~InvalidColumnIndexException() throw() override {}
   };
 
 
@@ -231,7 +231,7 @@ namespace coral {
     InvalidColumnNameException() {}
 
     /// Destructor
-    virtual ~InvalidColumnNameException() throw() {}
+    ~InvalidColumnNameException() throw() override {}
   };
 
 
@@ -250,7 +250,7 @@ namespace coral {
     NoPrimaryKeyException() {}
 
     /// Destructor
-    virtual ~NoPrimaryKeyException() throw() {}
+    ~NoPrimaryKeyException() throw() override {}
   };
 
 
@@ -268,7 +268,7 @@ namespace coral {
     ExistingPrimaryKeyException() {}
 
     /// Destructor
-    virtual ~ExistingPrimaryKeyException() throw() {}
+    ~ExistingPrimaryKeyException() throw() override {}
   };
 
 
@@ -286,7 +286,7 @@ namespace coral {
     UniqueConstraintAlreadyExistingException() {}
 
     /// Destructor
-    virtual ~UniqueConstraintAlreadyExistingException() throw() {}
+    ~UniqueConstraintAlreadyExistingException() throw() override {}
   };
 
 
@@ -306,7 +306,7 @@ namespace coral {
     DataEditorException() {}
 
     /// Destructor
-    virtual ~DataEditorException() throw() {}
+    ~DataEditorException() throw() override {}
   };
 
 
@@ -325,7 +325,7 @@ namespace coral {
     DuplicateEntryInUniqueKeyException() {}
 
     /// Destructor
-    virtual ~DuplicateEntryInUniqueKeyException() throw() {}
+    ~DuplicateEntryInUniqueKeyException() throw() override {}
   };
 
 }

--- a/root/meta/genreflex/ROOT-5768/RelationalAccess/SessionException.h
+++ b/root/meta/genreflex/ROOT-5768/RelationalAccess/SessionException.h
@@ -21,7 +21,7 @@ namespace coral
     /// Default constructor
     SessionException() {}
     /// Destructor
-    virtual ~SessionException() throw() {}
+    ~SessionException() throw() override {}
   };
 
 
@@ -38,7 +38,7 @@ namespace coral
     /// Default constructor
     MaximumNumberOfSessionsException() {}
     /// Destructor
-    virtual ~MaximumNumberOfSessionsException() throw() {}
+    ~MaximumNumberOfSessionsException() throw() override {}
   };
 
 
@@ -55,7 +55,7 @@ namespace coral
     /// Default constructor
     StartSessionException() {}
     /// Destructor
-    virtual ~StartSessionException() throw() {}
+    ~StartSessionException() throw() override {}
   };
 
 
@@ -78,7 +78,7 @@ namespace coral
     /// Default constructor
     InvalidOperationInReadOnlyModeException() {}
     /// Destructor
-    virtual ~InvalidOperationInReadOnlyModeException() throw() {}
+    ~InvalidOperationInReadOnlyModeException() throw() override {}
   };
 
 
@@ -94,7 +94,7 @@ namespace coral
     /// Default constructor
     InvalidSchemaNameException() {}
     /// Destructor
-    virtual ~InvalidSchemaNameException() throw() {}
+    ~InvalidSchemaNameException() throw() override {}
   };
 
 
@@ -111,7 +111,7 @@ namespace coral
     /// Default constructor
     NoAuthenticationServiceException() {}
     /// Destructor
-    virtual ~NoAuthenticationServiceException() throw() {}
+    ~NoAuthenticationServiceException() throw() override {}
   };
 
 
@@ -127,7 +127,7 @@ namespace coral
     /// Default constructor
     AuthenticationFailureException() {}
     /// Destructor
-    virtual ~AuthenticationFailureException() throw() {}
+    ~AuthenticationFailureException() throw() override {}
   };
 
 
@@ -144,7 +144,7 @@ namespace coral
     /// Default constructor
     MonitoringServiceNotFoundException() {}
     /// Destructor
-    virtual ~MonitoringServiceNotFoundException() throw() {}
+    ~MonitoringServiceNotFoundException() throw() override {}
   };
 
 
@@ -178,7 +178,7 @@ namespace coral
     /// Default constructor
     ServerException() {}
     /// Destructor
-    virtual ~ServerException() throw() {}
+    ~ServerException() throw() override {}
   };
 
 
@@ -195,7 +195,7 @@ namespace coral
     /// Default constructor
     DatabaseNotAccessibleException() {}
     /// Destructor
-    virtual ~DatabaseNotAccessibleException() throw() {}
+    ~DatabaseNotAccessibleException() throw() override {}
   };
 
 
@@ -211,7 +211,7 @@ namespace coral
     /// Default constructor
     ConnectionException() {}
     /// Destructor
-    virtual ~ConnectionException() throw() {}
+    ~ConnectionException() throw() override {}
   };
 
 
@@ -227,7 +227,7 @@ namespace coral
     /// Default constructor
     ConnectionNotActiveException() {}
     /// Destructor
-    virtual ~ConnectionNotActiveException() throw() {}
+    ~ConnectionNotActiveException() throw() override {}
   };
 
 
@@ -244,7 +244,7 @@ namespace coral
     /// Default constructor
     ConnectionLostException() {}
     /// Destructor
-    virtual ~ConnectionLostException() throw() {}
+    ~ConnectionLostException() throw() override {}
   };
 
 
@@ -260,7 +260,7 @@ namespace coral
     /// Default constructor
     TransactionException() {}
     /// Destructor
-    virtual ~TransactionException() throw() {}
+    ~TransactionException() throw() override {}
   };
 
 
@@ -275,7 +275,7 @@ namespace coral
     /// Default constructor
     TransactionNotStartedException() {}
     /// Destructor
-    virtual ~TransactionNotStartedException() throw() {}
+    ~TransactionNotStartedException() throw() override {}
   };
 
 
@@ -290,7 +290,7 @@ namespace coral
     /// Default constructor
     TransactionNotCommittedException() {}
     /// Destructor
-    virtual ~TransactionNotCommittedException() throw() {}
+    ~TransactionNotCommittedException() throw() override {}
   };
 
 
@@ -306,7 +306,7 @@ namespace coral
     /// Default constructor
     TransactionNotActiveException() {}
     /// Destructor
-    virtual ~TransactionNotActiveException() throw() {}
+    ~TransactionNotActiveException() throw() override {}
   };
 
 
@@ -323,7 +323,7 @@ namespace coral
     /// Default constructor
     InvalidOperationInReadOnlyTransactionException() {}
     /// Destructor
-    virtual ~InvalidOperationInReadOnlyTransactionException() throw() {}
+    ~InvalidOperationInReadOnlyTransactionException() throw() override {}
   };
 
 
@@ -341,7 +341,7 @@ namespace coral
     /// Default constructor
     TypeConverterException() {}
     /// Destructor
-    virtual ~TypeConverterException() throw() {}
+    ~TypeConverterException() throw() override {}
   };
 
 
@@ -359,7 +359,7 @@ namespace coral
     /// Default constructor
     UnSupportedSqlTypeException() {}
     /// Destructor
-    virtual ~UnSupportedSqlTypeException() throw() {}
+    ~UnSupportedSqlTypeException() throw() override {}
   };
 
 
@@ -377,7 +377,7 @@ namespace coral
     /// Default constructor
     UnSupportedCppTypeException() {}
     /// Destructor
-    virtual ~UnSupportedCppTypeException() throw() {}
+    ~UnSupportedCppTypeException() throw() override {}
   };
 
 

--- a/root/meta/genreflex/ROOT-5768/RelationalAccess/TableDescription.h
+++ b/root/meta/genreflex/ROOT-5768/RelationalAccess/TableDescription.h
@@ -44,7 +44,7 @@ namespace coral {
                       std::string context = "User" );
 
     /// Destructor
-    virtual ~TableDescription();
+    ~TableDescription() override;
 
     /**
      * Sets the name of the table
@@ -74,20 +74,20 @@ namespace coral {
                        const std::string& type,
                        int size = 0,
                        bool fixedSize = true,
-                       std::string tableSpaceName = "" );
+                       std::string tableSpaceName = "" ) override;
 
     /**
      * Drops a column from the table.
      * If the column name does not exist or is invalid, an InvalidColumnNameException is thrown.
      */
-    void dropColumn( const std::string& name );
+    void dropColumn( const std::string& name ) override;
 
     /**
      * Renames a column in the table.
      * If the column name does not exist or is invalid, an InvalidColumnNameException is thrown.
      */
     void renameColumn( const std::string& originalName,
-                       const std::string& newName );
+                       const std::string& newName ) override;
 
     /**
      * Changes the C++ type of a column in the table.
@@ -96,14 +96,14 @@ namespace coral {
     void changeColumnType( const std::string& columnName,
                            const std::string& typeName,
                            int size = 0,
-                           bool fixedSize = true );
+                           bool fixedSize = true ) override;
 
     /**
      * Sets or removes a NOT NULL constraint on a column.
      * If the column name already exists or is invalid, an InvalidColumnNameException is thrown.
      */
     void setNotNullConstraint( const std::string& columnName,
-                               bool isNotNull = true );
+                               bool isNotNull = true ) override;
 
     /**
      * Adds or removes a unique constraint on a column.
@@ -113,7 +113,7 @@ namespace coral {
     void setUniqueConstraint( const std::string& columnName,
                               std::string name = "",
                               bool isUnique = true,
-                              std::string tableSpaceName = "" );
+                              std::string tableSpaceName = "" ) override;
 
     /**
      * Adds or removes a unique constraint defined over one or more columns.
@@ -123,7 +123,7 @@ namespace coral {
     void setUniqueConstraint( const std::vector<std::string>& columnNames,
                               std::string name = "",
                               bool isUnique = true,
-                              std::string tableSpaceName = "" );
+                              std::string tableSpaceName = "" ) override;
 
     /**
      * Defines a primary key from a single column.
@@ -131,7 +131,7 @@ namespace coral {
      * If a primary key has already been defined, an ExistingPrimaryKeyException is thrown.
      */
     void setPrimaryKey( const std::string& columnName,
-                        std::string tableSpaceName = "" );
+                        std::string tableSpaceName = "" ) override;
 
     /**
      * Defines a primary key from one or more columns.
@@ -139,13 +139,13 @@ namespace coral {
      * If a primary key has already been defined, an ExistingPrimaryKeyException is thrown.
      */
     void setPrimaryKey( const std::vector<std::string>& columnNames,
-                        std::string tableSpaceName = "" );
+                        std::string tableSpaceName = "" ) override;
 
     /**
      * Drops the existing primary key.
      * If there is no primary key defined a NoPrimaryKeyException is thrown.
      */
-    void dropPrimaryKey();
+    void dropPrimaryKey() override;
 
     /**
      * Creates an index on a column.
@@ -155,7 +155,7 @@ namespace coral {
     void createIndex( const std::string& indexName,
                       const std::string& columnName,
                       bool isUnique = false,
-                      std::string tableSpaceName = "" );
+                      std::string tableSpaceName = "" ) override;
 
     /**
      * Creates an index over one or more columns.
@@ -165,13 +165,13 @@ namespace coral {
     void createIndex( const std::string& name,
                       const std::vector<std::string>& columnNames,
                       bool isUnique = false,
-                      std::string tableSpaceName = "" );
+                      std::string tableSpaceName = "" ) override;
 
     /**
      * Drops an existing index.
      * If the specified index name is not valid an InvalidIndexIdentifierException is thrown.
      */
-    void dropIndex( const std::string& indexName );
+    void dropIndex( const std::string& indexName ) override;
 
     /**
      * Creates a foreign key constraint.
@@ -181,7 +181,7 @@ namespace coral {
     void createForeignKey( const std::string& name,
                            const std::string& columnName,
                            const std::string& referencedTableName,
-                           const std::string& referencedColumnName );
+                           const std::string& referencedColumnName ) override;
 
     /**
      * Creates a foreign key over one or more columns.
@@ -191,13 +191,13 @@ namespace coral {
     void createForeignKey( const std::string& name,
                            const std::vector<std::string>& columnNames,
                            const std::string& referencedTableName,
-                           const std::vector<std::string>& referencedColumnNames );
+                           const std::vector<std::string>& referencedColumnNames ) override;
 
     /**
      * Drops a foreign key.
      * If the specified name is not valid an InvalidForeignKeyIdentifierException is thrown.
      */
-    void dropForeignKey( const std::string& name );
+    void dropForeignKey( const std::string& name ) override;
 
 
 
@@ -208,78 +208,78 @@ namespace coral {
     /**
      * Returns the name of the table.
      */
-    std::string name() const;
+    std::string name() const override;
 
     /**
      * Returns the table type (RDBMS SPECIFIC)
      */
-    std::string type() const;
+    std::string type() const override;
 
     /**
      * Returns the name of the table space for this table.
      */
-    std::string tableSpaceName() const;
+    std::string tableSpaceName() const override;
 
     /**
      * Returns the number of columns in the table.
      */
-    int numberOfColumns() const;
+    int numberOfColumns() const override;
 
     /**
      * Returns the description of the column corresponding to the specified index.
      * If the index is out of range an InvalidColumnIndexException is thrown.
      */
-    const IColumn& columnDescription( int columnIndex ) const;
+    const IColumn& columnDescription( int columnIndex ) const override;
 
     /**
      * Returns the description of the column corresponding to the specified name.
      * If the specified column name is invalid an InvalidColumnNameException is thrown.
      */
-    const IColumn& columnDescription( const std::string& columnName ) const;
+    const IColumn& columnDescription( const std::string& columnName ) const override;
 
     /**
      * Returns the existence of a primary key in the table.
      */
-    bool hasPrimaryKey() const;
+    bool hasPrimaryKey() const override;
 
     /**
      * Returns the primary key for the table. If there is no primary key a NoPrimaryKeyException is thrown.
      */
-    const IPrimaryKey& primaryKey() const;
+    const IPrimaryKey& primaryKey() const override;
 
     /**
      * Returns the number of indices defined in the table.
      */
-    int numberOfIndices() const;
+    int numberOfIndices() const override;
 
     /**
      * Returns the index corresponding to the specified identitier.
      * If the identifier is out of range an InvalidIndexIdentifierException is thrown.
      */
-    const IIndex& index( int indexId ) const;
+    const IIndex& index( int indexId ) const override;
 
 
     /**
      * Returns the number of foreign key constraints defined in the table.
      */
-    int numberOfForeignKeys() const;
+    int numberOfForeignKeys() const override;
 
     /**
      * Returns the foreign key corresponding to the specified identifier.
      * In case the identifier is out of range an InvalidForeignKeyIdentifierException is thrown.
      */
-    const IForeignKey& foreignKey( int foreignKeyIdentifier ) const;
+    const IForeignKey& foreignKey( int foreignKeyIdentifier ) const override;
 
     /**
      * Returns the number of unique constraints defined in the table.
      */
-    int numberOfUniqueConstraints() const;
+    int numberOfUniqueConstraints() const override;
 
     /**
      * Returns the unique constraint for the specified identifier.
      * If the identifier is out of range an InvalidUniqueConstraintIdentifierException is thrown.
      */
-    const IUniqueConstraint& uniqueConstraint( int uniqueConstraintIdentifier ) const;
+    const IUniqueConstraint& uniqueConstraint( int uniqueConstraintIdentifier ) const override;
 
   private:
 

--- a/root/meta/genreflex/ROOT-5768/RelationalAccess/WebCacheControlException.h
+++ b/root/meta/genreflex/ROOT-5768/RelationalAccess/WebCacheControlException.h
@@ -24,7 +24,7 @@ namespace coral {
     WebCacheControlException() {}
 
     /// Destructor
-    virtual ~WebCacheControlException() throw() {}
+    ~WebCacheControlException() throw() override {}
 
   };
 

--- a/root/meta/genreflex/ROOT-5768/RelationalCool/src/CoralConnectionServiceProxy.h
+++ b/root/meta/genreflex/ROOT-5768/RelationalCool/src/CoralConnectionServiceProxy.h
@@ -28,7 +28,7 @@ namespace cool
     CoralConnectionServiceProxy( coral::IConnectionService* pConnSvc = 0 );
 
     /// Destructor
-    virtual ~CoralConnectionServiceProxy();
+    ~CoralConnectionServiceProxy() override;
 
     /// Get the pointer - throws if the pointer is 0.
     const coral::IConnectionService* getICS() const;
@@ -49,7 +49,7 @@ namespace cool
      * and access mode.
      */
     coral::ISessionProxy* connect( const std::string& connectionName,
-                                   coral::AccessMode accessMode = coral::Update )
+                                   coral::AccessMode accessMode = coral::Update ) override
     {
       boost::mutex::scoped_lock lock( m_mutex );
       return getICS()->connect( connectionName, accessMode );;
@@ -61,7 +61,7 @@ namespace cool
      */
     coral::ISessionProxy* connect( const std::string& connectionName,
                                    const std::string& asRole,
-                                   coral::AccessMode accessMode = coral::Update )
+                                   coral::AccessMode accessMode = coral::Update ) override
     {
       boost::mutex::scoped_lock lock( m_mutex );
       return getICS()->connect( connectionName, asRole, accessMode );
@@ -70,7 +70,7 @@ namespace cool
     /**
      * Returns the configuration object for the service.
      */
-    coral::IConnectionServiceConfiguration& configuration()
+    coral::IConnectionServiceConfiguration& configuration() override
     {
       boost::mutex::scoped_lock lock( m_mutex );
       return getICS()->configuration();
@@ -80,7 +80,7 @@ namespace cool
      * Cleans up the connection pool from the unused connection, according to
      * the policy defined in the configuration.
      */
-    void purgeConnectionPool()
+    void purgeConnectionPool() override
     {
       //std::cout << "CoralConnectionServiceProxy::purgeConnectionPool" << std::endl;
       boost::mutex::scoped_lock lock( m_mutex );
@@ -90,7 +90,7 @@ namespace cool
     /**
      * Returns the monitoring reporter
      */
-    const coral::IMonitoringReporter& monitoringReporter() const
+    const coral::IMonitoringReporter& monitoringReporter() const override
     {
       boost::mutex::scoped_lock lock( m_mutex );
       return getICS()->monitoringReporter();
@@ -99,7 +99,7 @@ namespace cool
     /**
      * Returns the object which controls the web cache
      */
-    coral::IWebCacheControl& webCacheControl()
+    coral::IWebCacheControl& webCacheControl() override
     {
       boost::mutex::scoped_lock lock( m_mutex );
       return getICS()->webCacheControl();

--- a/root/meta/genreflex/ROOT-5768/RelationalCool/src/RalBulkOperation.h
+++ b/root/meta/genreflex/ROOT-5768/RelationalCool/src/RalBulkOperation.h
@@ -22,7 +22,7 @@ namespace cool {
   public:
 
     /// Destructor
-    virtual ~RalBulkOperation() {}
+    ~RalBulkOperation() override {}
 
     /// Constructor
     RalBulkOperation( const boost::shared_ptr<coral::IBulkOperation> bulkOp,
@@ -30,20 +30,20 @@ namespace cool {
       : m_bulkOperation( bulkOp ), m_rowCacheSize( rowCacheSize ) {}
 
     /// Processes the next iteration
-    void processNextIteration()
+    void processNextIteration() override
     {
       m_bulkOperation->processNextIteration();
     }
 
     /// Flushes the data on the client side to the server.
-    void flush()
+    void flush() override
     {
       m_bulkOperation->flush();
     }
 
     /// Get the row cache size associated to this bulk operation
     /// (the bulk operation is auto-flushed if this is exceeded)
-    int rowCacheSize() const
+    int rowCacheSize() const override
     {
       return m_rowCacheSize;
     }

--- a/root/meta/genreflex/ROOT-5768/RelationalCool/src/RalCursor.h
+++ b/root/meta/genreflex/ROOT-5768/RelationalCool/src/RalCursor.h
@@ -25,7 +25,7 @@ namespace cool
   public:
 
     /// Destructor
-    virtual ~RalCursor() {}
+    ~RalCursor() override {}
 
     /// Constructor from a CORAL query.
     /// The constructor takes ownership of the query and executes it.
@@ -36,20 +36,20 @@ namespace cool
 
     /// Positions the cursor to the next available row in the result set.
     /// If there are no more rows in the result set false is returned.
-    bool next()
+    bool next() override
     {
       return m_cursor.next();
       //return RalQueryMgr::cursorNext( m_cursor ); // with TimingReport
     }
 
     /// Returns a reference to the output buffer holding the last row fetched.
-    const coral::AttributeList& currentRow() const
+    const coral::AttributeList& currentRow() const override
     {
       return m_cursor.currentRow();
     }
 
     /// Explicitly closes the cursor, releasing the resources on the server.
-    void close()
+    void close() override
     {
       return m_cursor.close();
     }

--- a/root/meta/genreflex/ROOT-5768/RelationalCool/src/RalSequenceMgr.h
+++ b/root/meta/genreflex/ROOT-5768/RelationalCool/src/RalSequenceMgr.h
@@ -39,24 +39,24 @@ namespace cool
     }
 
     /// Destructor
-    virtual ~RalSequenceMgr();
+    ~RalSequenceMgr() override;
 
     /// Create a new sequence (ownership of the C++ instance is shared).
     boost::shared_ptr<RelationalSequence>
-    createSequence( const std::string& name );
+    createSequence( const std::string& name ) override;
 
     /// Does this sequence exist?
-    bool existsSequence( const std::string& name );
+    bool existsSequence( const std::string& name ) override;
 
     /// Get an existing sequence (ownership of the C++ instance is shared).
     boost::shared_ptr<RelationalSequence>
-    getSequence( const std::string& name );
+    getSequence( const std::string& name ) override;
 
     /// Drop an existing sequence
-    void dropSequence( const std::string& name );
+    void dropSequence( const std::string& name ) override;
 
     /// Init the sequence (fill with initial values)
-    void initSequence( const std::string& name );
+    void initSequence( const std::string& name ) override;
 
   private:
 

--- a/root/meta/genreflex/ROOT-5768/RelationalCool/src/RalTransactionMgr.h
+++ b/root/meta/genreflex/ROOT-5768/RelationalCool/src/RalTransactionMgr.h
@@ -27,7 +27,7 @@ namespace cool {
   public:
 
     /// Destructor
-    virtual ~RalTransactionMgr();
+    ~RalTransactionMgr() override;
 
     /// Constructor from a RalSessionMgr
     RalTransactionMgr( const boost::shared_ptr<ISessionMgr>& sessionMgr,
@@ -47,25 +47,25 @@ namespace cool {
   protected:
 
     /// Start a transaction
-    void start( bool readOnly );
+    void start( bool readOnly ) override;
 
     /// Commit a transaction
-    void commit();
+    void commit() override;
 
     /// Rollback a transaction
-    void rollback();
+    void rollback() override;
 
     /// Is the transaction active?
-    bool isActive();
+    bool isActive() override;
 
     /// Is the transaction read-only?
     bool isReadOnly();
 
     /// Enable auto-transactions
-    void setAutoTransactions( bool flag ) { m_autoTransactions = flag; }
+    void setAutoTransactions( bool flag ) override { m_autoTransactions = flag; }
 
     /// Are auto-transactions enabled?
-    bool autoTransactions() const { return m_autoTransactions; }
+    bool autoTransactions() const override { return m_autoTransactions; }
 
     /// Get the CORAL transaction
     coral::ITransaction& coralTransaction( const std::string& source ) const;

--- a/root/meta/genreflex/ROOT-5768/RelationalCool/src/RelationalTableRow.h
+++ b/root/meta/genreflex/ROOT-5768/RelationalCool/src/RelationalTableRow.h
@@ -30,7 +30,7 @@ namespace cool
   public:
 
     /// Destructor.
-    virtual ~RelationalTableRow();
+    ~RelationalTableRow() override;
 
     /// Standard constructor.
     /// Creates a table row with empty AttributeList data.

--- a/root/meta/genreflex/virtualInheritance.h
+++ b/root/meta/genreflex/virtualInheritance.h
@@ -1,5 +1,5 @@
 #include "TObject.h"
 class DummyVIClass: public virtual TObject {
-ClassDef(DummyVIClass,0)
+ClassDefOverride(DummyVIClass,0)
 };
 


### PR DESCRIPTION
This is done using `clang-tidy`.