### PR TITLE
Fix nbconvert version specifier in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ jupyter
 pytest
 # nbconvert 7.3 has a bug that does not respect --output option
 # See https://github.com/jupyter/nbconvert/issues/1970
-nbconvert < 7.3 , >= 7.4
+nbconvert != 7.3.*
 
 # Needed by tutorials (run as part of roottest)
 pandas


### PR DESCRIPTION
A comma is interpreted as a logical AND and naturally there exists no version that satisfies the requirement `< 7.3 , >= 7.4`. Change it to exclude `7.3.*`.