### PR TITLE
[windows] Fix warnings when compiling testinterface.cxx

### DIFF
--- a/root/meta/method/offset/testinterface.cpp
+++ b/root/meta/method/offset/testinterface.cpp
@@ -5,18 +5,18 @@
 ClassImp(TestInterface);
 
 void TestInterface::foo() const {
-   //printf("<TestInterface>Performing dynamic_cast of thisptr %lx to TObject inside TestInterface...\n", (Long_t) this);
+   //printf("<TestInterface>Performing dynamic_cast of thisptr %lx to TObject inside TestInterface...\n", (Longptr_t) this);
    //const TObject* obj = dynamic_cast<const TObject*>(this);
-   //printf("<TestInterface>Result is %lx\n", (Long_t) obj);
+   //printf("<TestInterface>Result is %lx\n", (Longptr_t) obj);
 
    TestObj checkObj;
    const TestInterface* checkObjAsTestIface = dynamic_cast<const TestInterface*>(&checkObj);
    const TObject* checkObjAsTObj = dynamic_cast<const TObject*>(&checkObj);
-   Long_t checkTheRealOffsetDiff = ((Long_t)checkObjAsTestIface) - ((Long_t)checkObjAsTObj);
+   Longptr_t checkTheRealOffsetDiff = ((Longptr_t)checkObjAsTestIface) - ((Longptr_t)checkObjAsTObj);
 
-   Long_t This = (Long_t)this;
+   Longptr_t This = (Longptr_t)this;
    const TObject* obj = dynamic_cast<const TObject*>(this);
-   Long_t tobj = (Long_t)obj;
+   Longptr_t tobj = (Longptr_t)obj;
    printf("<TestInterface>Performing dynamic_cast of thisptr to TObject inside TestInterface...\n");
    printf("<TestInterface>The difference is %s\n",
           This - tobj == checkTheRealOffsetDiff  ? "expected." : "UNEXPECTED!");


### PR DESCRIPTION
Use the proper `Longptr_t` instead of `Long_t` to cast pointers. This fixes the following warnings when compiling `testinterface.cxx` on Windows (x64):
```
  Processing C:/ROOT-CI/src/roottest/root/meta/method/offset/execmethodtest.cxx+...
  Info in <TWinNTSystem::ACLiC>: creating shared library C:/ROOT-CI/build/roottest/root/meta/method/offset/execmethodtest_cxx.dll
  In file included from input_line_9:9:
  In file included from C:/ROOT-CI/src/roottest/root/meta/method/offset/execmethodtest.cxx:3:
  C:/ROOT-CI/src/roottest/root/meta/method/offset/testinterface.cpp:15:37: warning: cast to smaller integer type 'long' from 'const TestInterface *' [-Wpointer-to-int-cast]
     Long_t checkTheRealOffsetDiff = ((Long_t)checkObjAsTestIface) - ((Long_t)checkObjAsTObj);
                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~
  C:/ROOT-CI/src/roottest/root/meta/method/offset/testinterface.cpp:15:69: warning: cast to smaller integer type 'long' from 'const TObject *' [-Wpointer-to-int-cast]
     Long_t checkTheRealOffsetDiff = ((Long_t)checkObjAsTestIface) - ((Long_t)checkObjAsTObj);
                                                                      ^~~~~~~~~~~~~~~~~~~~~~
  C:/ROOT-CI/src/roottest/root/meta/method/offset/testinterface.cpp:17:18: warning: cast to smaller integer type 'long' from 'const TestInterface *' [-Wpointer-to-int-cast]
     Long_t This = (Long_t)this;
                   ^~~~~~~~~~~~
  C:/ROOT-CI/src/roottest/root/meta/method/offset/testinterface.cpp:19:18: warning: cast to smaller integer type 'long' from 'const TObject *' [-Wpointer-to-int-cast]
     Long_t tobj = (Long_t)obj;
                   ^~~~~~~~~~~
  execmethodtest_cxx_ACLiC_dict.cxx
  C:\ROOT-CI\src\roottest\root\meta\method\offset\testinterface.cpp(15): warning C4311: 'type cast': pointer truncation from 'const TestInterface *' to 'Long_t'
  C:\ROOT-CI\src\roottest\root\meta\method\offset\testinterface.cpp(15): warning C4302: 'type cast': truncation from 'const TestInterface *' to 'Long_t'
  C:\ROOT-CI\src\roottest\root\meta\method\offset\testinterface.cpp(15): warning C4311: 'type cast': pointer truncation from 'const TObject *' to 'Long_t'
  C:\ROOT-CI\src\roottest\root\meta\method\offset\testinterface.cpp(15): warning C4302: 'type cast': truncation from 'const TObject *' to 'Long_t'
  C:\ROOT-CI\src\roottest\root\meta\method\offset\testinterface.cpp(17): warning C4311: 'type cast': pointer truncation from 'const TestInterface *' to 'Long_t'
  C:\ROOT-CI\src\roottest\root\meta\method\offset\testinterface.cpp(17): warning C4302: 'type cast': truncation from 'const TestInterface *' to 'Long_t'
  C:\ROOT-CI\src\roottest\root\meta\method\offset\testinterface.cpp(19): warning C4311: 'type cast': pointer truncation from 'const TObject *' to 'Long_t'
  C:\ROOT-CI\src\roottest\root\meta\method\offset\testinterface.cpp(19): warning C4302: 'type cast': truncation from 'const TObject *' to 'Long_t'
     Creating library C:/ROOT-CI/build/roottest/root/meta/method/offset\execmethodtest_cxx.lib and object C:/ROOT-CI/build/roottest/root/meta/method/offset\execmethodtest_cxx.exp
  execmethodtest_cxx_ACLiC_dict.cxx
  C:\ROOT-CI\src\roottest\root\meta\method\offset\testinterface.cpp(15): warning C4311: 'type cast': pointer truncation from 'const TestInterface *' to 'Long_t'
  C:\ROOT-CI\src\roottest\root\meta\method\offset\testinterface.cpp(15): warning C4302: 'type cast': truncation from 'const TestInterface *' to 'Long_t'
  C:\ROOT-CI\src\roottest\root\meta\method\offset\testinterface.cpp(15): warning C4311: 'type cast': pointer truncation from 'const TObject *' to 'Long_t'
  C:\ROOT-CI\src\roottest\root\meta\method\offset\testinterface.cpp(15): warning C4302: 'type cast': truncation from 'const TObject *' to 'Long_t'
  C:\ROOT-CI\src\roottest\root\meta\method\offset\testinterface.cpp(17): warning C4311: 'type cast': pointer truncation from 'const TestInterface *' to 'Long_t'
  C:\ROOT-CI\src\roottest\root\meta\method\offset\testinterface.cpp(17): warning C4302: 'type cast': truncation from 'const TestInterface *' to 'Long_t'
  C:\ROOT-CI\src\roottest\root\meta\method\offset\testinterface.cpp(19): warning C4311: 'type cast': pointer truncation from 'const TObject *' to 'Long_t'
  C:\ROOT-CI\src\roottest\root\meta\method\offset\testinterface.cpp(19): warning C4302: 'type cast': truncation from 'const TObject *' to 'Long_t'
     Creating library C:/ROOT-CI/build/roottest/root/meta/method/offset\execmethodtest_cxx.lib and object C:/ROOT-CI/build/roottest/root/meta/method/offset\execmethodtest_cxx.exp
```