### PR TITLE
Don't use templated class in `test4ClassAndTypedefEquality`

### DIFF
--- a/python/basic/PyROOT_basictests.py
+++ b/python/basic/PyROOT_basictests.py
@@ -141,14 +141,14 @@ class Basic3PythonLanguageTestCase( MyTestCase ):
       gInterpreter.Declare( """namespace PyABC {
          struct SomeStruct {};
          struct SomeOtherStruct {
-            typedef std::vector<const PyABC::SomeStruct*> StructContainer;
+            typedef SomeStruct SomeStructAlias;
          };
       }""" )
 
-      import cppyy
-      PyABC = cppyy.gbl.PyABC
+      A = ROOT.PyABC.SomeStruct
+      B = ROOT.PyABC.SomeOtherStruct.SomeStructAlias
 
-      self.assertTrue( PyABC.SomeOtherStruct.StructContainer is cppyy.gbl.std.vector('const PyABC::SomeStruct*') )
+      self.assertTrue(B is A)
 
 
 ### basic C++ argument basic (value/ref and compiled/interpreted) ============


### PR DESCRIPTION
Template class instantiations are a bit fragile in PyROOT. At least the situation got better with ROOT 6.32. Buf for 6.30, we should not use templated classes to unit-test functionality that is not related to templates per se. In this concrete example, the
`test4ClassAndTypedefEquality` test was occasionally failing on some platforms (failures spotted on Fedora 38 and Ubuntu 23.10).

Also, using `cppyy` directly in only this test (instead of PyROOT) might have been a problem.