### PR TITLE
[DF] Update test with behaviour of new unified constructor

### DIFF
--- a/root/dataframe/test_readTotemNtuple.ref
+++ b/root/dataframe/test_readTotemNtuple.ref
@@ -1,8 +1,8 @@
 
-Foreach:
 Warning in <TClass::Init>: no dictionary for class RPRootDumpPatternInfo is available
 Warning in <TClass::Init>: no dictionary for class RPRootDumpTrackInfo is available
 Warning in <TClass::Init>: no dictionary for class RPRootDumpPattern is available
+Foreach:
 9.10796
 8.10288
 7.6934


### PR DESCRIPTION
With ROOT7 enabled, The RDataFrame constructor taking (std::string_view
treename, std::string_view filename) now opens the file to check whether
the dataset is a TTree or an RNTuple. The warnings about the missing
dictionaries will now happen at construction time.

Create a new .ref file and instruct cmake to use the right one depending
on the ROOT configuration.

Sibling PR of https://github.com/root-project/root/pull/13090