### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,28 +5,29 @@ CTest. These tests are executed as part of ROOT's Continuous Integration setup.
 
 ## Run tests locally
 
-
 ### Configuration and Build
 
 There are two ways to generate and execute the tests:
 
 #### Option 1: roottest as part of a ROOT build
 
-Before building, enable the 'testing' and 'roottest' option:
+Before building, create a build directory, change into it, enable the 'testing' and 'roottest' option:
 
-       cmake -Dtesting=ON -Droottest=ON $PATH_TO_ROOT_SOURCES
-       cmake --build . -j8
+   mkdir build
+   cd build
+   cmake -Dtesting=ON -Droottest=ON $PATH_TO_ROOT_SOURCES
+   cmake --build . -j8
 
 #### Option 2: roottest as a stand-alone project
 
 Set the ROOT environment to an existing build / installation:
 
-       . ${ROOTSYS}/thisroot.[c]sh
+   . ${ROOTSYS}/thisroot.[c]sh
 
 Create a build directory, change into it and execute
 
-       cmake $PATH_TO_ROOTTEST
-       cmake --build . -j8
+   cmake $PATH_TO_ROOTTEST
+   cmake --build . -j8
 
 ### Running the test suite
 
@@ -91,7 +92,7 @@ Options:
                         like resolving the full path of the macro is done).
 
     EXEC                Execute program in $PATH or current directory.
-    
+
     COMMAND             Execute a command (program or script) with its arguments
 
     MACROARG            Arguments that shall be passed to the specified
@@ -102,8 +103,8 @@ Options:
     OUTREF              File that references the stdout output of the test. If
                         the systems architecture influences the test output, a
                         *.ref32 / *.ref64 file can be created. They will be
-                        preferred to a *.ref file.  
-                        
+                        preferred to a *.ref file.
+
     ERRREF              File that references the stderr output of the test.
                         For system architecture specific output, see option
                         OUTREF.
@@ -113,20 +114,20 @@ Options:
 
     COPY_TO_BUILDDIR    Copy files into the current build directory, so tests
                         find them without the need for full paths.
-    
+
     PRECMD              Command to be executed before the macro or the executable.
                         Only the return code is checked. If error code is returned
                         the overall test fails.
-                        
+
     POSTCMD             Command to be executed after the macro or the executable.
                         Only the return code is checked.
-                        
+
     OUTCNVCMD           Possibility to process the output before is given to the
                         diff utility to check it against the reference file.
-                        
+
     PASSREGEX           Property to verify that the output of the test contains
                         certain strings (regular expression) to pass
-                        
+
     FAILREGEX           Property to verify that the output of the test contains
                         certain strings (regular expression) to fail
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ CTest. These tests are executed as part of ROOT's Continuous Integration setup.
 
 ## Run tests locally
 
+
 ### Configuration and Build
 
 There are two ways to generate and execute the tests:

--- a/README.md
+++ b/README.md
@@ -14,21 +14,21 @@ There are two ways to generate and execute the tests:
 
 Before building, create a build directory, change into it, enable the 'testing' and 'roottest' option:
 
-   mkdir build
-   cd build
-   cmake -Dtesting=ON -Droottest=ON $PATH_TO_ROOT_SOURCES
-   cmake --build . -j8
+    mkdir build
+    cd build
+    cmake -Dtesting=ON -Droottest=ON $PATH_TO_ROOT_SOURCES
+    cmake --build . -j8
 
 #### Option 2: roottest as a stand-alone project
 
 Set the ROOT environment to an existing build / installation:
 
-   . ${ROOTSYS}/thisroot.[c]sh
+    . ${ROOTSYS}/thisroot.[c]sh
 
 Create a build directory, change into it and execute
 
-   cmake $PATH_TO_ROOTTEST
-   cmake --build . -j8
+    cmake $PATH_TO_ROOTTEST
+    cmake --build . -j8
 
 ### Running the test suite
 
@@ -42,8 +42,11 @@ Tests can then be executed using the ctest command in the build directory:
     ctest -L regex          (run all tests that contain the label regex)
     ctest --print-labels    (list all existing labels)
 
-You can combine most of the ctest options, e.g. ctest -V -j4 -R root-meta is a
-valid call.
+You can combine most of the ctest options, for example:
+
+    ctest -V -j4 -R root-meta 
+
+is a valid call.
 
 
 ## Adding tests


### PR DESCRIPTION
I made minor edits to the README.md file. Some of the code blocks had too many spaces in the indentations, so unnecessary spaces would get copied with the commands. For option 1, I added commands for creating a build directory and changing into it, in order for the readme to be in line with ROOT's official website (please, see https://root.cern/for_developers/run_the_tests/).