### PR TITLE
[RF] Adapt roottest to new `RooFit::EvalBackend()` command argument

### DIFF
--- a/root/roofitstats/vectorisedPDFs/VectorisedPDFTests.cxx
+++ b/root/roofitstats/vectorisedPDFs/VectorisedPDFTests.cxx
@@ -489,7 +489,7 @@ std::unique_ptr<RooFitResult> PDFTest::runBatchFit(RooAbsPdf* pdf) {
 
   MyTimer batchTimer("Fitting batch mode " + _name);
   std::unique_ptr<RooFitResult> result{pdf->fitTo(*_dataFit,
-      RooFit::BatchMode("cpu"),
+      RooFit::EvalBackend::Cpu(),
       RooFit::SumW2Error(false),
       RooFit::Optimize(1),
       RooFit::PrintLevel(_printLevel), RooFit::Save(),
@@ -536,7 +536,7 @@ std::unique_ptr<RooFitResult> PDFTest::runScalarFit(RooAbsPdf* pdf) {
 
   MyTimer singleTimer("Fitting scalar mode " + _name);
   std::unique_ptr<RooFitResult> result{pdf->fitTo(*_dataFit,
-      RooFit::BatchMode("off"),
+      RooFit::EvalBackend::Legacy(),
       RooFit::SumW2Error(false),
       RooFit::PrintLevel(_printLevel), RooFit::Save(),
       _multiProcess > 0 ? RooFit::NumCPU(_multiProcess) : RooCmdArg()


### PR DESCRIPTION
Sister PR of https://github.com/root-project/root/pull/12716.