### PR TITLE
dlopen race: speed up when dependent library are also unloaded.

### DIFF
--- a/root/meta/race-12552/User.hpp
+++ b/root/meta/race-12552/User.hpp
@@ -1,6 +1,13 @@
 #ifndef USER_CLASS_HPP
 #define USER_CLASS_HPP
 
-class UserClass {};
+#include <vector>
+#include <TString.h>
+
+struct UserClass {
+   // The dictionary for this class is generated using genreflex
+   // so the following is not enough to trigger a GenerateInitInstance
+   std::vector<TString> fValues;
+};
 
 #endif

--- a/root/meta/race-12552/User.xml
+++ b/root/meta/race-12552/User.xml
@@ -1,3 +1,4 @@
 <lcgdict>
 <class name="UserClass" />
+<class name="std::vector<TString>" />
 </lcgdict>

--- a/root/meta/race-12552/exec_dlopenrace.C
+++ b/root/meta/race-12552/exec_dlopenrace.C
@@ -3,10 +3,20 @@
 #include "TROOT.h"
 #include <dlfcn.h>
 #include <iostream>
+#include <atomic>
+
+std::atomic<int> gOpenDone(0);
+std::atomic<int> gLookupDone(0);
 
 void repeatopen(int n)
 {
    for(int i = 0; i < n; ++i) {
+     if (i % 100 == 0) std::cerr << "Opening library #" << i << '\n';
+     if (gLookupDone) {
+        // No need to continue as the lookup has stopped
+	std::cout << "Stopping after Opening library #" << i << '\n';
+        break;
+     }
      auto r = dlopen("./libUser.so", RTLD_LAZY);
      if (!r) {
         std::cerr << "Failed to open libUser.so at iteration " << i << "\n";
@@ -15,12 +25,13 @@ void repeatopen(int n)
      // Waste some time
      for(int j = 0; j < 10; ++j)
        auto d = TClassTable::GetDictNorm("UserClass");
-     // std::cerr << "Seeing dict pointer: " << (void*)d << '\n';
      dlclose(r);
    }
+   gOpenDone = 1;
+   std::cout << "Done with opening the libraries\n";
 }
 
-void repeatlookup(int n)
+void repeatlookup(Long64_t n)
 {
    static DictFuncPtr_t value = nullptr;
 
@@ -32,15 +43,31 @@ void repeatlookup(int n)
      if (r != nullptr && r != value)
        std::cerr << "Value of dictionary pointer changed from " << (void*)value << " to " << (void*)r << '\n';
    }
+   gLookupDone = 1;
+   std::cout << "Done with doing lookups\n";
 }
 
 
-int exec_dlopenrace()
+int exec_dlopenrace(int iter = 1000)
 {
+   // Preload some of the libraries to reduce but not eliminate
+   // the number of libraries that unloaded and reloaded at each
+   // iteration.
+   // Note only some platform (eg. EL8 with clang) will actually
+   // unload the dependent libraries as part of the library's dlclose.
+   // When this happens (at least for now) glibc's cxa_atexit.c and cxa_finalize.c
+   // accumulate atexit function/structure such that the cost of loop through
+   // them increase (in this example) in O(N^2) of the number of dlopen/dlclose
+   // and libraries actually (un)loaded.
+   // We keep some to actually exercise the unloading and reloading of complex
+   // dictionaries.
+   gSystem->Load("libGpad");
+   // If we load this then only libUser is loaded and unloaded.
+   // gSystem->Load("libTree");
+
    ROOT::EnableThreadSafety();
-   constexpr auto iter = 10000;
    std::thread openlib{repeatopen, iter};
-   std::thread lookup{repeatlookup, iter};
+   std::thread lookup{repeatlookup, 10000*iter};
    openlib.join();
    lookup.join();
    return 0;


### PR DESCRIPTION
To reduce the number of libraries unloaded on EL8 when clang++ (other platform don't seem to unload the dependent libraries) we preload some (but not all) of the libraries (keeping some to test the unloading and reloading of complex dictionary).

Also speed-up the test by stopping as soon as the lookups are done looping.

This is linked to https://github.com/root-project/root/pull/12863