### PR TITLE
Update reference public members of TH1

### DIFF
--- a/root/meta/MemberComments.ref
+++ b/root/meta/MemberComments.ref
@@ -14,6 +14,12 @@ OBJ: TViewPubDataMembers	TViewPubDataMembers	 : 0
  OBJ: TDataMember	kIgnore	 : 0
  OBJ: TDataMember	kConsider	 : 0
  OBJ: TDataMember	kNeutral	 : 0
+ OBJ: TDataMember	kFullyConsistent	 : 0
+ OBJ: TDataMember	kDifferentLabels	 : 0
+ OBJ: TDataMember	kDifferentBinLimits	 : 0
+ OBJ: TDataMember	kDifferentAxisLimits	 : 0
+ OBJ: TDataMember	kDifferentNumberOfBins	 : 0
+ OBJ: TDataMember	kDifferentDimensions	 : 0
  OBJ: TDataMember	kNoStats	 : 0
  OBJ: TDataMember	kUserContour	 : 0
  OBJ: TDataMember	kLogX	 : 0

--- a/root/meta/MemberComments_win32.ref
+++ b/root/meta/MemberComments_win32.ref
@@ -14,6 +14,12 @@ OBJ: TViewPubDataMembers	TViewPubDataMembers	 : 0
  OBJ: TDataMember	kIgnore	 : 0
  OBJ: TDataMember	kConsider	 : 0
  OBJ: TDataMember	kNeutral	 : 0
+ OBJ: TDataMember	kFullyConsistent	 : 0
+ OBJ: TDataMember	kDifferentLabels	 : 0
+ OBJ: TDataMember	kDifferentBinLimits	 : 0
+ OBJ: TDataMember	kDifferentAxisLimits	 : 0
+ OBJ: TDataMember	kDifferentNumberOfBins	 : 0
+ OBJ: TDataMember	kDifferentDimensions	 : 0
  OBJ: TDataMember	kNoStats	 : 0
  OBJ: TDataMember	kUserContour	 : 0
  OBJ: TDataMember	kLogX	 : 0

--- a/root/meta/MemberComments_win64.ref
+++ b/root/meta/MemberComments_win64.ref
@@ -14,6 +14,12 @@ OBJ: TViewPubDataMembers	TViewPubDataMembers	 : 0
  OBJ: TDataMember	kIgnore	 : 0
  OBJ: TDataMember	kConsider	 : 0
  OBJ: TDataMember	kNeutral	 : 0
+ OBJ: TDataMember	kFullyConsistent	 : 0
+ OBJ: TDataMember	kDifferentLabels	 : 0
+ OBJ: TDataMember	kDifferentBinLimits	 : 0
+ OBJ: TDataMember	kDifferentAxisLimits	 : 0
+ OBJ: TDataMember	kDifferentNumberOfBins	 : 0
+ OBJ: TDataMember	kDifferentDimensions	 : 0
  OBJ: TDataMember	kNoStats	 : 0
  OBJ: TDataMember	kUserContour	 : 0
  OBJ: TDataMember	kLogX	 : 0


### PR DESCRIPTION
This PR updates the reference log for the [MemberComments](https://github.com/root-project/roottest/blob/master/root/meta/Makefile#L140-L141) test so that it reflects the changes proposed in https://github.com/root-project/root/pull/14077.
These changes include making public the enum `TH1::EInconsistencyBits`, and the addition of new public data members changes the output of [runMemberComments.C](https://github.com/root-project/roottest/blob/master/root/meta/runMemberComments.C#L34-L35), making the test fail.