### PR TITLE
[ci] Avoid nbconvert-7.14 for now

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ jupyter
 pytest
 # nbconvert 7.3 has a bug that does not respect --output option
 # See https://github.com/jupyter/nbconvert/issues/1970
-nbconvert != 7.3.*
+# nbconvert 7.14 produces different output than earlier versions
+nbconvert != 7.3.*, < 7.14
 
 # Needed by tutorials (run as part of roottest)
 pandas


### PR DESCRIPTION
Currently `roottest-python-JupyROOT-tpython_notebook` fails on most platforms with the following difference to the reference output:
```diff
--- tpython.ipynb
+++ tpython_out.ipynb
@@ -16,7 +16,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1\n"
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
```

The only exception is `alma8` which is stuck with `nbconvert-6.0.7` as newer versions require at least Python 3.7 or 3.8 in the most recent releases.