### PR TITLE
[v626][RF] Reduce number of events in the vectorised pdf tests

### DIFF
--- a/root/roofitstats/vectorisedPDFs/VectorisedPDFTests.cxx
+++ b/root/roofitstats/vectorisedPDFs/VectorisedPDFTests.cxx
@@ -369,18 +369,14 @@ void PDFTest::checkParameters() {
     auto postFit = static_cast<RooRealVar*>(param);
     auto preFit  = static_cast<RooRealVar*>(_origParameters.find(param->GetName()));
     ASSERT_NE(preFit, nullptr) << "for parameter '" << param->GetName() << '\'';
-    EXPECT_LE(fabs(postFit->getVal() - preFit->getVal()), 2.*postFit->getError())
-    << "[Within 2 std-dev: " << param->GetName()
-    << " (" << postFit->getVal() << " +- " << 2.*postFit->getError() << ")"
+    const double error3sigma = 3*postFit->getError();
+    EXPECT_LE(fabs(postFit->getVal() - preFit->getVal()), error3sigma)
+    << "[Within 3 std-dev: " << param->GetName()
+    << " (" << postFit->getVal() << " +- " << error3sigma << ")"
     << " == " << preFit->getVal() << "]";
 
-    EXPECT_LE(fabs(postFit->getVal() - preFit->getVal()), 1.5*postFit->getError())
-    << "[Within 1.5 std-dev: " << param->GetName()
-    << " (" << postFit->getVal() << " +- " << 1.5*postFit->getError() << ")"
-    << " == " << preFit->getVal() << "]";
-
-    EXPECT_NEAR(postFit->getVal(), preFit->getVal(), fabs(postFit->getVal())*5.E-2)
-    << "[Within 5% for parameter '" << param->GetName() << "']";
+    EXPECT_NEAR(postFit->getVal(), preFit->getVal(), fabs(postFit->getVal())*0.15)
+    << "[Within 15% for parameter '" << param->GetName() << "']";
 
   }
 

--- a/root/roofitstats/vectorisedPDFs/VectorisedPDFTests.h
+++ b/root/roofitstats/vectorisedPDFs/VectorisedPDFTests.h
@@ -28,7 +28,7 @@ class RooAbsPdf;
 class PDFTest : public ::testing::Test
 {
   protected:
-    PDFTest(std::string&& name, std::size_t nEvt = 100000);
+    PDFTest(std::string&& name, std::size_t nEvt = 10000);
 
     void SetUp() override;
 
@@ -82,7 +82,7 @@ class PDFTest : public ::testing::Test
 
 class PDFTestWeightedData : public PDFTest {
   protected:
-    PDFTestWeightedData(const char* name, std::size_t events = 100000) :
+    PDFTestWeightedData(const char* name, std::size_t events = 10000) :
       PDFTest(name, events) { }
 
     void makeFitData() override;

--- a/root/roofitstats/vectorisedPDFs/testAddPdf.cxx
+++ b/root/roofitstats/vectorisedPDFs/testAddPdf.cxx
@@ -25,7 +25,7 @@ class TestGaussPlusPoisson : public PDFTest
 {
   protected:
     TestGaussPlusPoisson() :
-      PDFTest("Gauss + Poisson", 100000)
+      PDFTest("Gauss + Poisson")
     {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
       auto x = new RooRealVar("x", "x", -1.5, 40.5);
@@ -78,7 +78,7 @@ class TestGaussPlusGaussPlusExp : public PDFTest
 {
   protected:
     TestGaussPlusGaussPlusExp() :
-      PDFTest("Gauss + Gauss + Exp", 100001)
+      PDFTest("Gauss + Gauss + Exp")
     {
       auto x = new RooRealVar("x", "x", 0., 100.);
 

--- a/root/roofitstats/vectorisedPDFs/testArgusBG.cxx
+++ b/root/roofitstats/vectorisedPDFs/testArgusBG.cxx
@@ -21,7 +21,7 @@ class TestArgus : public PDFTest
 {
   protected:
     TestArgus() :
-      PDFTest("Argus", 100000)
+      PDFTest("Argus")
   { 
       auto m = new RooRealVar("m", "m", 300.0, 1.0, 800.0);
       auto m0 = new RooRealVar("m0", "m0", 1100.0, 800.0, 1400.0);

--- a/root/roofitstats/vectorisedPDFs/testBernstein.cxx
+++ b/root/roofitstats/vectorisedPDFs/testBernstein.cxx
@@ -21,7 +21,7 @@ class TestBernstein2 : public PDFTest
 {
   protected:
     TestBernstein2() :
-      PDFTest("Bernstein2", 100000)
+      PDFTest("Bernstein2")
   {
         auto x = new RooRealVar("x", "x", -10, 10);
         auto a1 = new RooRealVar("a1", "a1", 1, 0.8, 1.2);
@@ -54,7 +54,7 @@ class TestBernstein5 : public PDFTest
 {
   protected:
     TestBernstein5() :
-      PDFTest("Bernstein5", 100000)
+      PDFTest("Bernstein5")
   {
         auto x = new RooRealVar("x", "x", -100, 50);
         auto a1 = new RooRealVar("a1", "a1", 0.8, 0.6, 1.2);

--- a/root/roofitstats/vectorisedPDFs/testBifurGauss.cxx
+++ b/root/roofitstats/vectorisedPDFs/testBifurGauss.cxx
@@ -22,7 +22,7 @@ class TestBifurGauss : public PDFTest
 {
   protected:
     TestBifurGauss() :
-      PDFTest("BifurGauss", 100000)
+      PDFTest("BifurGauss")
   { 
     auto x = new RooRealVar("x", "x", 300.0, 100.0, 800.0);
     auto mean = new RooRealVar("mean", "mean", 350.0, 250.0, 500.0);

--- a/root/roofitstats/vectorisedPDFs/testBreitWigner.cxx
+++ b/root/roofitstats/vectorisedPDFs/testBreitWigner.cxx
@@ -21,7 +21,7 @@ class TestBreitWigner : public PDFTest
 {
   protected:
     TestBreitWigner() :
-      PDFTest("BreitWigner", 100000)
+      PDFTest("BreitWigner")
   {
         auto x = new RooRealVar("x", "x", -10, 10);
         auto mean = new RooRealVar("mean", "mean", 1, -7, 7);

--- a/root/roofitstats/vectorisedPDFs/testBukin.cxx
+++ b/root/roofitstats/vectorisedPDFs/testBukin.cxx
@@ -23,7 +23,7 @@ class TestBukin : public PDFTest
 {
   protected:
     TestBukin() :
-      PDFTest("Bukin", 100000)
+      PDFTest("Bukin")
   { 
       auto x = new RooRealVar("x", "x", 0.6, -15., 10.);
       auto Xp = new RooRealVar("Xp", "Xp", 0.5, -3., 5.);

--- a/root/roofitstats/vectorisedPDFs/testCBShape.cxx
+++ b/root/roofitstats/vectorisedPDFs/testCBShape.cxx
@@ -21,7 +21,7 @@ class TestCBShape : public PDFTest
 {
   protected:
     TestCBShape() :
-      PDFTest("CBShape", 100000)
+      PDFTest("CBShape")
   {
         auto m = new RooRealVar("m", "m", -10, 10);
         auto m0 = new RooRealVar("m0", "m0", 1, -7, 7);

--- a/root/roofitstats/vectorisedPDFs/testChebychev.cxx
+++ b/root/roofitstats/vectorisedPDFs/testChebychev.cxx
@@ -22,7 +22,7 @@ class TestChebychev2 : public PDFTest
 {
   protected:
     TestChebychev2() :
-      PDFTest("Chebychev2", 100000)
+      PDFTest("Chebychev2")
   {
         auto x = new RooRealVar("x", "x", -10, 10);
         auto a1 = new RooRealVar("a1", "a1", 0.3, -0.5, 0.5);
@@ -52,7 +52,7 @@ class TestChebychev5 : public PDFTest
 {
   protected:
     TestChebychev5() :
-      PDFTest("Chebychev5", 50000)
+      PDFTest("Chebychev5")
   {
         auto x = new RooRealVar("x", "x", -10, 10);
         auto a1 = new RooRealVar("a1", "a1", 0.15, -0.3, 0.3);

--- a/root/roofitstats/vectorisedPDFs/testChiSquarePdf.cxx
+++ b/root/roofitstats/vectorisedPDFs/testChiSquarePdf.cxx
@@ -21,7 +21,7 @@ class TestChiSquarePdfinX: public PDFTest
 {
   protected:
     TestChiSquarePdfinX() :
-      PDFTest("ChiSquarePdf", 100000)
+      PDFTest("ChiSquarePdf")
     {
       auto x = new RooRealVar("x", "x", 0.1, 100);
       auto ndof = new RooRealVar("ndof", "ndof of chiSquarePdf", 2, 1, 5);

--- a/root/roofitstats/vectorisedPDFs/testCompatMode.cxx
+++ b/root/roofitstats/vectorisedPDFs/testCompatMode.cxx
@@ -185,7 +185,7 @@ class TestNonVecGauss : public PDFTest
 {
   protected:
     TestNonVecGauss() :
-      PDFTest("GaussNoBatches", 200000) {
+      PDFTest("GaussNoBatches") {
       auto x = new RooRealVar("x", "x", -10, 10);
       auto mean = new RooRealVar("mean", "mean of gaussian", 1, -10, 10);
       auto sigma = new RooRealVar("sigma", "width of gaussian", 1, 0.1, 10);

--- a/root/roofitstats/vectorisedPDFs/testDstD0BG.cxx
+++ b/root/roofitstats/vectorisedPDFs/testDstD0BG.cxx
@@ -22,7 +22,7 @@ class TestDstD0BG : public PDFTest
 {
   protected:
     TestDstD0BG() :
-      PDFTest("DstD0BG", 100000)
+      PDFTest("DstD0BG")
   { 
       auto m = new RooRealVar("m", "m", 2.0, 1.61, 3);
       auto m0 = new RooRealVar("m0", "m0", 1.6);

--- a/root/roofitstats/vectorisedPDFs/testExponential.cxx
+++ b/root/roofitstats/vectorisedPDFs/testExponential.cxx
@@ -25,7 +25,7 @@ class TestExponential : public PDFTest
 {
   protected:
     TestExponential() :
-      PDFTest("Exp(x, c1)", 100000)
+      PDFTest("Exp(x, c1)")
   {
       //Beyond ~19, the VDT polynomials break down when c1 is very negative
       auto x = new RooRealVar("x", "x", 0.001, 18.);

--- a/root/roofitstats/vectorisedPDFs/testGamma.cxx
+++ b/root/roofitstats/vectorisedPDFs/testGamma.cxx
@@ -22,7 +22,7 @@ class TestGamma : public PDFTest
 {
   protected:
     TestGamma() :
-      PDFTest("Gamma", 100000)
+      PDFTest("Gamma")
   {
     auto x = new RooRealVar("x", "x", 5, 4, 10);
     auto gamma = new RooRealVar("gamma", "N+1", 6, 4, 8);

--- a/root/roofitstats/vectorisedPDFs/testGauss.cxx
+++ b/root/roofitstats/vectorisedPDFs/testGauss.cxx
@@ -23,7 +23,7 @@ class TestGauss : public PDFTest
 {
   protected:
     TestGauss() :
-      PDFTest("Gauss", 200000)
+      PDFTest("Gauss")
   {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
         auto x = new RooRealVar("x", "x", -10, 10);
@@ -62,7 +62,7 @@ class TestGaussWeighted : public PDFTestWeightedData
 {
   protected:
     TestGaussWeighted() :
-      PDFTestWeightedData("GaussWithWeights", 100000)
+      PDFTestWeightedData("GaussWithWeights")
   {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
       auto x = new RooRealVar("x", "x", -10, 10);
@@ -126,7 +126,7 @@ class TestGaussWithFormulaParameters : public PDFTest
 {
   protected:
     TestGaussWithFormulaParameters() :
-      PDFTest("Gauss(x, mean)", 50000)
+      PDFTest("Gauss(x, mean)")
   {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
       auto x = new RooRealVar("x", "x", 0, 30);

--- a/root/roofitstats/vectorisedPDFs/testJohnson.cxx
+++ b/root/roofitstats/vectorisedPDFs/testJohnson.cxx
@@ -24,7 +24,7 @@ class TestJohnson : public PDFTest
 {
   protected:
     TestJohnson() :
-      PDFTest("Johnson", 200000)
+      PDFTest("Johnson")
   {
       auto mass = new RooRealVar("mass", "mass", 0., 0., 500.);
       auto mu = new RooRealVar("mu", "Location parameter of normal distribution", 300., 0., 500.);
@@ -67,7 +67,7 @@ class TestJohnsonInMassAndMu : public PDFTest
 {
   protected:
     TestJohnsonInMassAndMu() :
-      PDFTest("Johnson in mass and mu", 200000)
+      PDFTest("Johnson in mass and mu")
   {
       auto mass = new RooRealVar("mass", "mass", 0., -100., 500.);
       auto mu = new RooRealVar("mu", "Location parameter of normal distribution", 100., 90., 110.);
@@ -110,7 +110,7 @@ class TestJohnsonWithFormulaParameters : public PDFTest
 {
   protected:
     TestJohnsonWithFormulaParameters() :
-      PDFTest("Johnson with formula", 100000)
+      PDFTest("Johnson with formula")
   {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
       auto mass = new RooRealVar("mass", "mass", 0., -500., 500.);

--- a/root/roofitstats/vectorisedPDFs/testLandau.cxx
+++ b/root/roofitstats/vectorisedPDFs/testLandau.cxx
@@ -21,7 +21,7 @@ class TestLandauEvil: public PDFTest
 {
   protected:
     TestLandauEvil() :
-      PDFTest("Landau_evil", 100000)
+      PDFTest("Landau_evil")
     {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
         auto x = new RooRealVar("x", "x", -250, 3000);
@@ -55,7 +55,7 @@ class TestLandau: public PDFTest
 {
   protected:
     TestLandau() :
-      PDFTest("Landau_convenient", 100000)
+      PDFTest("Landau_convenient")
     {
       // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
         auto x = new RooRealVar("x", "x", -3, 40);

--- a/root/roofitstats/vectorisedPDFs/testLegendre.cxx
+++ b/root/roofitstats/vectorisedPDFs/testLegendre.cxx
@@ -23,7 +23,7 @@ class TestLegendre : public PDFTest
 {
   protected:
     TestLegendre() :
-      PDFTest("Legendre", 100000)
+      PDFTest("Legendre")
   {
     auto x = new RooRealVar("x", "x", 0.5, 0.1, 1.0);
     auto coef = new RooRealVar("coef", "coef", 0.5, 0.3, 1.0);

--- a/root/roofitstats/vectorisedPDFs/testLognormal.cxx
+++ b/root/roofitstats/vectorisedPDFs/testLognormal.cxx
@@ -22,7 +22,7 @@ class TestLognormal : public PDFTest
 {
   protected:
     TestLognormal() :
-      PDFTest("Lognormal", 100000)
+      PDFTest("Lognormal")
   {
         auto x = new RooRealVar("x", "x", 1, 0.1, 10);
         auto m0 = new RooRealVar("m0", "m0", 5, 0.1, 10);
@@ -54,7 +54,7 @@ class TestLognormalInMeanAndX : public PDFTest
 {
   protected:
     TestLognormalInMeanAndX() :
-      PDFTest("Lognormal(x, mean)", 100000)
+      PDFTest("Lognormal(x, mean)")
   {
         auto x = new RooRealVar("x", "x", 1, 0.1, 10);
         auto m0 = new RooRealVar("m0", "m0", 1, 0.1, 10);

--- a/root/roofitstats/vectorisedPDFs/testNestedPDFs.cxx
+++ b/root/roofitstats/vectorisedPDFs/testNestedPDFs.cxx
@@ -28,7 +28,7 @@ class TestNestedPDFs : public PDFTest
 {
   protected:
     TestNestedPDFs() :
-      PDFTest("Gauss + RooRealSumPdf(pol2)", 50000)
+      PDFTest("Gauss + RooRealSumPdf(pol2)")
   {
       auto x = new RooRealVar("x", "x", -5., 5.);
 

--- a/root/roofitstats/vectorisedPDFs/testNovosibirsk.cxx
+++ b/root/roofitstats/vectorisedPDFs/testNovosibirsk.cxx
@@ -22,7 +22,7 @@ class TestNovosibirsk : public PDFTest
 {
   protected:
     TestNovosibirsk() :
-      PDFTest("Novosibirsk", 100000)
+      PDFTest("Novosibirsk")
   {
       auto x = new RooRealVar("x", "x", 0, -5, 1.1);
       auto peak = new RooRealVar("peak", "peak", 0.5, 0, 1);

--- a/root/roofitstats/vectorisedPDFs/testPoisson.cxx
+++ b/root/roofitstats/vectorisedPDFs/testPoisson.cxx
@@ -23,7 +23,7 @@ class TestPoisson : public PDFTest
 {
   protected:
     TestPoisson() :
-      PDFTest("Poisson", 100000)
+      PDFTest("Poisson")
   {
       auto x = new RooRealVar("x", "x", -10, 100);
       auto mean = new RooRealVar("mean", "Mean of Poisson", 2., 0., 50);
@@ -46,7 +46,7 @@ class TestPoissonOddMean : public PDFTest
 {
   protected:
     TestPoissonOddMean() :
-      PDFTest("PoissonOddMean", 100000)
+      PDFTest("PoissonOddMean")
   {
       auto x = new RooRealVar("x", "x", -10, 50);
       auto mean = new RooRealVar("mean", "Mean of Poisson", 7.5, 0., 50);
@@ -69,7 +69,7 @@ class TestPoissonOddMeanNoRounding : public PDFTest
 {
   protected:
     TestPoissonOddMeanNoRounding() :
-      PDFTest("PoissonOddMeanNoRounding", 100000)
+      PDFTest("PoissonOddMeanNoRounding")
   {
       auto x = new RooRealVar("x", "x", 0., 100);
       auto mean = new RooRealVar("mean", "Mean of Poisson", 7.8529298854862928, 0., 10);

--- a/root/roofitstats/vectorisedPDFs/testPolynomial.cxx
+++ b/root/roofitstats/vectorisedPDFs/testPolynomial.cxx
@@ -21,7 +21,7 @@ class TestPolynomial2 : public PDFTest
 {
   protected:
     TestPolynomial2() :
-      PDFTest("Polynomial2", 100000)
+      PDFTest("Polynomial2")
   {
         auto x = new RooRealVar("x", "x", -10, 10);
         auto a1 = new RooRealVar("a1", "a1", 0.3, 0.01, 0.5);
@@ -51,7 +51,7 @@ class TestPolynomial5 : public PDFTest
 {
   protected:
     TestPolynomial5() :
-      PDFTest("Polynomial5", 100000)
+      PDFTest("Polynomial5")
   {
       auto x = new RooRealVar("x", "x", -150, 40);
       auto a0 = new RooRealVar("a0", "a0", 1000.0);

--- a/root/roofitstats/vectorisedPDFs/testProductPdf.cxx
+++ b/root/roofitstats/vectorisedPDFs/testProductPdf.cxx
@@ -23,7 +23,7 @@ class TestProdPdf : public PDFTest
 {
   protected:
     TestProdPdf() :
-      PDFTest("Gauss(x) * Gauss(y)", 75000)
+      PDFTest("Gauss(x) * Gauss(y)")
   {
       auto x = new RooRealVar("x", "x", 1, -7, 7);
       auto m1 = new RooRealVar("m1", "m1", -0.3 , -5., 5.);

--- a/root/roofitstats/vectorisedPDFs/testVoigtian.cxx
+++ b/root/roofitstats/vectorisedPDFs/testVoigtian.cxx
@@ -21,7 +21,7 @@ class TestVoigtian : public PDFTest
 {
   protected:
     TestVoigtian() :
-      PDFTest("Voigtian", 100000)
+      PDFTest("Voigtian")
   {
         auto x = new RooRealVar("x", "x", 1, 0.1, 10);
         auto mean = new RooRealVar("mean", "mean", 1, 0.1, 10);
@@ -56,7 +56,7 @@ class TestVoigtianInXandMean : public PDFTest
 {
   protected:
     TestVoigtianInXandMean() :
-      PDFTest("Voigtian(x,m)", 100000)
+      PDFTest("Voigtian(x,m)")
   {
         auto x = new RooRealVar("x", "x", 1, 0.1, 10);
         auto mean = new RooRealVar("mean", "mean", 1, 0.1, 10);


### PR DESCRIPTION
Reduce numer of events in the vectorised pdf tests, and accordingly increase the post-fit tolerance a bit, because the statistical fluctuations are higher.

This cuts down the total time of the tests on one CI node by about 14 minuits.

Furthermore, the vectorized evaluation is now validated so much - also in the full integration test `stressRooFit` - that these tests are mostly redundant.

Backport of: https://github.com/root-project/roottest/pull/1076