### PR TITLE
Remove traces of Proof

### DIFF
--- a/root/io/compression/MainEvent.cxx
+++ b/root/io/compression/MainEvent.cxx
@@ -83,7 +83,6 @@
 #include "TClonesArray.h"
 #include "TStopwatch.h"
 #include "TClass.h"
-#include "TProofServ.h"
 #include "Event.h"
 #include "TSocket.h"
 #include "TObjString.h"

--- a/root/tree/friend/testFriendsIndices.C
+++ b/root/tree/friend/testFriendsIndices.C
@@ -6,7 +6,6 @@
 #include <vector>
 #include "TFile.h"
 #include "TChain.h"
-#include "TDSet.h"
 #include "TError.h"
 
 const Int_t noChains = 2;


### PR DESCRIPTION
Since now the component is off by default.
Moreover, Proof was not tested, only headers included and not used.