### PR TITLE
Adapt to removal of internal `TStringView`

### DIFF
--- a/root/core/assertHumanReadable.cxx
+++ b/root/core/assertHumanReadable.cxx
@@ -46,11 +46,6 @@ int checkParsing(std::string_view input, Long64_t expected)
    }
 }
 
-int checkParsing(ROOT::Internal::TStringView input, Long64_t expected)
-{
-   return checkParsing(std::string_view(input),expected);
-}
-
 int checkParsingSet(const char *unit, Long64_t exp)
 {
    TString value;


### PR DESCRIPTION
Sister PR of https://github.com/root-project/root/pull/13993.