### PR TITLE
[CMake][ 7978] Lump together tests and genereflex dicts generation with fixtures

### DIFF
--- a/cmake/modules/RoottestMacros.cmake
+++ b/cmake/modules/RoottestMacros.cmake
@@ -352,7 +352,11 @@ endmacro(ROOTTEST_GENERATE_DICTIONARY)
 #
 # macro ROOTTEST_GENERATE_REFLEX_DICTIONARY(<targetname> <dictionary>
 #                                              [SELECTION sel...]
-#                                              [headerfiles...]     )
+#                                              [headerfiles...]
+#                                              [LIBNAME lib...]
+#                                              [FIXTURES_SETUP ...] [FIXTURES_CLEANUP ...] [FIXTURES_REQUIRED ...]
+#                                              [LIBRARIES lib1 lib2 ...]
+#                                              [OPTIONS opt1 opt2 ...])
 #
 # This macro generates a reflexion dictionary and creates a shared library.
 # A test that performs the dictionary generation is created.  The target name of
@@ -361,7 +365,7 @@ endmacro(ROOTTEST_GENERATE_DICTIONARY)
 #
 #-------------------------------------------------------------------------------
 macro(ROOTTEST_GENERATE_REFLEX_DICTIONARY dictionary)
-  CMAKE_PARSE_ARGUMENTS(ARG "NO_ROOTMAP" "SELECTION;LIBNAME" "LIBRARIES;OPTIONS"  ${ARGN})
+  CMAKE_PARSE_ARGUMENTS(ARG "NO_ROOTMAP" "SELECTION;LIBNAME;FIXTURES_SETUP;FIXTURES_CLEANUP;FIXTURES_REQUIRED" "LIBRARIES;OPTIONS" ${ARGN})
 
   set(CMAKE_ROOTTEST_DICT ON)
 
@@ -425,6 +429,21 @@ macro(ROOTTEST_GENERATE_REFLEX_DICTIONARY dictionary)
   set_property(TEST ${GENERATE_REFLEX_TEST} PROPERTY ENVIRONMENT ${ROOTTEST_ENVIRONMENT})
   if(CMAKE_GENERATOR MATCHES Ninja)
     set_property(TEST ${GENERATE_REFLEX_TEST} PROPERTY RUN_SERIAL true)
+  endif()
+
+  if (ARG_FIXTURES_SETUP)
+    set_property(TEST ${GENERATE_REFLEX_TEST} PROPERTY
+      FIXTURES_SETUP ${ARG_FIXTURES_SETUP})
+  endif()
+
+  if (ARG_FIXTURES_CLEANUP)
+    set_property(TEST ${GENERATE_REFLEX_TEST} PROPERTY
+      FIXTURES_CLEANUP ${ARG_FIXTURES_CLEANUP})
+  endif()
+
+  if (ARG_FIXTURES_REQUIRED)
+    set_property(TEST ${GENERATE_REFLEX_TEST} PROPERTY
+      FIXTURES_REQUIRED ${ARG_FIXTURES_REQUIRED})
   endif()
 
   if(MSVC)

--- a/root/meta/ROOT-5694/CMakeLists.txt
+++ b/root/meta/ROOT-5694/CMakeLists.txt
@@ -1,13 +1,16 @@
 if(NOT MSVC OR win_broken_tests)
-    ROOTTEST_GENERATE_REFLEX_DICTIONARY(One One.h SELECTION One_selection.xml NO_ROOTMAP)
-    set(depends ${GENERATE_REFLEX_TEST})
+    ROOTTEST_GENERATE_REFLEX_DICTIONARY(One One.h
+                                        SELECTION One_selection.xml
+                                        NO_ROOTMAP
+                                        FIXTURES_SETUP execLoadLibs_fixture)
 
-    ROOTTEST_GENERATE_REFLEX_DICTIONARY(Two Two.h SELECTION Two_selection.xml NO_ROOTMAP)
-    set(depends ${depends} ${GENERATE_REFLEX_TEST})
-
+    ROOTTEST_GENERATE_REFLEX_DICTIONARY(Two Two.h
+                                        SELECTION Two_selection.xml
+                                        NO_ROOTMAP
+                                        FIXTURES_SETUP execLoadLibs_fixture)
     ROOTTEST_ADD_TEST(execLoadLibs
                       MACRO execLoadLibs.C
                       OUTREF execLoadLibs.oref
                       ERRREF execLoadLibs.eref
-                      DEPENDS ${depends})
+                      FIXTURES_REQUIRED execLoadLibs_fixture)
 endif()


### PR DESCRIPTION
This PR allows to group together tests and genreflex dictionary generation with fixtures. This new features allows to select group of tests with the "-R" comment of `ctest`.
This PR also fixes issue https://github.com/root-project/root/issues/7978.