### PR TITLE
[Cling] Fix CMS test relying on unary_function

### DIFF
--- a/boost/functional.hpp
+++ b/boost/functional.hpp
@@ -16,7 +16,7 @@
 #include <boost/call_traits.hpp>
 #include <functional>
 
-#if defined(_MSC_VER) && __cplusplus > 201402L
+#if __cplusplus > 201402L
 namespace std
 {
     // std::unary_function and std::binary_function were both removed

--- a/boost/functional.hpp
+++ b/boost/functional.hpp
@@ -16,7 +16,7 @@
 #include <boost/call_traits.hpp>
 #include <functional>
 
-#if __cplusplus > 201402L
+#if __cplusplus > 201402L && (defined(_MSC_VER) || defined(R__MACOSX))
 namespace std
 {
     // std::unary_function and std::binary_function were both removed

--- a/root/meta/naming/cmsExample01.h
+++ b/root/meta/naming/cmsExample01.h
@@ -11,6 +11,7 @@ namespace reco {
 #include <functional>
 #include <algorithm>
 
+#if __cplusplus > 201402L && (defined(_MSC_VER) || defined(R__MACOSX))
 namespace std {
    // std::unary_function and std::binary_function were both removed
    // in C++17.
@@ -28,6 +29,7 @@ namespace std {
       typedef Result result_type;
    };
 }
+#endif
 
 namespace edm {
    template<typename C, typename T, typename F> class RefVector;


### PR DESCRIPTION
which has been removed in c++17