### PR TITLE
Update `tree-fastcloning-execCheckClusterRange` reference files

### DIFF
--- a/root/tree/fastcloning/references/execCheckClusterRange.ref32
+++ b/root/tree/fastcloning/references/execCheckClusterRange.ref32
@@ -142,7 +142,7 @@ Cluster #47 starts at 1740 and ends at 1769
 Cluster #48 starts at 1770 and ends at 1799
 ******************************************************************************
 *Tree    :t1        :                                                        *
-*Entries :     1800 : Total =           29346 bytes  File  Size =      17989 *
+*Entries :     1800 : Total =           29346 bytes  File  Size =      17985 *
 *        :          : Tree compression factor =   1.59                       *
 ******************************************************************************
 Cluster Range #  Entry Start      Last Entry           Size   Number of clusters
@@ -222,7 +222,7 @@ Cluster #67 starts at 2340 and ends at 2369
 Cluster #68 starts at 2370 and ends at 2399
 ******************************************************************************
 *Tree    :t1        :                                                        *
-*Entries :     2400 : Total =           33566 bytes  File  Size =      20848 *
+*Entries :     2400 : Total =           33566 bytes  File  Size =      20843 *
 *        :          : Tree compression factor =   1.56                       *
 ******************************************************************************
 Cluster Range #  Entry Start      Last Entry           Size   Number of clusters

--- a/root/tree/fastcloning/references/execCheckClusterRange_builtinzlib.ref
+++ b/root/tree/fastcloning/references/execCheckClusterRange_builtinzlib.ref
@@ -142,7 +142,7 @@ Cluster #47 starts at 1740 and ends at 1769
 Cluster #48 starts at 1770 and ends at 1799
 ******************************************************************************
 *Tree    :t1        :                                                        *
-*Entries :     1800 : Total =           29346 bytes  File  Size =      17979 *
+*Entries :     1800 : Total =           29346 bytes  File  Size =      17978 *
 *        :          : Tree compression factor =   1.59                       *
 ******************************************************************************
 Cluster Range #  Entry Start      Last Entry           Size   Number of clusters
@@ -222,7 +222,7 @@ Cluster #67 starts at 2340 and ends at 2369
 Cluster #68 starts at 2370 and ends at 2399
 ******************************************************************************
 *Tree    :t1        :                                                        *
-*Entries :     2400 : Total =           33566 bytes  File  Size =      20849 *
+*Entries :     2400 : Total =           33566 bytes  File  Size =      20852 *
 *        :          : Tree compression factor =   1.56                       *
 ******************************************************************************
 Cluster Range #  Entry Start      Last Entry           Size   Number of clusters

--- a/root/tree/fastcloning/references/execCheckClusterRange_zlib.ref
+++ b/root/tree/fastcloning/references/execCheckClusterRange_zlib.ref
@@ -142,7 +142,7 @@ Cluster #47 starts at 1740 and ends at 1769
 Cluster #48 starts at 1770 and ends at 1799
 ******************************************************************************
 *Tree    :t1        :                                                        *
-*Entries :     1800 : Total =           29346 bytes  File  Size =      17984 *
+*Entries :     1800 : Total =           29346 bytes  File  Size =      17988 *
 *        :          : Tree compression factor =   1.59                       *
 ******************************************************************************
 Cluster Range #  Entry Start      Last Entry           Size   Number of clusters
@@ -222,7 +222,7 @@ Cluster #67 starts at 2340 and ends at 2369
 Cluster #68 starts at 2370 and ends at 2399
 ******************************************************************************
 *Tree    :t1        :                                                        *
-*Entries :     2400 : Total =           33566 bytes  File  Size =      20847 *
+*Entries :     2400 : Total =           33566 bytes  File  Size =      20841 *
 *        :          : Tree compression factor =   1.56                       *
 ******************************************************************************
 Cluster Range #  Entry Start      Last Entry           Size   Number of clusters


### PR DESCRIPTION
In `root-project/root`, we are changing some of the TLeaf data member doc strings.

These class comments are part of the TStreamerInfo, which can affect compressed size as explaine by Philippe Canal in this comment: https://github.com/root-project/root/pull/14268#issuecomment-1865251700

Sister PR of [#14268](https://github.com/root-project/root/pull/14268).