### PR TITLE
Import vdt target when necessary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,11 @@ if(ROOT_pyroot_FOUND)
   set(PYTESTS_WILLFAIL WILLFAIL)
 endif()
 
+#---Make sure the vdt target is imported when necessary
+if(ROOT_vdt_FOUND AND NOT TARGET VDT::VDT)
+  find_package(Vdt REQUIRED)
+endif()
+
 # Find OpenGL
 find_library(OPENGL_gl_LIBRARY NAMES GL)
 


### PR DESCRIPTION
https://github.com/root-project/root/pull/11844 has reworked the CMake machinery for finding/including vdt. When roottest is built on top of an external installation of ROOT, if the vdt package used to build ROOT with is not builtin, then the roottest build system is not able to find it. Use the same logic found in the ROOT build system to populate the vdt target for roottest as well.

Note that the scenario that triggered these changes was our nightly conda builds where roottest is built with an external ROOT installation which also takes vdt from the conda channel. https://lcgapp-services.cern.ch/root-jenkins/job/conda-nightlies/1507/console

```
[2024-02-04T03:25:38.391Z] CMake Error at /opt/conda/envs/test-root/cmake/ROOTConfig-targets.cmake:374 (set_target_properties):
[2024-02-04T03:25:38.391Z]   The link interface of target "ROOT::ROOTVecOps" contains:
[2024-02-04T03:25:38.391Z] 
[2024-02-04T03:25:38.391Z]     VDT::VDT
[2024-02-04T03:25:38.391Z] 
[2024-02-04T03:25:38.391Z]   but the target was not found.  Possible reasons include:
[2024-02-04T03:25:38.391Z] 
[2024-02-04T03:25:38.391Z]     * There is a typo in the target name.
[2024-02-04T03:25:38.391Z]     * A find_package call is missing for an IMPORTED target.
[2024-02-04T03:25:38.391Z]     * An ALIAS target is missing.
```