### PR TITLE
[RF] Always use `addOwned()` overload that takes `unique_ptr`

### DIFF
--- a/root/roofitstats/vectorisedPDFs/testAddPdf.cxx
+++ b/root/roofitstats/vectorisedPDFs/testAddPdf.cxx
@@ -28,35 +28,35 @@ class TestGaussPlusPoisson : public PDFTest
       PDFTest("Gauss + Poisson", 100000)
     {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
-      auto x = new RooRealVar("x", "x", -1.5, 40.5);
+      auto x = std::make_unique<RooRealVar>("x", "x", -1.5, 40.5);
       x->setBins(42);//Prettier plots for Poisson
 
-      auto mean = new RooRealVar("mean", "mean of gaussian", 20., -10, 30);
-      auto sigma = new RooRealVar("sigma", "width of gaussian", 4., 0.5, 10);
+      auto mean = std::make_unique<RooRealVar>("mean", "mean of gaussian", 20., -10, 30);
+      auto sigma = std::make_unique<RooRealVar>("sigma", "width of gaussian", 4., 0.5, 10);
 
       // Build gaussian p.d.f in terms of x,mean and sigma
-      auto gauss = new RooGaussian("gauss", "gaussian PDF", *x, *mean, *sigma);
+      auto gauss = std::make_unique<RooGaussian>("gauss", "gaussian PDF", *x, *mean, *sigma);
 
-      auto meanPois = new RooRealVar("meanPois", "Mean of Poisson", 10.3, 0, 30);
-      auto pois = new RooPoisson("Pois", "Poisson PDF", *x, *meanPois, true);
+      auto meanPois = std::make_unique<RooRealVar>("meanPois", "Mean of Poisson", 10.3, 0, 30);
+      auto pois = std::make_unique<RooPoisson>("Pois", "Poisson PDF", *x, *meanPois, true);
 
-      auto fractionGaus = new RooRealVar("fractionGaus", "Fraction of Gauss component", 0.5, 0., 1.);
+      auto fractionGaus = std::make_unique<RooRealVar>("fractionGaus", "Fraction of Gauss component", 0.5, 0., 1.);
       auto sumGausPois = std::make_unique<RooAddPdf>("SumGausPois", "Sum of Gaus and Poisson",
           RooArgSet(*gauss, *pois), *fractionGaus);
       sumGausPois->fixCoefNormalization(*x);
       _pdf = std::move(sumGausPois);
 
-      _variables.addOwned(*x);
+      _variables.addOwned(std::move(x));
 
 //      _variablesToPlot.add(x);
 
-      for (auto par : {mean, sigma, meanPois, fractionGaus}) {
-        _parameters.addOwned(*par);
-      }
+      _parameters.addOwned(std::move(mean));
+      _parameters.addOwned(std::move(sigma));
+      _parameters.addOwned(std::move(meanPois));
+      _parameters.addOwned(std::move(fractionGaus));
 
-      for (auto obj : std::initializer_list<RooAbsPdf*>{gauss, pois}) {
-        _otherObjects.addOwned(*obj);
-      }
+      _otherObjects.addOwned(std::move(gauss));
+      _otherObjects.addOwned(std::move(pois));
 
       // Gauss is slightly less accurate
       _toleranceCompareBatches = 2.E-13;
@@ -80,23 +80,23 @@ class TestGaussPlusGaussPlusExp : public PDFTest
     TestGaussPlusGaussPlusExp() :
       PDFTest("Gauss + Gauss + Exp", 100001)
     {
-      auto x = new RooRealVar("x", "x", 0., 100.);
+      auto x = std::make_unique<RooRealVar>("x", "x", 0., 100.);
 
-      auto c = new RooRealVar("c", "c", -0.05, -100., -0.005);
-      auto expo = new RooExponential("expo", "expo", *x, *c);
+      auto c = std::make_unique<RooRealVar>("c", "c", -0.05, -100., -0.005);
+      auto expo = std::make_unique<RooExponential>("expo", "expo", *x, *c);
 
 
-      auto mean = new RooRealVar("mean1", "mean of gaussian", 30., -10, 100);
-      auto sigma = new RooRealVar("sigma1", "width of gaussian", 4., 0.1, 20);
-      auto gauss = new RooGaussian("gauss1", "gaussian PDF", *x, *mean, *sigma);
+      auto mean = std::make_unique<RooRealVar>("mean1", "mean of gaussian", 30., -10, 100);
+      auto sigma = std::make_unique<RooRealVar>("sigma1", "width of gaussian", 4., 0.1, 20);
+      auto gauss = std::make_unique<RooGaussian>("gauss1", "gaussian PDF", *x, *mean, *sigma);
 
-      auto mean2 = new RooRealVar("mean2", "mean of gaussian", 60., 50, 100);
-      auto sigma2 = new RooRealVar("sigma2", "width of gaussian", 10., 0.1, 20);
-      auto gauss2 = new RooGaussian("gauss2", "gaussian PDF", *x, *mean2, *sigma2);
+      auto mean2 = std::make_unique<RooRealVar>("mean2", "mean of gaussian", 60., 50, 100);
+      auto sigma2 = std::make_unique<RooRealVar>("sigma2", "width of gaussian", 10., 0.1, 20);
+      auto gauss2 = std::make_unique<RooGaussian>("gauss2", "gaussian PDF", *x, *mean2, *sigma2);
 
-      auto nGauss = new RooRealVar("nGauss", "Fraction of Gauss component", 800., 0., 1.E6);
-      auto nGauss2 = new RooRealVar("nGauss2", "Fraction of Gauss component", 600., 0., 1.E6);
-      auto nExp = new RooRealVar("nExp", "Number of events in exp", 1000, 0, 1.E6);
+      auto nGauss = std::make_unique<RooRealVar>("nGauss", "Fraction of Gauss component", 800., 0., 1.E6);
+      auto nGauss2 = std::make_unique<RooRealVar>("nGauss2", "Fraction of Gauss component", 600., 0., 1.E6);
+      auto nExp = std::make_unique<RooRealVar>("nExp", "Number of events in exp", 1000, 0, 1.E6);
       auto sum2GausExp = std::make_unique<RooAddPdf>("Sum2GausExp", "Sum of Gaus and Exponentials",
           RooArgSet(*gauss, *gauss2, *expo),
           RooArgSet(*nGauss, *nGauss2, *nExp));
@@ -104,19 +104,21 @@ class TestGaussPlusGaussPlusExp : public PDFTest
       _pdf = std::move(sum2GausExp);
 
 
-      _variables.addOwned(*x);
+      _variables.addOwned(std::move(x));
 
-      for (auto par : {c, mean, sigma, mean2, sigma2}) {
-        _parameters.addOwned(*par);
-      }
+      _parameters.addOwned(std::move(c));
+      _parameters.addOwned(std::move(mean));
+      _parameters.addOwned(std::move(sigma));
+      _parameters.addOwned(std::move(mean2));
+      _parameters.addOwned(std::move(sigma2));
 
-      for (auto par : {nGauss, nGauss2, nExp}) {
-        _yields.addOwned(*par);
-      }
+      _yields.addOwned(std::move(nGauss));
+      _yields.addOwned(std::move(nGauss2));
+      _yields.addOwned(std::move(nExp));
 
-      for (auto obj : std::initializer_list<RooAbsPdf*>{expo, gauss, gauss2}) {
-        _otherObjects.addOwned(*obj);
-      }
+      _otherObjects.addOwned(std::move(expo));
+      _otherObjects.addOwned(std::move(gauss));
+      _otherObjects.addOwned(std::move(gauss2));
 
       _toleranceCompareLogs = 4.3E-14;
 

--- a/root/roofitstats/vectorisedPDFs/testArgusBG.cxx
+++ b/root/roofitstats/vectorisedPDFs/testArgusBG.cxx
@@ -23,25 +23,23 @@ class TestArgus : public PDFTest
     TestArgus() :
       PDFTest("Argus", 100000)
   { 
-      auto m = new RooRealVar("m", "m", 300.0, 1.0, 800.0);
-      auto m0 = new RooRealVar("m0", "m0", 1100.0, 800.0, 1400.0);
-      auto c = new RooRealVar("c", "c", 10.0, 5.0, 15.0);
+      auto m = std::make_unique<RooRealVar>("m", "m", 300.0, 1.0, 800.0);
+      auto m0 = std::make_unique<RooRealVar>("m0", "m0", 1100.0, 800.0, 1400.0);
+      auto c = std::make_unique<RooRealVar>("c", "c", 10.0, 5.0, 15.0);
       c->setConstant();
-      auto p = new RooRealVar("p", "p", 1.0, 0.9, 1.3);
+      auto p = std::make_unique<RooRealVar>("p", "p", 1.0, 0.9, 1.3);
       p->setConstant();
       _pdf = std::make_unique<RooArgusBG>("argus1", "argus1", *m, *m0, *c, *p);
-      for (auto var : {m}) {
-        _variables.addOwned(*var);
-      }
-
 //      for (auto var : {m}) {
 //        _variablesToPlot.add(*var);
 //      }
 //      _printLevel = 2;
 
-      for (auto par : {m0, c, p}) {
-        _parameters.addOwned(*par);
-      }
+      _variables.addOwned(std::move(m));
+
+      _parameters.addOwned(std::move(m0));
+      _parameters.addOwned(std::move(c));
+      _parameters.addOwned(std::move(p));
       
       _toleranceParameter = 2.E-6;
   }

--- a/root/roofitstats/vectorisedPDFs/testBernstein.cxx
+++ b/root/roofitstats/vectorisedPDFs/testBernstein.cxx
@@ -23,8 +23,8 @@ class TestBernstein2 : public PDFTest
     TestBernstein2() :
       PDFTest("Bernstein2", 100000)
   {
-        auto x = new RooRealVar("x", "x", -10, 10);
-        auto a1 = new RooRealVar("a1", "a1", 1, 0.8, 1.2);
+        auto x = std::make_unique<RooRealVar>("x", "x", -10, 10);
+        auto a1 = std::make_unique<RooRealVar>("a1", "a1", 1, 0.8, 1.2);
         auto a2 = new RooRealVar("a2", "a2", 1.5, 1.2, 1.8);
         a2->setConstant(true);
 
@@ -32,13 +32,12 @@ class TestBernstein2 : public PDFTest
         *x, RooArgSet(*a1,*a2));
 
 
-      _variables.addOwned(*x);
+      _variables.addOwned(std::move(x));
 
       //_variablesToPlot.add(*x);
 
-      for (auto par : {a1}) {
-        _parameters.addOwned(*par);
-      }
+      _parameters.addOwned(std::move(a1));
+
       _toleranceParameter = 1.5e-6;
   }
 };
@@ -56,12 +55,12 @@ class TestBernstein5 : public PDFTest
     TestBernstein5() :
       PDFTest("Bernstein5", 100000)
   {
-        auto x = new RooRealVar("x", "x", -100, 50);
-        auto a1 = new RooRealVar("a1", "a1", 0.8, 0.6, 1.2);
+        auto x = std::make_unique<RooRealVar>("x", "x", -100, 50);
+        auto a1 = std::make_unique<RooRealVar>("a1", "a1", 0.8, 0.6, 1.2);
         auto a2 = new RooRealVar("a2", "a2", 0.0, -1.0, 1.0);
         auto a3 = new RooRealVar("a3", "a3", 0.09, 0.05, 0.4);
         auto a4 = new RooRealVar("a4", "a4", 0.0, 0.2, 0.8);
-        auto a5 = new RooRealVar("a5", "a5", 0.09, 0.05, 0.5);
+        auto a5 = std::make_unique<RooRealVar>("a5", "a5", 0.09, 0.05, 0.5);
         a4->setConstant(true);
         a3->setConstant(true);
         a2->setConstant(true);
@@ -69,13 +68,12 @@ class TestBernstein5 : public PDFTest
         _pdf = std::make_unique<RooBernstein>("bernstein5", "bernstein PDF 5 coefficients", *x, RooArgSet(*a1, *a2, *a3, *a4, *a5));
 
 
-      _variables.addOwned(*x);
+      _variables.addOwned(std::move(x));
 
       //_variablesToPlot.add(*x);
 
-      for (auto par : { a1, a5}) {
-        _parameters.addOwned(*par);
-      }
+      _parameters.addOwned(std::move(a1));
+      _parameters.addOwned(std::move(a5));
   }
 };
 

--- a/root/roofitstats/vectorisedPDFs/testBifurGauss.cxx
+++ b/root/roofitstats/vectorisedPDFs/testBifurGauss.cxx
@@ -24,23 +24,22 @@ class TestBifurGauss : public PDFTest
     TestBifurGauss() :
       PDFTest("BifurGauss", 100000)
   { 
-    auto x = new RooRealVar("x", "x", 300.0, 100.0, 800.0);
-    auto mean = new RooRealVar("mean", "mean", 350.0, 250.0, 500.0);
+    auto x = std::make_unique<RooRealVar>("x", "x", 300.0, 100.0, 800.0);
+    auto mean = std::make_unique<RooRealVar>("mean", "mean", 350.0, 250.0, 500.0);
     mean->setConstant();
-    auto sigmaL = new RooRealVar("sigmaL", "sigmaL", 60.0, 50.0, 150.0);
-    auto sigmaR = new RooRealVar("sigmaR", "sigmaR", 100.0, 50.0, 150.0);
+    auto sigmaL = std::make_unique<RooRealVar>("sigmaL", "sigmaL", 60.0, 50.0, 150.0);
+    auto sigmaR = std::make_unique<RooRealVar>("sigmaR", "sigmaR", 100.0, 50.0, 150.0);
     _pdf = std::make_unique<RooBifurGauss>("bifurGauss1", "bifurGauss1", *x, *mean, *sigmaL, *sigmaR);
-    for (auto var : {x}) {
-      _variables.addOwned(*var);
-    }
 
 //    for (auto var : {x}) {
 //      _variablesToPlot.add(*var);
 //    }
 
-    for (auto par : {mean, sigmaL, sigmaR}) {
-      _parameters.addOwned(*par);
-    }
+    _variables.addOwned(std::move(x));
+
+    _parameters.addOwned(std::move(mean));
+    _parameters.addOwned(std::move(sigmaL));
+    _parameters.addOwned(std::move(sigmaR));
 
     _toleranceParameter = 8.E-6;
   }

--- a/root/roofitstats/vectorisedPDFs/testBreitWigner.cxx
+++ b/root/roofitstats/vectorisedPDFs/testBreitWigner.cxx
@@ -23,20 +23,19 @@ class TestBreitWigner : public PDFTest
     TestBreitWigner() :
       PDFTest("BreitWigner", 100000)
   {
-        auto x = new RooRealVar("x", "x", -10, 10);
-        auto mean = new RooRealVar("mean", "mean", 1, -7, 7);
-        auto width = new RooRealVar("a2", "a2", 1.8, 0.5, 2.5);
+        auto x = std::make_unique<RooRealVar>("x", "x", -10, 10);
+        auto mean = std::make_unique<RooRealVar>("mean", "mean", 1, -7, 7);
+        auto width = std::make_unique<RooRealVar>("a2", "a2", 1.8, 0.5, 2.5);
 
         _pdf = std::make_unique<RooBreitWigner>("breitWigner", "breitWigner PDF", *x, *mean, *width);
 
 
-      _variables.addOwned(*x);
-
 //      _variablesToPlot.add(*x);
 
-      for (auto par : {mean, width}) {
-        _parameters.addOwned(*par);
-      }
+      _variables.addOwned(std::move(x));
+
+      _parameters.addOwned(std::move(mean));
+      _parameters.addOwned(std::move(width));
 
       _toleranceCompareLogs = 5.e-13;
       _toleranceCorrelation = 0.007;

--- a/root/roofitstats/vectorisedPDFs/testBukin.cxx
+++ b/root/roofitstats/vectorisedPDFs/testBukin.cxx
@@ -25,9 +25,9 @@ class TestBukin : public PDFTest
     TestBukin() :
       PDFTest("Bukin", 100000)
   { 
-      auto x = new RooRealVar("x", "x", 0.6, -15., 10.);
-      auto Xp = new RooRealVar("Xp", "Xp", 0.5, -3., 5.);
-      auto sigp = new RooRealVar("sigp", "sigp", 3., 1., 5.);
+      auto x = std::make_unique<RooRealVar>("x", "x", 0.6, -15., 10.);
+      auto Xp = std::make_unique<RooRealVar>("Xp", "Xp", 0.5, -3., 5.);
+      auto sigp = std::make_unique<RooRealVar>("sigp", "sigp", 3., 1., 5.);
       auto xi = new RooRealVar("xi", "xi", -0.2, -0.3, 0.3);
       auto rho1 = new RooRealVar("rho1", "rho1", -0.1, -0.3, -0.05);
       auto rho2 = new RooRealVar("rho2", "rho2", 0.15, 0.05, 0.25);
@@ -36,17 +36,15 @@ class TestBukin : public PDFTest
       rho1->setConstant(true);
       rho2->setConstant(true);
       
-      for (auto var : {x}) {
-        _variables.addOwned(*var);
-      }
+      _variables.addOwned(std::move(x));
 
       //for (auto var : {x}) {
         //_variablesToPlot.add(*var);
       //}
 
-      for (auto par : {Xp, sigp}) {
-        _parameters.addOwned(*par);
-      }
+      _parameters.addOwned(std::move(Xp));
+      _parameters.addOwned(std::move(sigp));
+
       _toleranceParameter = 3e-5;
       _toleranceCompareBatches = 2.5e-14;
       //_toleranceCompareLogs{2.E-14};

--- a/root/roofitstats/vectorisedPDFs/testCBShape.cxx
+++ b/root/roofitstats/vectorisedPDFs/testCBShape.cxx
@@ -23,22 +23,22 @@ class TestCBShape : public PDFTest
     TestCBShape() :
       PDFTest("CBShape", 100000)
   {
-        auto m = new RooRealVar("m", "m", -10, 10);
-        auto m0 = new RooRealVar("m0", "m0", 1, -7, 7);
-        auto sigma = new RooRealVar("sigma", "sigma", 1, 0.5, 2.5);
-        auto alpha = new RooRealVar("alpha", "alpha", 1, -3, 3);
-        auto n = new RooRealVar("n", "n", 1, 0.5, 2.5);
+        auto m = std::make_unique<RooRealVar>("m", "m", -10, 10);
+        auto m0 = std::make_unique<RooRealVar>("m0", "m0", 1, -7, 7);
+        auto sigma = std::make_unique<RooRealVar>("sigma", "sigma", 1, 0.5, 2.5);
+        auto alpha = std::make_unique<RooRealVar>("alpha", "alpha", 1, -3, 3);
+        auto n = std::make_unique<RooRealVar>("n", "n", 1, 0.5, 2.5);
 
         _pdf = std::make_unique<RooCBShape>("CBShape", "CBShape PDF", *m, *m0, *sigma, *alpha, *n);
 
-
-      _variables.addOwned(*m);
-
       //_variablesToPlot.add(*m);
 
-      for (auto par : {m0, sigma, alpha, n}) {
-        _parameters.addOwned(*par);
-      }
+      _variables.addOwned(std::move(m));
+
+      _parameters.addOwned(std::move(m0));
+      _parameters.addOwned(std::move(sigma));
+      _parameters.addOwned(std::move(alpha));
+      _parameters.addOwned(std::move(n));
 
       // For i686:
       _toleranceParameter = 1.E-5;

--- a/root/roofitstats/vectorisedPDFs/testChebychev.cxx
+++ b/root/roofitstats/vectorisedPDFs/testChebychev.cxx
@@ -24,20 +24,19 @@ class TestChebychev2 : public PDFTest
     TestChebychev2() :
       PDFTest("Chebychev2", 100000)
   {
-        auto x = new RooRealVar("x", "x", -10, 10);
-        auto a1 = new RooRealVar("a1", "a1", 0.3, -0.5, 0.5);
-        auto a2 = new RooRealVar("a2", "a2", -0.2, -0.5, 0.5);
+        auto x = std::make_unique<RooRealVar>("x", "x", -10, 10);
+        auto a1 = std::make_unique<RooRealVar>("a1", "a1", 0.3, -0.5, 0.5);
+        auto a2 = std::make_unique<RooRealVar>("a2", "a2", -0.2, -0.5, 0.5);
 
         _pdf = std::make_unique<RooChebychev>("chebychev2", "chebychev PDF 2 coefficients", *x, RooArgSet(*a1,*a2));
 
 
-      _variables.addOwned(*x);
-
       //_variablesToPlot.add(*x);
 
-      for (auto par : {a1, a2}) {
-        _parameters.addOwned(*par);
-      }
+      _variables.addOwned(std::move(x));
+
+      _parameters.addOwned(std::move(a1));
+      _parameters.addOwned(std::move(a2));
   }
 };
 
@@ -54,25 +53,26 @@ class TestChebychev5 : public PDFTest
     TestChebychev5() :
       PDFTest("Chebychev5", 50000)
   {
-        auto x = new RooRealVar("x", "x", -10, 10);
-        auto a1 = new RooRealVar("a1", "a1", 0.15, -0.3, 0.3);
-        auto a2 = new RooRealVar("a2", "a2", -0.15, -0.3, 0.3);
+        auto x = std::make_unique<RooRealVar>("x", "x", -10, 10);
+        auto a1 = std::make_unique<RooRealVar>("a1", "a1", 0.15, -0.3, 0.3);
+        auto a2 = std::make_unique<RooRealVar>("a2", "a2", -0.15, -0.3, 0.3);
         auto a3 = new RooRealVar("a3", "a3", 0.20, 0.10, 0.30);
-        auto a4 = new RooRealVar("a4", "a4", 0.35, 0.3, 0.5);
-        auto a5 = new RooRealVar("a5", "a5", -0.07, -0.2, 0.2);
+        auto a4 = std::make_unique<RooRealVar>("a4", "a4", 0.35, 0.3, 0.5);
+        auto a5 = std::make_unique<RooRealVar>("a5", "a5", -0.07, -0.2, 0.2);
         a2->setConstant(true);
         a3->setConstant(true);
 
-        _pdf = std::make_unique<RooChebychev>("chebychev5", "chebychev PDF 5 coefficients", *x, RooArgSet(*a1, *a2, *a3, *a4, *a5));
-
-
-      _variables.addOwned(*x);
+        _pdf = std::make_unique<RooChebychev>("chebychev5", "chebychev PDF 5 coefficients", *x, RooArgSet{*a1, *a2, *a3, *a4, *a5});
 
       //_variablesToPlot.add(*x);
 
-      for (auto par : {a1, a2, a4, a5}) {
-        _parameters.addOwned(*par);
-      }
+      _variables.addOwned(std::move(x));
+
+      _parameters.addOwned(std::move(a1));
+      _parameters.addOwned(std::move(a2));
+      _parameters.addOwned(std::move(a4));
+      _parameters.addOwned(std::move(a5));
+
       _toleranceParameter = 2e-6;
 
   }

--- a/root/roofitstats/vectorisedPDFs/testChiSquarePdf.cxx
+++ b/root/roofitstats/vectorisedPDFs/testChiSquarePdf.cxx
@@ -23,21 +23,18 @@ class TestChiSquarePdfinX: public PDFTest
     TestChiSquarePdfinX() :
       PDFTest("ChiSquarePdf", 100000)
     {
-      auto x = new RooRealVar("x", "x", 0.1, 100);
-      auto ndof = new RooRealVar("ndof", "ndof of chiSquarePdf", 2, 1, 5);
+      auto x = std::make_unique<RooRealVar>("x", "x", 0.1, 100);
+      auto ndof = std::make_unique<RooRealVar>("ndof", "ndof of chiSquarePdf", 2, 1, 5);
       
       // Build chiSquarePdf p.d.f 
       _pdf = std::make_unique<RooChiSquarePdf>("chiSquarePdf", "chiSquarePdf PDF", *x, *ndof);
       
-      for (auto var : {x}) {
-        _variables.addOwned(*var);
-      }
-      
       //      _variablesToPlot.add(x);
+
+      _variables.addOwned(std::move(x));
       
-      for (auto par : {ndof}) {
-        _parameters.addOwned(*par);
-      }
+      _parameters.addOwned(std::move(ndof));
+
       _toleranceCompareLogs = 5e-14;
     }
 };

--- a/root/roofitstats/vectorisedPDFs/testCompatMode.cxx
+++ b/root/roofitstats/vectorisedPDFs/testCompatMode.cxx
@@ -33,24 +33,21 @@ class TestRooPolynomial : public PDFTest
     TestRooPolynomial() :
       PDFTest("Polynomial(...)")
   {
-      auto x = new RooRealVar("x", "x", 0, 10);
-      auto a1 = new RooRealVar("a1", "First coefficient", 5, 0, 10);
-      auto a2 = new RooRealVar("a2", "Second coefficient", 1, 0, 10);
-      auto a3 = new RooFormulaVar("a3", "Third coefficient", "a1+a2", RooArgList(*a1, *a2));
+      auto x = std::make_unique<RooRealVar>("x", "x", 0, 10);
+      auto a1 = std::make_unique<RooRealVar>("a1", "First coefficient", 5, 0, 10);
+      auto a2 = std::make_unique<RooRealVar>("a2", "Second coefficient", 1, 0, 10);
+      auto a3 = std::make_unique<RooFormulaVar>("a3", "Third coefficient", "a1+a2", RooArgList(*a1, *a2));
 
       _pdf = std::make_unique<RooPolynomial>("pol", "Polynomial", *x, RooArgList(*a1, *a2, *a3));
 
 
-      for (auto var : {x, a1}) {
-        _variables.addOwned(*var);
+      _variables.addOwned(std::move(x));
+      _variables.addOwned(std::move(a1));
 //        _variablesToPlot.add(var);
-      }
 
-      for (auto par : {a2}) {
-        _parameters.addOwned(*par);
-      }
+      _parameters.addOwned(std::move(a2));
 
-      _otherObjects.addOwned(*a3);
+      _otherObjects.addOwned(std::move(a3));
   }
 };
 
@@ -186,18 +183,17 @@ class TestNonVecGauss : public PDFTest
   protected:
     TestNonVecGauss() :
       PDFTest("GaussNoBatches", 200000) {
-      auto x = new RooRealVar("x", "x", -10, 10);
-      auto mean = new RooRealVar("mean", "mean of gaussian", 1, -10, 10);
-      auto sigma = new RooRealVar("sigma", "width of gaussian", 1, 0.1, 10);
+      auto x = std::make_unique<RooRealVar>("x", "x", -10, 10);
+      auto mean = std::make_unique<RooRealVar>("mean", "mean of gaussian", 1, -10, 10);
+      auto sigma = std::make_unique<RooRealVar>("sigma", "width of gaussian", 1, 0.1, 10);
 
       // Build gaussian p.d.f in terms of x,mean and sigma
       _pdf = std::make_unique<RooNonVecGaussian>("gauss", "gaussian PDF", *x, *mean, *sigma);
 
-      _variables.addOwned(*x);
+      _variables.addOwned(std::move(x));
 
-      for (auto par : {mean, sigma}) {
-        _parameters.addOwned(*par);
-      }
+      _parameters.addOwned(std::move(mean));
+      _parameters.addOwned(std::move(sigma));
 
       _toleranceCompareLogs = 2.5E-14;
     }
@@ -220,19 +216,18 @@ class TestNonVecGaussWeighted : public PDFTestWeightedData
       PDFTestWeightedData("GaussNoBatchesWithWeights", 50000)
   {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
-      auto x = new RooRealVar("x", "x", -10, 10);
-      auto mean = new RooRealVar("mean", "mean of gaussian", 1, -10, 10);
-      auto sigma = new RooRealVar("sigma", "width of gaussian", 2.3, 0.1, 10);
+      auto x = std::make_unique<RooRealVar>("x", "x", -10, 10);
+      auto mean = std::make_unique<RooRealVar>("mean", "mean of gaussian", 1, -10, 10);
+      auto sigma = std::make_unique<RooRealVar>("sigma", "width of gaussian", 2.3, 0.1, 10);
 
       // Build gaussian p.d.f in terms of x,mean and sigma
       _pdf = std::make_unique<RooNonVecGaussian>("gauss", "gaussian PDF", *x, *mean, *sigma);
 
 
-      _variables.addOwned(*x);
+      _variables.addOwned(std::move(x));
 
-      for (auto par : {mean, sigma}) {
-        _parameters.addOwned(*par);
-      }
+      _parameters.addOwned(std::move(mean));
+      _parameters.addOwned(std::move(sigma));
 
       _toleranceCompareLogs = 2.5E-14;
   }
@@ -255,22 +250,19 @@ class TestNonVecGaussInMeanAndX : public PDFTest
       PDFTest("GaussNoBatches(x, mean)")
   {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
-      auto x = new RooRealVar("x", "x", -10, 10);
-      auto mean = new RooRealVar("mean", "mean of gaussian", 1, -10, 10);
-      auto sigma = new RooRealVar("sigma", "width of gaussian", 1, 0.1, 10);
+      auto x = std::make_unique<RooRealVar>("x", "x", -10, 10);
+      auto mean = std::make_unique<RooRealVar>("mean", "mean of gaussian", 1, -10, 10);
+      auto sigma = std::make_unique<RooRealVar>("sigma", "width of gaussian", 1, 0.1, 10);
 
       // Build gaussian p.d.f in terms of x,mean and sigma
       _pdf = std::make_unique<RooNonVecGaussian>("gauss", "gaussian PDF", *x, *mean, *sigma);
 
 
-      for (auto var : {x, mean}) {
-        _variables.addOwned(*var);
+      _variables.addOwned(std::move(x));
+      _variables.addOwned(std::move(mean));
 //        _variablesToPlot.add(var);
-      }
 
-      for (auto par : {sigma}) {
-        _parameters.addOwned(*par);
-      }
+      _parameters.addOwned(std::move(sigma));
   }
 };
 
@@ -281,7 +273,3 @@ COMPARE_FIXED_VALUES_NORM_LOG(TestNonVecGaussInMeanAndX, CompareFixedNormLog)
 FIT_TEST_SCALAR(TestNonVecGaussInMeanAndX, RunScalar)
 FIT_TEST_BATCH(TestNonVecGaussInMeanAndX, RunBatch)
 FIT_TEST_BATCH_VS_SCALAR(TestNonVecGaussInMeanAndX, CompareBatchScalar)
-
-
-
-

--- a/root/roofitstats/vectorisedPDFs/testDstD0BG.cxx
+++ b/root/roofitstats/vectorisedPDFs/testDstD0BG.cxx
@@ -24,21 +24,17 @@ class TestDstD0BG : public PDFTest
     TestDstD0BG() :
       PDFTest("DstD0BG", 100000)
   { 
-      auto m = new RooRealVar("m", "m", 2.0, 1.61, 3);
+      auto m = std::make_unique<RooRealVar>("m", "m", 2.0, 1.61, 3);
       auto m0 = new RooRealVar("m0", "m0", 1.6);
-      auto C = new RooRealVar("C", "C", 1, 0.1, 2);
+      auto C = std::make_unique<RooRealVar>("C", "C", 1, 0.1, 2);
       auto A = new RooRealVar("A", "A", -1.2);
       auto B = new RooRealVar("B", "B", 0.1);
 
       _pdf = std::make_unique<RooDstD0BG>("DstD0BG", "DstD0BG", *m, *m0, *C, *A, *B);
 
-      for (auto var : {m}) {
-        _variables.addOwned(*var);
-      }
+      _variables.addOwned(std::move(m));
 
-      for (auto par : {C}) {
-        _parameters.addOwned(*par);
-      }
+      _parameters.addOwned(std::move(C));
 
     _toleranceCompareBatches = 3.E-14;
     _toleranceCompareLogs    = 3.E-10;

--- a/root/roofitstats/vectorisedPDFs/testExponential.cxx
+++ b/root/roofitstats/vectorisedPDFs/testExponential.cxx
@@ -28,21 +28,17 @@ class TestExponential : public PDFTest
       PDFTest("Exp(x, c1)", 100000)
   {
       //Beyond ~19, the VDT polynomials break down when c1 is very negative
-      auto x = new RooRealVar("x", "x", 0.001, 18.);
-      auto c1 = new RooRealVar("c1", "c1", -0.2, -50., -0.001);
+      auto x = std::make_unique<RooRealVar>("x", "x", 0.001, 18.);
+      auto c1 = std::make_unique<RooRealVar>("c1", "c1", -0.2, -50., -0.001);
       _pdf = std::make_unique<RooExponential>("expo1", "expo1", *x, *c1);
 
-      for (auto var : {x}) {
-        _variables.addOwned(*var);
-      }
+      _variables.addOwned(std::move(x));
 
 //      for (auto var : {x}) {
 //        _variablesToPlot.add(*var);
 //      }
 
-      for (auto par : {c1}) {
-        _parameters.addOwned(*par);
-      }
+      _parameters.addOwned(std::move(c1));
 
       _toleranceCompareLogs = 3E-13;
       // For i686, this needs to be a bit less strict:

--- a/root/roofitstats/vectorisedPDFs/testGamma.cxx
+++ b/root/roofitstats/vectorisedPDFs/testGamma.cxx
@@ -24,23 +24,21 @@ class TestGamma : public PDFTest
     TestGamma() :
       PDFTest("Gamma", 100000)
   {
-    auto x = new RooRealVar("x", "x", 5, 4, 10);
-    auto gamma = new RooRealVar("gamma", "N+1", 6, 4, 8);
+    auto x = std::make_unique<RooRealVar>("x", "x", 5, 4, 10);
+    auto gamma = std::make_unique<RooRealVar>("gamma", "N+1", 6, 4, 8);
     gamma->setConstant();
-    auto beta = new RooRealVar("beta", "beta", 1.5, 0.5, 10);
-    auto mu = new RooRealVar("mu", "mu", 0.2, -1., 1.);
+    auto beta = std::make_unique<RooRealVar>("beta", "beta", 1.5, 0.5, 10);
+    auto mu = std::make_unique<RooRealVar>("mu", "mu", 0.2, -1., 1.);
     mu->setConstant();
     
     // Build gaussian p.d.f in terms of x,mean and sigma
     _pdf = std::make_unique<RooGamma>("Gamma", "Gamma PDF", *x, *gamma, *beta, *mu);
     
-    for (auto var : {x}) {
-    _variables.addOwned(*var);      
-    }
+    _variables.addOwned(std::move(x));      
 
-    for (auto par : {gamma, beta, mu}) {
-      _parameters.addOwned(*par);
-    }
+    _parameters.addOwned(std::move(gamma));
+    _parameters.addOwned(std::move(beta));
+    _parameters.addOwned(std::move(mu));
     
 //    _variablesToPlot.add(*x);
     _toleranceCompareBatches = 1.2E-14;

--- a/root/roofitstats/vectorisedPDFs/testGauss.cxx
+++ b/root/roofitstats/vectorisedPDFs/testGauss.cxx
@@ -26,21 +26,20 @@ class TestGauss : public PDFTest
       PDFTest("Gauss", 200000)
   {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
-        auto x = new RooRealVar("x", "x", -10, 10);
-        auto mean = new RooRealVar("mean", "mean of gaussian", 1, -10, 10);
-        auto sigma = new RooRealVar("sigma", "width of gaussian", 1, 0.1, 10);
+        auto x = std::make_unique<RooRealVar>("x", "x", -10, 10);
+        auto mean = std::make_unique<RooRealVar>("mean", "mean of gaussian", 1, -10, 10);
+        auto sigma = std::make_unique<RooRealVar>("sigma", "width of gaussian", 1, 0.1, 10);
 
         // Build gaussian p.d.f in terms of x,mean and sigma
         _pdf = std::make_unique<RooGaussian>("gauss", "gaussian PDF", *x, *mean, *sigma);
 
 
-      _variables.addOwned(*x);
-
 //      _variablesToPlot.add(x);
 
-      for (auto par : {mean, sigma}) {
-        _parameters.addOwned(*par);
-      }
+      _variables.addOwned(std::move(x));
+
+      _parameters.addOwned(std::move(mean));
+      _parameters.addOwned(std::move(sigma));
 
       // Standard of 1.E-14 is slightly too strong.
       _toleranceCompareBatches = 3.E-14;
@@ -65,19 +64,18 @@ class TestGaussWeighted : public PDFTestWeightedData
       PDFTestWeightedData("GaussWithWeights", 100000)
   {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
-      auto x = new RooRealVar("x", "x", -10, 10);
-      auto mean = new RooRealVar("mean", "mean of gaussian", 1, -10, 10);
-      auto sigma = new RooRealVar("sigma", "width of gaussian", 1, 0.1, 10);
+      auto x = std::make_unique<RooRealVar>("x", "x", -10, 10);
+      auto mean = std::make_unique<RooRealVar>("mean", "mean of gaussian", 1, -10, 10);
+      auto sigma = std::make_unique<RooRealVar>("sigma", "width of gaussian", 1, 0.1, 10);
 
       // Build gaussian p.d.f in terms of x,mean and sigma
       _pdf = std::make_unique<RooGaussian>("gauss", "gaussian PDF", *x, *mean, *sigma);
 
 
-      _variables.addOwned(*x);
+      _variables.addOwned(std::move(x));
 
-      for (auto par : {mean, sigma}) {
-        _parameters.addOwned(*par);
-      }
+      _parameters.addOwned(std::move(mean));
+      _parameters.addOwned(std::move(sigma));
 
       _multiProcess = 4;
   }
@@ -95,22 +93,20 @@ class TestGaussInMeanAndX : public PDFTest
       PDFTest("Gauss(x, mean)")
   {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
-      auto x = new RooRealVar("x", "x", -10, 10);
-      auto mean = new RooRealVar("mean", "mean of gaussian", 1, -10, 10);
-      auto sigma = new RooRealVar("sigma", "width of gaussian", 1, 0.1, 10);
+      auto x = std::make_unique<RooRealVar>("x", "x", -10, 10);
+      auto mean = std::make_unique<RooRealVar>("mean", "mean of gaussian", 1, -10, 10);
+      auto sigma = std::make_unique<RooRealVar>("sigma", "width of gaussian", 1, 0.1, 10);
 
       // Build gaussian p.d.f in terms of x,mean and sigma
       _pdf = std::make_unique<RooGaussian>("gauss", "gaussian PDF", *x, *mean, *sigma);
 
 
-      for (auto var : {x, mean}) {
-        _variables.addOwned(*var);
 //        _variablesToPlot.add(var);
-      }
 
-      for (auto par : {sigma}) {
-        _parameters.addOwned(*par);
-      }
+      _variables.addOwned(std::move(x));
+      _variables.addOwned(std::move(mean));
+
+      _parameters.addOwned(std::move(sigma));
   }
 };
 
@@ -129,27 +125,24 @@ class TestGaussWithFormulaParameters : public PDFTest
       PDFTest("Gauss(x, mean)", 50000)
   {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
-      auto x = new RooRealVar("x", "x", 0, 30);
-      auto a1 = new RooRealVar("a1", "First coefficient", 5, 0, 10);
-      auto a2 = new RooRealVar("a2", "Second coefficient", 1, 0, 10);
-      auto mean = new RooFormulaVar("mean", "mean", "a1+a2", RooArgList(*a1, *a2));
-      auto sigma = new RooFormulaVar("sigma", "sigma", "1.7*mean", RooArgList(*mean));
+      auto x = std::make_unique<RooRealVar>("x", "x", 0, 30);
+      auto a1 = std::make_unique<RooRealVar>("a1", "First coefficient", 5, 0, 10);
+      auto a2 = std::make_unique<RooRealVar>("a2", "Second coefficient", 1, 0, 10);
+      auto mean = std::make_unique<RooFormulaVar>("mean", "mean", "a1+a2", RooArgList(*a1, *a2));
+      auto sigma = std::make_unique<RooFormulaVar>("sigma", "sigma", "1.7*mean", RooArgList(*mean));
 
       // Build gaussian p.d.f in terms of x,mean and sigma
       _pdf = std::make_unique<RooGaussian>("gauss", "gaussian PDF", *x, *mean, *sigma);
 
-
-      for (auto var : {x, a1}) {
-        _variables.addOwned(*var);
 //        _variablesToPlot.add(*var);
-      }
 
-      for (auto par : {a2}) {
-        _parameters.addOwned(*par);
-      }
+      _variables.addOwned(std::move(x));
+      _variables.addOwned(std::move(a1));
 
-      _otherObjects.addOwned(*mean);
-      _otherObjects.addOwned(*sigma);
+      _parameters.addOwned(std::move(a2));
+
+      _otherObjects.addOwned(std::move(mean));
+      _otherObjects.addOwned(std::move(sigma));
 
       _toleranceCompareBatches = 2.E-14;
   }

--- a/root/roofitstats/vectorisedPDFs/testGaussBinned.cxx
+++ b/root/roofitstats/vectorisedPDFs/testGaussBinned.cxx
@@ -14,13 +14,14 @@
  * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
  *****************************************************************************/
 
-#include "RooRealVar.h"
-#include "RooDataHist.h"
-#include "RooGaussian.h"
-#include "RooHelpers.h"
-#include "RooRandom.h"
+#include <RooDataHist.h>
+#include <RooFitResult.h>
+#include <RooGaussian.h>
+#include <RooHelpers.h>
+#include <RooRandom.h>
+#include <RooRealVar.h>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <chrono>
 

--- a/root/roofitstats/vectorisedPDFs/testJohnson.cxx
+++ b/root/roofitstats/vectorisedPDFs/testJohnson.cxx
@@ -26,24 +26,25 @@ class TestJohnson : public PDFTest
     TestJohnson() :
       PDFTest("Johnson", 200000)
   {
-      auto mass = new RooRealVar("mass", "mass", 0., 0., 500.);
-      auto mu = new RooRealVar("mu", "Location parameter of normal distribution", 300., 0., 500.);
-      auto lambda = new RooRealVar ("lambda", "Two sigma of normal distribution", 100., 10, 200.);
-      auto gamma = new RooRealVar ("gamma", "gamma", 0.5, -10., 10.);
-      auto delta = new RooRealVar ("delta", "delta", 2., 1., 10.);
+      auto mass = std::make_unique<RooRealVar>("mass", "mass", 0., 0., 500.);
+      auto mu = std::make_unique<RooRealVar>("mu", "Location parameter of normal distribution", 300., 0., 500.);
+      auto lambda = std::make_unique<RooRealVar> ("lambda", "Two sigma of normal distribution", 100., 10, 200.);
+      auto gamma = std::make_unique<RooRealVar> ("gamma", "gamma", 0.5, -10., 10.);
+      auto delta = std::make_unique<RooRealVar> ("delta", "delta", 2., 1., 10.);
       // delta is highly correlated with lambda. This troubles the fit.
       delta->setConstant();
 
       _pdf = std::make_unique<RooJohnson>("johnson", "johnson", *mass, *mu, *lambda, *gamma, *delta, -1.E300);
 
 
-      _variables.addOwned(*mass);
+      _variables.addOwned(std::move(mass));
 
 //      _variablesToPlot.add(*mass);
 
-      for (auto par : {mu, lambda, gamma, delta}) {
-        _parameters.addOwned(*par);
-      }
+      _parameters.addOwned(std::move(mu));
+      _parameters.addOwned(std::move(lambda));
+      _parameters.addOwned(std::move(gamma));
+      _parameters.addOwned(std::move(delta));
 
       _toleranceCompareBatches = 6.E-12;
       _toleranceCompareLogs = 6.E-12;
@@ -69,23 +70,23 @@ class TestJohnsonInMassAndMu : public PDFTest
     TestJohnsonInMassAndMu() :
       PDFTest("Johnson in mass and mu", 200000)
   {
-      auto mass = new RooRealVar("mass", "mass", 0., -100., 500.);
-      auto mu = new RooRealVar("mu", "Location parameter of normal distribution", 100., 90., 110.);
-      auto lambda = new RooRealVar ("lambda", "Two sigma of normal distribution", 20., 10., 30.);
-      auto gamma = new RooRealVar ("gamma", "gamma", -0.7, -2., 2.);
-      auto delta = new RooRealVar ("delta", "delta", 1.337, 0.9, 2.);
+      auto mass = std::make_unique<RooRealVar>("mass", "mass", 0., -100., 500.);
+      auto mu = std::make_unique<RooRealVar>("mu", "Location parameter of normal distribution", 100., 90., 110.);
+      auto lambda = std::make_unique<RooRealVar> ("lambda", "Two sigma of normal distribution", 20., 10., 30.);
+      auto gamma = std::make_unique<RooRealVar> ("gamma", "gamma", -0.7, -2., 2.);
+      auto delta = std::make_unique<RooRealVar> ("delta", "delta", 1.337, 0.9, 2.);
 
       _pdf = std::make_unique<RooJohnson>("johnson", "johnson", *mass, *mu, *lambda, *gamma, *delta);
 
 
-      _variables.addOwned(*mass);
-      _variables.addOwned(*mu);
+      _variables.addOwned(std::move(mass));
+      _variables.addOwned(std::move(mu));
 
 //      _variablesToPlot.add(*mass);
 
-      for (auto par : {gamma, lambda, delta}) {
-        _parameters.addOwned(*par);
-      }
+      _parameters.addOwned(std::move(lambda));
+      _parameters.addOwned(std::move(gamma));
+      _parameters.addOwned(std::move(delta));
 
       _toleranceCompareBatches = 6.E-12;
       _toleranceCompareLogs = 6.E-12;
@@ -113,25 +114,23 @@ class TestJohnsonWithFormulaParameters : public PDFTest
       PDFTest("Johnson with formula", 100000)
   {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
-      auto mass = new RooRealVar("mass", "mass", 0., -500., 500.);
-      auto mu = new RooRealVar("mu", "Location parameter of normal distribution", -50, -150., 200.);
-      auto lambda = new RooRealVar ("lambda", "Two sigma of normal distribution", 120., 10, 180.);
-      auto gamma = new RooRealVar ("gamma", "gamma", -1.8, -10., 10.);
-      auto delta = new RooFormulaVar("delta", "delta", "1.337 + 0.1*gamma", RooArgList(*gamma));
+      auto mass = std::make_unique<RooRealVar>("mass", "mass", 0., -500., 500.);
+      auto mu = std::make_unique<RooRealVar>("mu", "Location parameter of normal distribution", -50, -150., 200.);
+      auto lambda = std::make_unique<RooRealVar> ("lambda", "Two sigma of normal distribution", 120., 10, 180.);
+      auto gamma = std::make_unique<RooRealVar> ("gamma", "gamma", -1.8, -10., 10.);
+      auto delta = std::make_unique<RooFormulaVar>("delta", "delta", "1.337 + 0.1*gamma", RooArgList(*gamma));
 
       _pdf = std::make_unique<RooJohnson>("johnson", "johnson", *mass, *mu, *lambda, *gamma, *delta, -1.E300);
 
 //      _variablesToPlot.add(*mass);
 
-      for (auto var : {mass}) {
-        _variables.addOwned(*var);
-      }
+      _variables.addOwned(std::move(mass));
 
-      for (auto par : {mu, lambda, gamma}) {
-        _parameters.addOwned(*par);
-      }
+      _parameters.addOwned(std::move(mu));
+      _parameters.addOwned(std::move(lambda));
+      _parameters.addOwned(std::move(gamma));
 
-      _otherObjects.addOwned(*delta);
+      _otherObjects.addOwned(std::move(delta));
 
       _toleranceCompareBatches = 6.E-12;
       _toleranceCompareLogs = 6.E-12;

--- a/root/roofitstats/vectorisedPDFs/testLandau.cxx
+++ b/root/roofitstats/vectorisedPDFs/testLandau.cxx
@@ -24,20 +24,19 @@ class TestLandauEvil: public PDFTest
       PDFTest("Landau_evil", 100000)
     {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
-        auto x = new RooRealVar("x", "x", -250, 3000);
-        auto mean = new RooRealVar("mean", "mean of landau", 10, -100, 300);
-        auto sigma = new RooRealVar("sigma", "width of landau", 100, 1, 300);
+        auto x = std::make_unique<RooRealVar>("x", "x", -250, 3000);
+        auto mean = std::make_unique<RooRealVar>("mean", "mean of landau", 10, -100, 300);
+        auto sigma = std::make_unique<RooRealVar>("sigma", "width of landau", 100, 1, 300);
 
         // Build landau p.d.f in terms of x, mean and sigma
         _pdf = std::make_unique<RooLandau>("landau", "landau PDF", *x, *mean, *sigma);
 
-      _variables.addOwned(*x);
+      _variables.addOwned(std::move(x));
 
       //_variablesToPlot.add(*x);
 
-      for (auto par : {mean, sigma}) {
-        _parameters.addOwned(*par);
-      }
+      _parameters.addOwned(std::move(mean));
+      _parameters.addOwned(std::move(sigma));
 
       _toleranceParameter = 8.E-6;
     }
@@ -58,20 +57,19 @@ class TestLandau: public PDFTest
       PDFTest("Landau_convenient", 100000)
     {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
-        auto x = new RooRealVar("x", "x", -3, 40);
-        auto mean = new RooRealVar("mean", "mean of landau", 1, -5, 10);
-        auto sigma = new RooRealVar("sigma", "width of landau", 3, 1, 6);
+        auto x = std::make_unique<RooRealVar>("x", "x", -3, 40);
+        auto mean = std::make_unique<RooRealVar>("mean", "mean of landau", 1, -5, 10);
+        auto sigma = std::make_unique<RooRealVar>("sigma", "width of landau", 3, 1, 6);
 
         // Build landau p.d.f in terms of x, mean and sigma
         _pdf = std::make_unique<RooLandau>("landau", "landau PDF", *x, *mean, *sigma);
 
-      _variables.addOwned(*x);
+      _variables.addOwned(std::move(x));
 
 //      _variablesToPlot.add(x);
 
-      for (auto par : {mean, sigma}) {
-        _parameters.addOwned(*par);
-      }
+      _parameters.addOwned(std::move(mean));
+      _parameters.addOwned(std::move(sigma));
 
       _toleranceParameter = 8.E-6;
     }

--- a/root/roofitstats/vectorisedPDFs/testLegendre.cxx
+++ b/root/roofitstats/vectorisedPDFs/testLegendre.cxx
@@ -25,20 +25,18 @@ class TestLegendre : public PDFTest
     TestLegendre() :
       PDFTest("Legendre", 100000)
   {
-    auto x = new RooRealVar("x", "x", 0.5, 0.1, 1.0);
+    auto x = std::make_unique<RooRealVar>("x", "x", 0.5, 0.1, 1.0);
     auto coef = new RooRealVar("coef", "coef", 0.5, 0.3, 1.0);
     auto coef2 = new RooRealVar("coef2", "coef2", 100, 80, 120);
     
     auto uniform = new RooUniform("uniform","uniform",*x);
     
     auto legendre = new RooLegendre("Legendre", "Legendre PDF", *x, 3, 2, 2, 1);
-    _pdf = std::make_unique<RooRealSumPdf>("Sum","sum",RooArgList(*legendre,*uniform),RooArgList(*coef,*coef2),true);
-    
-    for (auto var : {x}) {
-    _variables.addOwned(*var);      
-    }
+    _pdf = std::make_unique<RooRealSumPdf>("Sum","sum",RooArgList{*legendre,*uniform},RooArgList{*coef,*coef2},true);
     
     _variablesToPlot.add(*x);
+
+    _variables.addOwned(std::move(x));
   }
 };
 

--- a/root/roofitstats/vectorisedPDFs/testLognormal.cxx
+++ b/root/roofitstats/vectorisedPDFs/testLognormal.cxx
@@ -24,18 +24,17 @@ class TestLognormal : public PDFTest
     TestLognormal() :
       PDFTest("Lognormal", 100000)
   {
-        auto x = new RooRealVar("x", "x", 1, 0.1, 10);
-        auto m0 = new RooRealVar("m0", "m0", 5, 0.1, 10);
-        auto k = new RooRealVar("k", "k", 0.6, 0.1, 0.9);
+        auto x = std::make_unique<RooRealVar>("x", "x", 1, 0.1, 10);
+        auto m0 = std::make_unique<RooRealVar>("m0", "m0", 5, 0.1, 10);
+        auto k = std::make_unique<RooRealVar>("k", "k", 0.6, 0.1, 0.9);
 
         _pdf = std::make_unique<RooLognormal>("Lognormal", "Lognormal PDF", *x, *m0, *k);
 
 
-      _variables.addOwned(*x);
+      _variables.addOwned(std::move(x));
 
-      for (auto par : {m0, k}) {
-        _parameters.addOwned(*par);
-      }
+      _parameters.addOwned(std::move(m0));
+      _parameters.addOwned(std::move(k));
 
        //Standard of 1.E-14 is too strong.
       _toleranceCompareBatches = 8.E-14;
@@ -56,21 +55,18 @@ class TestLognormalInMeanAndX : public PDFTest
     TestLognormalInMeanAndX() :
       PDFTest("Lognormal(x, mean)", 100000)
   {
-        auto x = new RooRealVar("x", "x", 1, 0.1, 10);
-        auto m0 = new RooRealVar("m0", "m0", 1, 0.1, 10);
-        auto k = new RooRealVar("k", "k", 2, 1.1, 10);
+        auto x = std::make_unique<RooRealVar>("x", "x", 1, 0.1, 10);
+        auto m0 = std::make_unique<RooRealVar>("m0", "m0", 1, 0.1, 10);
+        auto k = std::make_unique<RooRealVar>("k", "k", 2, 1.1, 10);
 
         _pdf = std::make_unique<RooLognormal>("Lognormal", "Lognormal PDF", *x, *m0, *k);
 
-
-      for (auto var : {x, m0}) {
-        _variables.addOwned(*var);
-      }
       //_variablesToPlot.add(*x);
 
-      for (auto par : {k}) {
-        _parameters.addOwned(*par);
-      }
+      _variables.addOwned(std::move(x));
+      _variables.addOwned(std::move(m0));
+
+      _parameters.addOwned(std::move(k));
 
       // Standard of 1.E-14 is slightly too strong.
       _toleranceCompareBatches = 2.E-14;

--- a/root/roofitstats/vectorisedPDFs/testNestedPDFs.cxx
+++ b/root/roofitstats/vectorisedPDFs/testNestedPDFs.cxx
@@ -30,42 +30,44 @@ class TestNestedPDFs : public PDFTest
     TestNestedPDFs() :
       PDFTest("Gauss + RooRealSumPdf(pol2)", 50000)
   {
-      auto x = new RooRealVar("x", "x", -5., 5.);
+      auto x = std::make_unique<RooRealVar>("x", "x", -5., 5.);
 
       // Implement a polynomial. Value ranges are chosen to keep it positive.
       // Note that even though the parameters are constant for the fit, they are still
       // varied within their ranges when testing the function at random parameter points.
-      auto a0 = new RooRealVar("a0", "a0", 2., 3., 10.);
-      auto a1 = new RooRealVar("a1", "a1", -2, -2.1, -1.9);
-      auto a2 = new RooRealVar("a2", "a2", 1., 1., 5.);
+      auto a0 = std::make_unique<RooRealVar>("a0", "a0", 2., 3., 10.);
+      auto a1 = std::make_unique<RooRealVar>("a1", "a1", -2, -2.1, -1.9);
+      auto a2 = std::make_unique<RooRealVar>("a2", "a2", 1., 1., 5.);
       a0->setConstant(true);
       a1->setConstant(true);
       auto xId = new RooProduct("xId", "x", RooArgList(*x));
       auto xSq = new RooProduct("xSq", "x^2", RooArgList(*x, *x));
       auto one = new RooConstVar("one", "one", 1.);
-      auto pol = new RooRealSumPdf("pol", "pol", RooArgList(*one, *xId, *xSq), RooArgList(*a0, *a1, *a2));
+      auto pol = std::make_unique<RooRealSumPdf>("pol", "pol", RooArgList{*one, *xId, *xSq}, RooArgList{*a0, *a1, *a2});
 
-      auto mean = new RooRealVar("mean", "mean of gaussian", 2., 0., 20.);
-      auto sigma = new RooRealVar("sigma", "width of gaussian", 0.337, 0.1, 10);
+      auto mean = std::make_unique<RooRealVar>("mean", "mean of gaussian", 2., 0., 20.);
+      auto sigma = std::make_unique<RooRealVar>("sigma", "width of gaussian", 0.337, 0.1, 10);
       sigma->setConstant();
-      auto gauss = new RooGaussian("gauss", "gaussian PDF", *x, *mean, *sigma);
+      auto gauss = std::make_unique<RooGaussian>("gauss", "gaussian PDF", *x, *mean, *sigma);
 
-      auto nGauss = new RooRealVar("nGauss", "Fraction of Gauss component", 0.05, 0., 0.5);
+      auto nGauss = std::make_unique<RooRealVar>("nGauss", "Fraction of Gauss component", 0.05, 0., 0.5);
       _pdf = std::make_unique<RooAddPdf>("SumGausPol", "Sum of a Gauss and a simple polynomial",
-          RooArgSet(*gauss, *pol),
-          RooArgSet(*nGauss));
-
-      _variables.addOwned(*x);
+          RooArgSet{*gauss, *pol},
+          RooArgSet{*nGauss});
 
 //      _variablesToPlot.add(*x);
 
-      for (auto par : std::initializer_list<RooAbsArg*>{mean, sigma, a0, a1, a2, nGauss}) {
-        _parameters.addOwned(*par);
-      }
+      _variables.addOwned(std::move(x));
 
-      for (auto obj : std::initializer_list<RooAbsArg*>{gauss, pol}) {
-        _otherObjects.addOwned(*obj);
-      }
+      _parameters.addOwned(std::move(mean));
+      _parameters.addOwned(std::move(sigma));
+      _parameters.addOwned(std::move(a0));
+      _parameters.addOwned(std::move(a1));
+      _parameters.addOwned(std::move(a2));
+      _parameters.addOwned(std::move(nGauss));
+
+      _otherObjects.addOwned(std::move(gauss));
+      _otherObjects.addOwned(std::move(pol));
 
 //      RooMsgService::instance().getStream(0).minLevel = RooFit::DEBUG;
 

--- a/root/roofitstats/vectorisedPDFs/testNovosibirsk.cxx
+++ b/root/roofitstats/vectorisedPDFs/testNovosibirsk.cxx
@@ -24,24 +24,22 @@ class TestNovosibirsk : public PDFTest
     TestNovosibirsk() :
       PDFTest("Novosibirsk", 100000)
   {
-      auto x = new RooRealVar("x", "x", 0, -5, 1.1);
-      auto peak = new RooRealVar("peak", "peak", 0.5, 0, 1);
-      auto width = new RooRealVar("width", "width", 1.1, 0.5, 3.);
-      auto tail = new RooRealVar("tail", "tail", 1.0, 0.5, 1.1);
+      auto x = std::make_unique<RooRealVar>("x", "x", 0, -5, 1.1);
+      auto peak = std::make_unique<RooRealVar>("peak", "peak", 0.5, 0, 1);
+      auto width = std::make_unique<RooRealVar>("width", "width", 1.1, 0.5, 3.);
+      auto tail = std::make_unique<RooRealVar>("tail", "tail", 1.0, 0.5, 1.1);
 
       _pdf = std::make_unique<RooNovosibirsk>("Novosibirsk", "Novosibirsk", *x, *peak, *width, *tail);
-
-      for (auto var : {x}) {
-        _variables.addOwned(*var);
-      }
 
 //      for (auto var : {x}) {
 //        _variablesToPlot.add(*var);
 //      }
 
-      for (auto par : { peak, width, tail}) {
-        _parameters.addOwned(*par);
-      }
+      _variables.addOwned(std::move(x));
+
+      _parameters.addOwned(std::move(peak));
+      _parameters.addOwned(std::move(width));
+      _parameters.addOwned(std::move(tail));
 
       _toleranceParameter = 1e-4;
   }

--- a/root/roofitstats/vectorisedPDFs/testPoisson.cxx
+++ b/root/roofitstats/vectorisedPDFs/testPoisson.cxx
@@ -25,16 +25,13 @@ class TestPoisson : public PDFTest
     TestPoisson() :
       PDFTest("Poisson", 100000)
   {
-      auto x = new RooRealVar("x", "x", -10, 100);
-      auto mean = new RooRealVar("mean", "Mean of Poisson", 2., 0., 50);
+      auto x = std::make_unique<RooRealVar>("x", "x", -10, 100);
+      auto mean = std::make_unique<RooRealVar>("mean", "Mean of Poisson", 2., 0., 50);
       _pdf = std::make_unique<RooPoisson>("Pois", "Poisson PDF", *x, *mean);
 
-      _variables.addOwned(*x);
+      _variables.addOwned(std::move(x));
 
-      for (auto par : {mean}) {
-        _parameters.addOwned(*par);
-      }
-
+      _parameters.addOwned(std::move(mean));
   }
 };
 
@@ -48,16 +45,13 @@ class TestPoissonOddMean : public PDFTest
     TestPoissonOddMean() :
       PDFTest("PoissonOddMean", 100000)
   {
-      auto x = new RooRealVar("x", "x", -10, 50);
-      auto mean = new RooRealVar("mean", "Mean of Poisson", 7.5, 0., 50);
+      auto x = std::make_unique<RooRealVar>("x", "x", -10, 50);
+      auto mean = std::make_unique<RooRealVar>("mean", "Mean of Poisson", 7.5, 0., 50);
       _pdf = std::make_unique<RooPoisson>("Pois", "Poisson PDF", *x, *mean);
 
-      _variables.addOwned(*x);
+      _variables.addOwned(std::move(x));
 
-      for (auto par : {mean}) {
-        _parameters.addOwned(*par);
-      }
-
+      _parameters.addOwned(std::move(mean));
   }
 };
 
@@ -71,15 +65,13 @@ class TestPoissonOddMeanNoRounding : public PDFTest
     TestPoissonOddMeanNoRounding() :
       PDFTest("PoissonOddMeanNoRounding", 100000)
   {
-      auto x = new RooRealVar("x", "x", 0., 100);
-      auto mean = new RooRealVar("mean", "Mean of Poisson", 7.8529298854862928, 0., 10);
+      auto x = std::make_unique<RooRealVar>("x", "x", 0., 100);
+      auto mean = std::make_unique<RooRealVar>("mean", "Mean of Poisson", 7.8529298854862928, 0., 10);
       _pdf = std::make_unique<RooPoisson>("Pois", "Poisson PDF", *x, *mean, true);
 
-      _variables.addOwned(*x);
+      _variables.addOwned(std::move(x));
 
-      for (auto par : {mean}) {
-        _parameters.addOwned(*par);
-      }
+      _parameters.addOwned(std::move(mean));
 
       _toleranceParameter = 1.2E-5;
       // For i686, this needs to be a bit less strict:

--- a/root/roofitstats/vectorisedPDFs/testPolynomial.cxx
+++ b/root/roofitstats/vectorisedPDFs/testPolynomial.cxx
@@ -23,20 +23,19 @@ class TestPolynomial2 : public PDFTest
     TestPolynomial2() :
       PDFTest("Polynomial2", 100000)
   {
-        auto x = new RooRealVar("x", "x", -10, 10);
-        auto a1 = new RooRealVar("a1", "a1", 0.3, 0.01, 0.5);
-        auto a2 = new RooRealVar("a2", "a2", 0.2, 0.01, 0.5);
+        auto x = std::make_unique<RooRealVar>("x", "x", -10, 10);
+        auto a1 = std::make_unique<RooRealVar>("a1", "a1", 0.3, 0.01, 0.5);
+        auto a2 = std::make_unique<RooRealVar>("a2", "a2", 0.2, 0.01, 0.5);
 
-        _pdf = std::make_unique<RooPolynomial>("polynomial2", "polynomial PDF 2 coefficients", *x, RooArgSet(*a1,*a2));
+        _pdf = std::make_unique<RooPolynomial>("polynomial2", "polynomial PDF 2 coefficients", *x, RooArgSet{*a1, *a2});
 
-
-      _variables.addOwned(*x);
 
       //_variablesToPlot.add(*x);
 
-      for (auto par : {a1, a2}) {
-        _parameters.addOwned(*par);
-      }
+      _variables.addOwned(std::move(x));
+
+      _parameters.addOwned(std::move(a1));
+      _parameters.addOwned(std::move(a2));
   }
 };
 
@@ -53,28 +52,28 @@ class TestPolynomial5 : public PDFTest
     TestPolynomial5() :
       PDFTest("Polynomial5", 100000)
   {
-      auto x = new RooRealVar("x", "x", -150, 40);
+      auto x = std::make_unique<RooRealVar>("x", "x", -150, 40);
       auto a0 = new RooRealVar("a0", "a0", 1000.0);
       auto a1 = new RooRealVar("a1", "a1", 1.0, 0.0, 3.0);
-      auto a2 = new RooRealVar("a2", "a2", 10.0, 9.0, 12.0);
+      auto a2 = std::make_unique<RooRealVar>("a2", "a2", 10.0, 9.0, 12.0);
       auto a3 = new RooRealVar("a3", "a3", 0.09, 0.05, 0.1);
-      auto a4 = new RooRealVar("a4", "a4", 0.001, 0.0005, 0.002);
-      auto a5 = new RooRealVar("a5", "a5", 0.0000009, 0.0000005, 0.000005);
+      auto a4 = std::make_unique<RooRealVar>("a4", "a4", 0.001, 0.0005, 0.002);
+      auto a5 = std::make_unique<RooRealVar>("a5", "a5", 0.0000009, 0.0000005, 0.000005);
       a0->setConstant(true);
       a1->setConstant(true);
       a3->setConstant(true);
       a4->setConstant(true);
 
-      _pdf = std::make_unique<RooPolynomial>("polynomial5", "polynomial PDF 5 coefficients", *x, RooArgSet(*a0,*a1, *a2, *a3, *a4, *a5),0);
-
-      _variables.addOwned(*x);
+      _pdf = std::make_unique<RooPolynomial>("polynomial5", "polynomial PDF 5 coefficients", *x, RooArgSet{*a0,*a1, *a2, *a3, *a4, *a5},0);
 
 //      _variablesToPlot.add(*x);
 //      _printLevel = 2;
 
-      for (auto par : { a2, a4, a5}) {
-        _parameters.addOwned(*par);
-      }
+      _variables.addOwned(std::move(x));
+
+      _parameters.addOwned(std::move(a2));
+      _parameters.addOwned(std::move(a4));
+      _parameters.addOwned(std::move(a5));
 
       _toleranceParameter = 2.E-5;
   }

--- a/root/roofitstats/vectorisedPDFs/testProductPdf.cxx
+++ b/root/roofitstats/vectorisedPDFs/testProductPdf.cxx
@@ -25,29 +25,28 @@ class TestProdPdf : public PDFTest
     TestProdPdf() :
       PDFTest("Gauss(x) * Gauss(y)", 75000)
   {
-      auto x = new RooRealVar("x", "x", 1, -7, 7);
-      auto m1 = new RooRealVar("m1", "m1", -0.3 , -5., 5.);
-      auto s1 = new RooRealVar("s1", "s1", 1.5, 0.7, 5.);
-      auto y = new RooRealVar("y", "y", 1, -5., 5.);
-      auto m2 = new RooRealVar("m2", "m2", 0.4, -5., 5.);
-      auto s2 = new RooRealVar("s2", "s2", 2., 0.7, 10.);
+      auto x = std::make_unique<RooRealVar>("x", "x", 1, -7, 7);
+      auto m1 = std::make_unique<RooRealVar>("m1", "m1", -0.3 , -5., 5.);
+      auto s1 = std::make_unique<RooRealVar>("s1", "s1", 1.5, 0.7, 5.);
+      auto y = std::make_unique<RooRealVar>("y", "y", 1, -5., 5.);
+      auto m2 = std::make_unique<RooRealVar>("m2", "m2", 0.4, -5., 5.);
+      auto s2 = std::make_unique<RooRealVar>("s2", "s2", 2., 0.7, 10.);
 
       //Make a 2D PDF
-      auto g1 = new RooGaussian("gaus1", "gaus1", *x, *m1, *s1);
-      auto g2 = new RooGaussian("gaus2", "gaus2", *y, *m2, *s2);
+      auto g1 = std::make_unique<RooGaussian>("gaus1", "gaus1", *x, *m1, *s1);
+      auto g2 = std::make_unique<RooGaussian>("gaus2", "gaus2", *y, *m2, *s2);
       _pdf = std::make_unique<RooProdPdf>("prod", "prod", RooArgSet(*g1, *g2));
 
-      for (auto var : {x, y}) {
-        _variables.addOwned(*var);
-      }
+      _variables.addOwned(std::move(x));
+      _variables.addOwned(std::move(y));
 
-      for (auto par : {m1, s1, m2, s2}) {
-        _parameters.addOwned(*par);
-      }
+      _parameters.addOwned(std::move(m1));
+      _parameters.addOwned(std::move(s1));
+      _parameters.addOwned(std::move(m2));
+      _parameters.addOwned(std::move(s2));
 
-      for (auto obj : {g1, g2}) {
-        _otherObjects.addOwned(*obj);
-      }
+      _otherObjects.addOwned(std::move(g1));
+      _otherObjects.addOwned(std::move(g2));
 
 //      _variablesToPlot.add(*x);
 //      _variablesToPlot.add(*y);

--- a/root/roofitstats/vectorisedPDFs/testVoigtian.cxx
+++ b/root/roofitstats/vectorisedPDFs/testVoigtian.cxx
@@ -23,21 +23,21 @@ class TestVoigtian : public PDFTest
     TestVoigtian() :
       PDFTest("Voigtian", 100000)
   {
-        auto x = new RooRealVar("x", "x", 1, 0.1, 10);
-        auto mean = new RooRealVar("mean", "mean", 1, 0.1, 10);
-        auto width = new RooRealVar("width", "width", 0.8, 0.1, 0.9);
-        auto sigma = new RooRealVar("sigma", "sigma", 0.7, 0.1, 0.9);
+        auto x = std::make_unique<RooRealVar>("x", "x", 1, 0.1, 10);
+        auto mean = std::make_unique<RooRealVar>("mean", "mean", 1, 0.1, 10);
+        auto width = std::make_unique<RooRealVar>("width", "width", 0.8, 0.1, 0.9);
+        auto sigma = std::make_unique<RooRealVar>("sigma", "sigma", 0.7, 0.1, 0.9);
 
         _pdf = std::make_unique<RooVoigtian>("Voigtian", "Voigtian PDF", *x, *mean, *width, *sigma);
 
 
-      _variables.addOwned(*x);
-
 //      _variablesToPlot.add(*x);
 
-      for (auto par : {mean, width, sigma}) {
-        _parameters.addOwned(*par);
-      }
+      _variables.addOwned(std::move(x));
+
+      _parameters.addOwned(std::move(mean));
+      _parameters.addOwned(std::move(width));
+      _parameters.addOwned(std::move(sigma));
 
       _toleranceParameter = 2.E-5;
       _toleranceCorrelation = 4.E-4;
@@ -58,23 +58,20 @@ class TestVoigtianInXandMean : public PDFTest
     TestVoigtianInXandMean() :
       PDFTest("Voigtian(x,m)", 100000)
   {
-        auto x = new RooRealVar("x", "x", 1, 0.1, 10);
-        auto mean = new RooRealVar("mean", "mean", 1, 0.1, 10);
-        auto width = new RooRealVar("width", "width", 0.5, 0.1, 0.9);
-        auto sigma = new RooRealVar("sigma", "sigma", 0.5, 0.1, 0.9);
+        auto x = std::make_unique<RooRealVar>("x", "x", 1, 0.1, 10);
+        auto mean = std::make_unique<RooRealVar>("mean", "mean", 1, 0.1, 10);
+        auto width = std::make_unique<RooRealVar>("width", "width", 0.5, 0.1, 0.9);
+        auto sigma = std::make_unique<RooRealVar>("sigma", "sigma", 0.5, 0.1, 0.9);
 
         _pdf = std::make_unique<RooVoigtian>("Voigtian", "Voigtian PDF", *x, *mean, *width, *sigma);
 
-
-      for (auto var: {x,mean} ) {
-        _variables.addOwned(*var);
-      }
-
       //_variablesToPlot.add(*x);
 
-      for (auto par : {width, sigma}) {
-        _parameters.addOwned(*par);
-      }
+      _variables.addOwned(std::move(x));
+      _variables.addOwned(std::move(mean));
+
+      _parameters.addOwned(std::move(width));
+      _parameters.addOwned(std::move(sigma));
 
   }
 };


### PR DESCRIPTION
This good practice to have the memory management handled automatically.