### PR TITLE
Use non-deprecated (and now removed) version of failUnlessEqual:

### DIFF
--- a/python/basic/PyROOT_operatortests.py
+++ b/python/basic/PyROOT_operatortests.py
@@ -63,20 +63,20 @@ class Cpp1OperatorsTestCase( MyTestCase ):
       n -= Number(10)
       n *= Number(10)
       n /= Number(2)
-      self.failUnlessEqual( n, Number(100) )
+      self.assertEqual( n, Number(100) )
 
       nn = -n;
-      self.failUnlessEqual( nn, Number( -100 ) )
+      self.assertEqual( nn, Number( -100 ) )
 
    def test3ComparisonOperators( self ):
       """Test overloading of comparison operators"""
 
-      self.failUnlessEqual( Number(20) >  Number(10), 1 )
-      self.failUnlessEqual( Number(20) <  Number(10), 0 )
-      self.failUnlessEqual( Number(20) >= Number(20), 1 )
-      self.failUnlessEqual( Number(20) <= Number(10), 0 )
-      self.failUnlessEqual( Number(20) != Number(10), 1 )
-      self.failUnlessEqual( Number(20) == Number(10), 0 )
+      self.assertEqual( Number(20) >  Number(10), 1 )
+      self.assertEqual( Number(20) <  Number(10), 0 )
+      self.assertEqual( Number(20) >= Number(20), 1 )
+      self.assertEqual( Number(20) <= Number(10), 0 )
+      self.assertEqual( Number(20) != Number(10), 1 )
+      self.assertEqual( Number(20) == Number(10), 0 )
 
    def test4BooleanOperator( self ):
       """Test implementation of operator bool"""

--- a/python/numba/CMakeLists.txt
+++ b/python/numba/CMakeLists.txt
@@ -1,8 +1,10 @@
 if(ROOT_pyroot_FOUND)
-  if(NOT MSVC OR win_broken_tests)
-    ROOTTEST_ADD_TEST(numba
-                      MACRO PyROOT_numbatests.py
-                      ENVIRONMENT LEGACY_PYROOT=${legacy_pyroot})
-    file(COPY vec_lv.root DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+  if(NOT (DEFINED ENV{ROOTTEST_IGNORE_NUMBA_PY3} AND PYTHON_VERSION_MAJOR_Development_Main EQUAL 3))
+    if(NOT MSVC OR win_broken_tests)
+      ROOTTEST_ADD_TEST(numba
+                        MACRO PyROOT_numbatests.py
+                        ENVIRONMENT LEGACY_PYROOT=${legacy_pyroot})
+      file(COPY vec_lv.root DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+    endif()
   endif()
 endif()


### PR DESCRIPTION
See https://docs.python.org/2/library/unittest.html#deprecated-aliases