### PR TITLE
[Meta] Fix test on Windows by using the correct, platform independent way, of referring to the root command

### DIFF
--- a/root/meta/rootmap/duplicateWarning/CMakeLists.txt
+++ b/root/meta/rootmap/duplicateWarning/CMakeLists.txt
@@ -2,5 +2,5 @@ configure_file(rfile1.rootmap . COPYONLY)
 configure_file(rfile2.rootmap . COPYONLY)
 
 ROOTTEST_ADD_TEST(myclassduplicated
-                  COMMAND root -b -q -l
+                  COMMAND ${ROOT_root_CMD} -b -q -l
                   PASSREGEX  "Warning in <TInterpreter::ReadRootmapFile>: While processing ./rfile[12]\.rootmap, class myclassduplicated was found to be associated to libdup[12]\.so although it is already associated to libdup[12]\.so")


### PR DESCRIPTION
On this platform the copying of files does not work. For this reason, the test is disabled in order to keep the CI working in a healthy way.