### PR TITLE
[skip-ci] Add test for enum with two autoload annotations [v6.28]

### DIFF
--- a/cling/dict/enum/CMakeLists.txt
+++ b/cling/dict/enum/CMakeLists.txt
@@ -1,0 +1,8 @@
+# List only header.h which transitively includes enum.h - this leads to two
+# __attribute__((annotate("$clingAutoload$...")))
+ROOTTEST_GENERATE_DICTIONARY(enumDict header.h LINKDEF LinkDef.h NO_CXXMODULE)
+
+ROOTTEST_ADD_TEST(exec
+    MACRO execEnumDict.C
+    DEPENDS ${GENERATE_DICTIONARY_TEST}
+)

--- a/cling/dict/enum/LinkDef.h
+++ b/cling/dict/enum/LinkDef.h
@@ -1,0 +1,1 @@
+#pragma link C++ class std::vector<Enum>+;

--- a/cling/dict/enum/enum.h
+++ b/cling/dict/enum/enum.h
@@ -1,0 +1,9 @@
+#ifndef ENUM_H
+#define ENUM_H
+
+enum Enum {
+  A = 1,
+  B = 2,
+};
+
+#endif

--- a/cling/dict/enum/execEnumDict.C
+++ b/cling/dict/enum/execEnumDict.C
@@ -1,0 +1,5 @@
+#include "enum.h"
+
+int execEnumDict() {
+  return gSystem->Load("enumDict");
+}

--- a/cling/dict/enum/header.h
+++ b/cling/dict/enum/header.h
@@ -1,0 +1,1 @@
+#include "enum.h"


### PR DESCRIPTION
This is a heavily reduced case that shows the problem originally reported in https://github.com/cms-sw/cmssw/issues/42234.

(cherry picked from commit 09f72c352068d7a2c2aad04a5ed8f4c9ad5b8e2c)