### PR TITLE
[rdf] Increase timeout of distributed test batteries

### DIFF
--- a/python/distrdf/common/CMakeLists.txt
+++ b/python/distrdf/common/CMakeLists.txt
@@ -28,6 +28,7 @@ if (ROOT_test_distrdf_pyspark_FOUND AND ROOT_test_distrdf_dask_FOUND)
     # tutorials of the root repository.
     ROOTTEST_ADD_TEST(test_all
                       MACRO test_all.py
+                      TIMEOUT 1200
                       ENVIRONMENT ${PYSPARK_ENV_VARS})
 
     # This test has to take multiple resource locks. This means that they should

--- a/python/distrdf/dask/CMakeLists.txt
+++ b/python/distrdf/dask/CMakeLists.txt
@@ -11,7 +11,7 @@ if (ROOT_test_distrdf_dask_FOUND)
     # repository.
     ROOTTEST_ADD_TEST(test_all
                       MACRO test_all.py
-                      TIMEOUT 420
+                      TIMEOUT 1200
                       PROPERTIES PROCESSORS 4 RESOURCE_LOCK dask_resource_lock)
 
 endif()

--- a/python/distrdf/spark/CMakeLists.txt
+++ b/python/distrdf/spark/CMakeLists.txt
@@ -27,7 +27,7 @@ if (ROOT_test_distrdf_pyspark_FOUND)
     ROOTTEST_ADD_TEST(test_all
                       MACRO test_all.py
                       ENVIRONMENT ${PYSPARK_ENV_VARS}
-                      TIMEOUT 420
+                      TIMEOUT 1200
                       PROPERTIES PROCESSORS 4 RESOURCE_LOCK spark_resource_lock)
 
 endif()


### PR DESCRIPTION
The distributed RDataFrame test batteries use pytest to run all the tests together as a single ctest test. This is crucial to ensure only one mock cluster connection is open for all the needed tests. Sometimes, these test batteries may take much longer than expected. For example, on older and less powerful machines such as the ones running MacOS 11, running one distributed test battery usually takes 3 minutes, while it may take up to 10 minutes in case the node is overbooked and different process happen at the same time. Thus, this commit increases the timeout threshold to 20 minutes, in line with some of the longest running tests in our CI suite. This should ensure that scenarios with a very slow machine but no real test failure still work.