### PR TITLE
Enable execAtlasTest2 on windows

### DIFF
--- a/root/meta/dictSelection/CMakeLists.txt
+++ b/root/meta/dictSelection/CMakeLists.txt
@@ -10,7 +10,6 @@ ROOTTEST_GENERATE_REFLEX_DICTIONARY(AtlasTest2 AtlasTest2.h SELECTION AtlasTest2
 ROOTTEST_ADD_TEST(execAtlasTest2
                   MACRO execAtlasTest2.C
                   OUTREF execAtlasTest2.ref
-                  ${WILLFAIL_ON_WIN32}
                   DEPENDS ${GENERATE_REFLEX_TEST})
 
 ROOTTEST_GENERATE_REFLEX_DICTIONARY(classesDictSelection classesDictSelection.h SELECTION classesDictSelection_selection.xml NO_ROOTMAP)


### PR DESCRIPTION
The [commit 5a601aacab4b3](https://github.com/root-project/roottest/commit/5a601aacab4b35bd7f90de71cc5b5e5769c400fc) fixes the execAtlasTest2 test on Windows (just remove the `WILL_FAIL` flag)

(cherry picked from commit 84f0a52f25dc510fcefe88d13f798dd398ad2cc0)