### PR TITLE
[CMake] Replace deprecated `FindPythonInterp` module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,8 @@ endif()
 
 find_package(ROOT REQUIRED CONFIG)
 
-if(NOT DEFINED PYTHON_EXECUTABLE)
-  find_package(PythonInterp ${ROOT_PYTHON_VERSION} REQUIRED QUIET)
+if(NOT DEFINED Python3_EXECUTABLE)
+  find_package(Python3 ${ROOT_PYTHON_VERSION} REQUIRED QUIET COMPONENTS Interpreter)
 endif()
 
 if(MSVC)
@@ -48,7 +48,7 @@ if(MSVC)
   if(NOT win_broken_tests)
     set(WILLFAIL_ON_WIN32 WILLFAIL)
   endif()
-  if (NOT PYTHON_EXECUTABLE)
+  if (NOT Python3_EXECUTABLE)
     find_package(PythonInterp)
   endif()
 
@@ -262,14 +262,14 @@ set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${ROOTTEST_DIR}/cmake/modules")
 
 # Find python.
 if(ROOT_pyroot_FOUND)
-  if (NOT PYTHON_EXECUTABLE)
+  if (NOT Python3_EXECUTABLE)
     find_package(PythonInterp)
     if(PYTHONINTERP_FOUND)
-      execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import sys;sys.stdout.write(sys.prefix)"
+      execute_process(COMMAND ${Python3_EXECUTABLE} -c "import sys;sys.stdout.write(sys.prefix)"
                        OUTPUT_VARIABLE PYTHON_PREFIX)
       set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${PYTHON_PREFIX})
     endif()
-    if (NOT PYTHON_LIBRARIES)
+    if (NOT Python3_LIBRARIES)
       find_package(PythonLibs)
     endif()
   endif()

--- a/cmake/modules/RoottestMacros.cmake
+++ b/cmake/modules/RoottestMacros.cmake
@@ -635,7 +635,7 @@ macro(ROOTTEST_SETUP_MACROTEST)
   # Add python script to CTest.
   elseif(ARG_MACRO MATCHES "[.]py")
     get_filename_component(realfp ${ARG_MACRO} REALPATH)
-    set(command ${PYTHON_EXECUTABLE} ${realfp} ${PYROOT_EXTRAFLAGS})
+    set(command ${Python3_EXECUTABLE} ${realfp} ${PYROOT_EXTRAFLAGS})
 
   elseif(DEFINED ARG_MACRO)
     set(command ${root_cmd} ${ARG_MACRO})
@@ -671,7 +671,7 @@ macro(ROOTTEST_SETUP_EXECTEST)
 
   if(MSVC)
     if(${realexec} MATCHES "[.]py" AND NOT ${realexec} MATCHES "[.]exe")
-      set(realexec ${PYTHON_EXECUTABLE} ${realexec})
+      set(realexec ${Python3_EXECUTABLE} ${realexec})
     else()
       set(realexec ${realexec})
     endif()
@@ -995,7 +995,7 @@ function(ROOTTEST_ADD_TEST testname)
                         ${outref}
                         ${errref}
                         WORKING_DIR ${test_working_dir}
-                        DIFFCMD ${PYTHON_EXECUTABLE} ${ROOTTEST_DIR}/scripts/custom_diff.py
+                        DIFFCMD ${Python3_EXECUTABLE} ${ROOTTEST_DIR}/scripts/custom_diff.py
                         TIMEOUT ${timeout}
                         ${environment}
                         ${build}
@@ -1211,7 +1211,7 @@ function(find_python_module module)
       endif()
       # A module's location is usually a directory, but for binary modules
       # it's a .so file.
-      execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
+      execute_process(COMMAND "${Python3_EXECUTABLE}" "-c"
          "import re, ${module}; print(re.compile('/__init__.py.*').sub('',${module}.__file__))"
          RESULT_VARIABLE _${module}_status
          OUTPUT_VARIABLE _${module}_location

--- a/python/JsMVA/CMakeLists.txt
+++ b/python/JsMVA/CMakeLists.txt
@@ -14,7 +14,7 @@
 #  foreach(NOTEBOOK ${NOTEBOOKS})
 #    get_filename_component(NOTEBOOKBASE ${NOTEBOOK} NAME_WE)
 #    ROOTTEST_ADD_TEST(${NOTEBOOKBASE}
-#                      COMMAND ${PYTHON_EXECUTABLE} ${NBDIFFUTIL} ${NOTEBOOK}
+#                      COMMAND ${Python3_EXECUTABLE} ${NBDIFFUTIL} ${NOTEBOOK}
 #                      RUN_SERIAL)
 #  endforeach()
 #endif()

--- a/python/JupyROOT/CMakeLists.txt
+++ b/python/JupyROOT/CMakeLists.txt
@@ -2,9 +2,7 @@
 if(NOT MSVC OR win_broken_tests)
 
 # Do not run with classic build or if tests are vetoed
-if (ROOT_pyroot_FOUND AND
-    NOT ROOT_CLASSIC_BUILD AND
-    NOT (DEFINED ENV{ROOTTEST_IGNORE_JUPYTER_PY3} AND PYTHON_VERSION_MAJOR EQUAL 3))
+if (ROOT_pyroot_FOUND AND NOT ROOT_CLASSIC_BUILD)
 
 set(MODULES_LOCATION ${ROOTSYS}/lib/JupyROOT/helpers)
 set(NBDIFFUTIL ${CMAKE_CURRENT_SOURCE_DIR}/nbdiff.py )
@@ -25,7 +23,7 @@ foreach(pyfile ${pyfiles})
   get_filename_component(SHORTPYFILE ${pyfile} NAME_WE)
   if (NOT ${SHORTPYFILE} STREQUAL "__init__")
     ROOTTEST_ADD_TEST(${SHORTPYFILE}_doctest
-                      COMMAND ${PYTHON_EXECUTABLE} ${DOCTEST_LAUNCHER} ${pyfile})
+                      COMMAND ${Python3_EXECUTABLE} ${DOCTEST_LAUNCHER} ${pyfile})
   endif()
 endforeach()
 
@@ -34,7 +32,7 @@ foreach(NOTEBOOK ${NOTEBOOKS})
   get_filename_component(NOTEBOOKBASE ${NOTEBOOK} NAME_WE)
   ROOTTEST_ADD_TEST(${NOTEBOOKBASE}_notebook
                     COPY_TO_BUILDDIR ${NOTEBOOK}
-                    COMMAND ${PYTHON_EXECUTABLE} ${NBDIFFUTIL} ${NOTEBOOK}
+                    COMMAND ${Python3_EXECUTABLE} ${NBDIFFUTIL} ${NOTEBOOK}
                     RUN_SERIAL)
 endforeach()
 
@@ -44,7 +42,7 @@ if(ROOT_imt_FOUND)
   get_filename_component(NOTEBOOKBASE ${IMT_NB} NAME_WE)
   ROOTTEST_ADD_TEST(${NOTEBOOKBASE}_notebook
                     COPY_TO_BUILDDIR ${IMT_NB}
-                    COMMAND ${PYTHON_EXECUTABLE} ${NBDIFFUTIL} ${IMT_NB} "OFF"
+                    COMMAND ${Python3_EXECUTABLE} ${NBDIFFUTIL} ${IMT_NB} "OFF"
                     RUN_SERIAL)
 endif()
 

--- a/python/cmdLineUtils/CMakeLists.txt
+++ b/python/cmdLineUtils/CMakeLists.txt
@@ -6,7 +6,7 @@ configure_file(multipleNameCycles.root . COPYONLY)
 configure_file(MakeNameCyclesRootmvInput.C . COPYONLY)
 
 ############################## PATTERN TESTS ############################
-set (TESTPATTERN_EXE ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/testPatternToFileNameAndPathSplitList.py)
+set (TESTPATTERN_EXE ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/testPatternToFileNameAndPathSplitList.py)
 ROOTTEST_ADD_TEST(SimplePattern1
                   COMMAND ${TESTPATTERN_EXE} test.root
                   OUTREF SimplePattern.ref)
@@ -23,7 +23,7 @@ ROOTTEST_ADD_TEST(SimplePattern3
 if(MSVC)
     # the command line tools works fine in the Windows command prompt but
     # not from CTest, so let's add Python.exe and the .py file extension
-    set(TOOLS_PREFIX ${PYTHON_EXECUTABLE} ${ROOTSYS}/bin)
+    set(TOOLS_PREFIX ${Python3_EXECUTABLE} ${ROOTSYS}/bin)
     set(pyext .py)
 else()
     set(TOOLS_PREFIX ${ROOTSYS}/bin)

--- a/python/distrdf/backends/CMakeLists.txt
+++ b/python/distrdf/backends/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 if(ROOT_test_distrdf_pyspark_FOUND)
 
     # Define environment variables needed in all pyspark tests
-    set(PYSPARK_ENV_VARS PYSPARK_PYTHON=${PYTHON_EXECUTABLE})
+    set(PYSPARK_ENV_VARS PYSPARK_PYTHON=${Python3_EXECUTABLE})
 
     if(MACOSX_VERSION VERSION_GREATER_EQUAL 10.13)
         # MacOS has changed rules about forking processes after 10.13

--- a/python/numba/CMakeLists.txt
+++ b/python/numba/CMakeLists.txt
@@ -1,10 +1,8 @@
 if(ROOT_pyroot_FOUND)
-  if(NOT (DEFINED ENV{ROOTTEST_IGNORE_NUMBA_PY3} AND PYTHON_VERSION_MAJOR EQUAL 3))
-    if(NOT MSVC OR win_broken_tests)
-      ROOTTEST_ADD_TEST(numba
-                        MACRO PyROOT_numbatests.py
-                        ENVIRONMENT LEGACY_PYROOT=${legacy_pyroot})
-      file(COPY vec_lv.root DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-    endif()
+  if(NOT MSVC OR win_broken_tests)
+    ROOTTEST_ADD_TEST(numba
+                      MACRO PyROOT_numbatests.py
+                      ENVIRONMENT LEGACY_PYROOT=${legacy_pyroot})
+    file(COPY vec_lv.root DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
   endif()
 endif()

--- a/root/meta/CMakeLists.txt
+++ b/root/meta/CMakeLists.txt
@@ -23,7 +23,7 @@ ROOTTEST_ADD_TEST(ROOT5268
                   PASSREGEX "error: unknown type name 'Tbrowser'")
 
 ROOTTEST_ADD_TEST(rlibmap
-                  COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/rlibmapLauncher.py
+                  COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/rlibmapLauncher.py
                   PASSRC 1
                   OUTREF  rlibmap.ref)
 

--- a/root/rint/CMakeLists.txt
+++ b/root/rint/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64.*|x86.*|amd64.*|AMD64.*|i686.*|i386.*")
   # All platforms except of ARM/AARCH64
   ROOTTEST_ADD_TEST(TabCom
-                    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/driveTabCom.py
+                    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/driveTabCom.py
                     INPUT TabCom_input.txt
                     OUTCNV filterOpt.sh
                     OUTREF TabCom.oref
@@ -9,7 +9,7 @@ if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64.*|x86.*|amd64.*|AMD64.*|i686.*|i386
                     COPY_TO_BUILDDIR MyClass.h)
 
   ROOTTEST_ADD_TEST(BackslashNewline
-                    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/driveTabCom.py
+                    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/driveTabCom.py
                     INPUT BackslashNewline_input.txt)
 endif()
 


### PR DESCRIPTION
See:
https://cmake.org/cmake/help/latest/module/FindPythonInterp.html

Sister PR of https://github.com/root-project/root/pull/15420.