### PR TITLE
[PyROOT] Don't use the `TDirectory.__getattr__` pythonization

### DIFF
--- a/python/numba/PyROOT_numbatests.py
+++ b/python/numba/PyROOT_numbatests.py
@@ -61,7 +61,7 @@ class TestClasNumba:
         # Obtain a vector of ROOT::Math::LorentzVector from the sample
         # .root file
         myfile = ROOT.TFile.Open("vec_lv.root")
-        vec_lv = myfile.vecOfLV
+        vec_lv = myfile.Get("vecOfLV")
 
         def calc_pt(lv):
             return math.sqrt(lv.Px() ** 2 + lv.Py() ** 2)

--- a/python/pythonizations/PyROOT_pythonizationtest.py
+++ b/python/pythonizations/PyROOT_pythonizationtest.py
@@ -132,9 +132,10 @@ class TestClassROOT_PYTHONIZATIONS:
         del ws
 
         f = ROOT.TFile.Open("foo.root")
-        assert f.w.var("x").getVal() == 5
-        f.w.var("x").setVal(6)
-        assert f.w.var("x").getVal() == 6   # uncached would give 5
+        ws = f.Get("w")
+        assert ws.var("x").getVal() == 5
+        ws.var("x").setVal(6)
+        assert ws.var("x").getVal() == 6   # uncached would give 5
 
     def test03_th2(self):
         """GetBinErrorUp and GetBinErrorLow overloads obtained with using decls"""

--- a/python/regression/PyROOT_regressiontests.py
+++ b/python/regression/PyROOT_regressiontests.py
@@ -422,10 +422,8 @@ class Regression12WriteTGraph( MyTestCase ):
       ff = TFile( "test.root", "RECREATE" )
       ff.WriteObject( gr, "grname", "" )
       if not legacy_pyroot:
-         # In new PyROOT, use a nicer way to get objects in files:
-         # (1) getattr syntax
-         ff.grname
-         # (2) Get pythonisation
+         # In new PyROOT, use a nicer way to get objects in files,
+         # the TDirectory::Get() pythonisation:
          ff.Get("grname")
       else:
          gr2 = TGraph()

--- a/python/ttree/PyROOT_ttreetests.py
+++ b/python/ttree/PyROOT_ttreetests.py
@@ -215,12 +215,8 @@ class TTree1ReadWriteSimpleObjectsTestCase( MyTestCase ):
       myarray = f.Get( 'myarray' )
       self.assertTrue( isinstance( myarray, TArrayI ) )
 
-      if not legacy_pyroot:
+      if legacy_pyroot:
          # New PyROOT does not implement a pythonisation for GetObject.
-         # Just use the getattr syntax, which is much nicer
-         arr = f.myarray
-         self.assertTrue( isinstance( arr, TArrayI ) )
-      else:
          myarray = MakeNullPointer( TArrayI )
          f.GetObject( 'myarray', myarray )
 
@@ -241,7 +237,7 @@ class TTree1ReadWriteSimpleObjectsTestCase( MyTestCase ):
 
       f = TFile( self.fname )
 
-      t = f.Proto2Analyzed
+      t = f.Get("Proto2Analyzed")
       self.assertEqual( type(t), TTree )
       self.assertEqual( t.GetEntriesFast(), 1 )
 
@@ -349,7 +345,6 @@ class TFileGetNonTObject( MyTestCase ):
       self.assertEqual( f.GetKey( 'totalEvents' ).GetClassName(), 'TArrayI' )
       self.assertTrue( f.Get( 'totalEvents' ) )
       self.assertEqual( f.Get( 'totalEvents' ).GetSize(), 1 )
-      self.assertEqual( f.totalEvents.GetSize(),          1 )
 
       # the following used to crash
       self.assertTrue( not gDirectory.Get( "non_existent_stuff" ) )


### PR DESCRIPTION
This allows us to later deprecate it in the main ROOT repo without requiring another PR in roottest.

Also, explicit tests for the `TDirectory.__getattr__` are removed, because this is already covered by pythonization tests in the main repo:

  * https://github.com/root-project/root/blob/master/bindings/pyroot/pythonizations/test/tdirectory_attrsyntax.py

  * https://github.com/root-project/root/blob/master/bindings/pyroot/pythonizations/test/tdirectoryfile_attrsyntax_get.py