### PR TITLE
[RF] Don't exclude vectorized pdf tests on Windows

### DIFF
--- a/root/roofitstats/CMakeLists.txt
+++ b/root/roofitstats/CMakeLists.txt
@@ -37,7 +37,5 @@ endif()
                  ${CMAKE_CURRENT_SOURCE_DIR}/data/test_workspace_01.root
                  )
 
-  if(NOT MSVC OR win_broken_tests)
-    add_subdirectory(vectorisedPDFs)
-  endif()
+  add_subdirectory(vectorisedPDFs)
 endif()

--- a/root/roofitstats/vectorisedPDFs/testAddPdf.cxx
+++ b/root/roofitstats/vectorisedPDFs/testAddPdf.cxx
@@ -139,7 +139,7 @@ FIT_TEST_BATCH(TestGaussPlusGaussPlusExp, DISABLED_Batch)   // Save time
 FIT_TEST_BATCH_VS_SCALAR(TestGaussPlusGaussPlusExp, CompareBatchScalar)
 
 
-
+#if !defined(_MSC_VER) // RooFit multiprocessing doesn't work on Windows
 
 class TestGaussPlusGaussPlusExp_MP : public TestGaussPlusGaussPlusExp {
 public:
@@ -157,3 +157,4 @@ FIT_TEST_SCALAR(TestGaussPlusGaussPlusExp_MP, DISABLED_Scalar) // Save time
 FIT_TEST_BATCH(TestGaussPlusGaussPlusExp_MP, DISABLED_Batch)   // Save time
 FIT_TEST_BATCH_VS_SCALAR(TestGaussPlusGaussPlusExp_MP, CompareBatchScalar)
 
+#endif // !defined(_MSC_VER)

--- a/root/roofitstats/vectorisedPDFs/testGauss.cxx
+++ b/root/roofitstats/vectorisedPDFs/testGauss.cxx
@@ -55,7 +55,7 @@ FIT_TEST_SCALAR(TestGauss, RunScalar)
 FIT_TEST_BATCH(TestGauss, RunBatch)
 FIT_TEST_BATCH_VS_SCALAR(TestGauss, CompareBatchScalar)
 
-
+#if !defined(_MSC_VER) // TODO: make TestGaussWeighted work on Windows
 
 class TestGaussWeighted : public PDFTestWeightedData
 {
@@ -84,6 +84,7 @@ class TestGaussWeighted : public PDFTestWeightedData
 FIT_TEST_BATCH(TestGaussWeighted, DISABLED_RunBatch) // Would need SumW2 or asymptotic error correction, but that's not in test macro.
 FIT_TEST_BATCH_VS_SCALAR(TestGaussWeighted, CompareBatchScalar)
 
+#endif // !defined(_MSC_VER)
 
 
 class TestGaussInMeanAndX : public PDFTest

--- a/root/roofitstats/vectorisedPDFs/testLandau.cxx
+++ b/root/roofitstats/vectorisedPDFs/testLandau.cxx
@@ -17,6 +17,8 @@
 #include "VectorisedPDFTests.h"
 #include "RooLandau.h"
 
+#if !defined(_MSC_VER) // TODO: make TestGaussWeighted work on Windows
+
 class TestLandauEvil: public PDFTest
 {
   protected:
@@ -49,6 +51,7 @@ FIT_TEST_SCALAR(TestLandauEvil, DISABLED_RunScalar) //numerical integral presuma
 FIT_TEST_BATCH(TestLandauEvil, DISABLED_RunBatch) //numerical integral presumably inaccurate
 FIT_TEST_BATCH_VS_SCALAR(TestLandauEvil, CompareBatchScalar)
 
+#endif // !defined(_MSC_VER)
 
 class TestLandau: public PDFTest
 {


### PR DESCRIPTION
There should be no reason anymore for these tests not running on Windows.