### PR TITLE
Remove stray int in python/stl/PyROOT_stltests.py

### DIFF
--- a/python/stl/PyROOT_stltests.py
+++ b/python/stl/PyROOT_stltests.py
@@ -1,4 +1,4 @@
-1# File: roottest/python/stl/PyROOT_stltests.py
+# File: roottest/python/stl/PyROOT_stltests.py
 # Author: Wim Lavrijsen (LBNL, WLavrijsen@lbl.gov)
 # Created: 10/25/05
 # Last: 02/28/16


### PR DESCRIPTION
This should fix the test on fedora37 and fedora38, which complain
```
TypeError: argument of type 'int' is not iterable
```
after the recent upgrade to Python 3.11.3.