### PR TITLE
[windows] Add missing include

### DIFF
--- a/root/io/issue-7754/mwe/read_updated.cxx
+++ b/root/io/issue-7754/mwe/read_updated.cxx
@@ -1,5 +1,6 @@
 #include <TFile.h>
 #include <TTree.h>
+#include <TBranch.h>
 #include <iostream>
 #include <TSystem.h>
 


### PR DESCRIPTION
Fix the following error with `roottest-root-io-issue-7754-read_mwe_0` and `roottest-root-io-issue-7754-read_mwe_1` on Windows:
```
1702: Processing C:/root-dev/git/roottest/root/io/issue-7754/mwe/combined.cxx+(1)...
1702: Info in <TWinNTSystem::ACLiC>: creating shared library C:/root-dev/build/x64/debug/roottest/root/io/issue-7754/combined_cxx.dll
1702: In file included from input_line_9:6:
1702: In file included from C:/root-dev/git/roottest/root/io/issue-7754/mwe/combined.cxx:13:
1702: C:/root-dev/git/roottest/root/io/issue-7754/mwe/read_updated.cxx:27:5: error: member access into incomplete type 'TBranch'
1702:   br->GetEntry(0);
1702:     ^
1702: C:/root-dev/build/x64/debug/include/ROOT/TIOFeatures.hxx:17:7: note: forward declaration of 'TBranch'
1702: class TBranch;
1702:       ^
```