### PR TITLE
[Dict] Test dict generation with rootcling+sel xml file

### DIFF
--- a/root/meta/rootcling/CMakeLists.txt
+++ b/root/meta/rootcling/CMakeLists.txt
@@ -1,5 +1,12 @@
 ROOTTEST_ADD_TESTDIRS()
 
+# issue #13543
+ROOTTEST_GENERATE_DICTIONARY(xmlusedByRootclingDict Classy.h LINKDEF xmlusedByRootcling_sel.xml)
+ROOTTEST_ADD_TEST(xmlusedByRootcling
+                  MACRO xmlusedByRootclingDict.C
+                  DEPENDS ${GENERATE_DICTIONARY_TEST})
+
+
 # ROOT-9335
 ROOTTEST_ADD_TEST(classDelCtor
                   MACRO classDelCtor.C+)
@@ -20,3 +27,4 @@ ROOTTEST_ADD_TEST(selectUnion
 # ROOT-10798
 ROOTTEST_ADD_TEST(ROOT10798
                   COMMAND ${ROOT_rootcling_CMD} -f ROOT10798Dict.cxx ${CMAKE_CURRENT_SOURCE_DIR}/ROOT10798LinkDef.h)
+

--- a/root/meta/rootcling/Classy.h
+++ b/root/meta/rootcling/Classy.h
@@ -1,0 +1,11 @@
+#ifndef CLASSY_H
+#define CLASSY_H
+namespace bug {
+  class Classy {
+  private:
+    int x_;
+    int y_;
+  };
+}
+#endif /* CLASSY_H */
+

--- a/root/meta/rootcling/xmlusedByRootclingDict.C
+++ b/root/meta/rootcling/xmlusedByRootclingDict.C
@@ -1,0 +1,29 @@
+int xmlusedByRootclingDict()
+{
+   gSystem->Load("xmlusedByRootclingDict");
+
+   const auto clName = "bug::Classy";
+   auto cl = TClass::GetClass(clName);
+   if (!cl) {
+      std::cerr << "Class " << std::quoted(clName) << " not found!" << std::endl;
+      return 1;
+   }
+   constexpr int classVersion = 42;
+   if (classVersion != cl->GetClassVersion()) {
+      std::cerr << "Class " << std::quoted(clName) << " version is " << cl->GetClassVersion() << " and should be 10!"
+                << std::endl;
+      return 2;
+   }
+   for (const auto dmName : {"x_", "y_"}) {
+      auto dm = cl->GetDataMember(dmName);
+      if (!dmName) {
+         std::cerr << "Data member " << std::quoted(dmName) << " not found!" << std::endl;
+         return 3;
+      }
+      if (dm->IsPersistent()) {
+         std::cerr << "Data member " << std::quoted(dmName) << " is persistent and should be transient!" << std::endl;
+         return 4;
+      }
+   }
+   return 0;
+}

--- a/root/meta/rootcling/xmlusedByRootcling_sel.xml
+++ b/root/meta/rootcling/xmlusedByRootcling_sel.xml
@@ -1,0 +1,7 @@
+<rootdict>
+  <class name="bug::Classy" ClassVersion="42">
+    <field name="x_" transient="true"/>
+    <field name="y_" transient="true"/>
+  </class>
+</rootdict>
+


### PR DESCRIPTION
This PR adds a test to the roottest battery which allows to test the correct generation of dictionaries through rootcling but using a selection xml file, which is the traditional selection file format of genreflex.
This work is triggered by this ROOT issue https://github.com/root-project/root/issues/13543 .
This PR is coupled with ROOT PR https://github.com/root-project/root/pull/13664