### PR TITLE
[ci] Fix specification of nbconvert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ jupyter
 pytest
 # nbconvert 7.3 has a bug that does not respect --output option
 # See https://github.com/jupyter/nbconvert/issues/1970
-nbconvert < 7.3 , >= 7.4
+nbconvert != 7.3.*
 
 # Needed by tutorials (run as part of roottest)
 pandas


### PR DESCRIPTION
Use the `!=` syntax to exclude the unwanted version of `nbconvert` in requirements.txt since there is no way to specify a logical OR operator in pip requirements.