### PR TITLE
[ci] Specify nbconvert version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,9 @@
 IPython
 jupyter
 pytest
+# nbconvert 7.3 has a bug that does not respect --output option
+# See https://github.com/jupyter/nbconvert/issues/1970
+nbconvert < 7.3 , >= 7.4
 
 # Needed by tutorials (run as part of roottest)
 pandas


### PR DESCRIPTION
Recent failures of roottest-python-JupyROOT-importROOT_notebook (specifically on Fedora 37) would report the message

```
[NbConvertApp] Converting notebook importROOT.ipynb to notebook
[NbConvertApp] Writing 988 bytes to importROOT_out.nbconvert.ipynb
...
    File "/tmp/workspace/src/roottest/python/JupyROOT/nbdiff.py", line 68, in getFilteredLines
      filteredLines = list(filter(customLineJunkFilter, open(fileName).readlines()))
                                                        ^^^^^^^^^^^^^^
  FileNotFoundError: [Errno 2] No such file or directory: 'importROOT_out.ipynb'
```

This is due to a bug in nbconvert version 7.3, as described in https://github.com/jupyter/nbconvert/issues/1970. Other versions of the package do not suffer from the bug, so we update the requirements.txt file accordingly.