### PR TITLE
execTEnumGetEnum now succeeds on Windows.

### DIFF
--- a/root/meta/enums/CMakeLists.txt
+++ b/root/meta/enums/CMakeLists.txt
@@ -34,7 +34,6 @@ ROOTTEST_GENERATE_REFLEX_DICTIONARY(tEnumGetEnumClasses
 ROOTTEST_ADD_TEST(execTEnumGetEnum
                   MACRO execTEnumGetEnum.C
                   OUTREF execTEnumGetEnum.ref
-                  ${WILLFAIL_ON_WIN32}
                   DEPENDS ${GENERATE_REFLEX_TEST})
 
 

--- a/root/meta/enums/CMakeLists.txt
+++ b/root/meta/enums/CMakeLists.txt
@@ -76,3 +76,7 @@ ROOTTEST_ADD_TEST(enumSize
                   MACRO execenumSize.C
                   OUTREF execenumSize.ref
                   DEPENDS ${GENERATE_DICTIONARY_TEST})
+
+ROOTTEST_ADD_TEST(testUsingEnum.cxx
+                  MACRO test_usingenum.cxx
+                  OUTREF test_usingenum.ref)

--- a/root/meta/enums/test_usingenum.cxx
+++ b/root/meta/enums/test_usingenum.cxx
@@ -1,0 +1,36 @@
+namespace A { enum E { kOne }; }
+namespace B { using A::E; }
+namespace C { using namespace A; }
+
+#include <iostream>
+
+int test_usingenum() {
+  auto e = TEnum::GetEnum("A::E");
+  if (!e) {
+    std::cerr << "Can not find A::E declaration\n";
+    return 1;
+  }
+  auto be = TEnum::GetEnum("B::E");
+  if (!be) {
+    std::cerr << "Can not find B::E\n";
+    return 2;
+  }
+  if (e != be) {
+    std::cerr << "The TEnum found for A::E and B::E is different\n";
+    return 3;
+  }
+#if CLING_FIXED_15407
+  // This is failing due to https://github.com/root-project/root/issues/15407
+  auto ce = TEnum::GetEnum("C::E");
+  if (!ce) {
+    std::cerr << "Can not find C::E\n";
+    return 4;
+     
+  }
+  if (e != ce) {
+    std::cerr << "The TEnum found for A::E and C::E is different\n";
+    return 5;
+  }
+#endif
+  return 0;
+};

--- a/root/meta/enums/test_usingenum.ref
+++ b/root/meta/enums/test_usingenum.ref
@@ -1,0 +1,3 @@
+
+Processing roottest/root/meta/enums/test_usingenum.cxx...
+(int) 0

--- a/root/multicore/exectsenums.C
+++ b/root/multicore/exectsenums.C
@@ -29,7 +29,10 @@ void exectsenums (){
    for (auto&& enName : enumNames){
       auto f = [&](){
          auto en = TEnum::GetEnum(enName);
-         names.addString(TEnum::GetEnum(enName)->GetQualifiedName());
+         if (en)
+            names.addString(TEnum::GetEnum(enName)->GetQualifiedName());
+         else
+            std::cerr << "Error: enum called " << enName << " was NOT found\n";
       };
       threads.emplace_back(f);
 //      f(); //just run serial
@@ -40,6 +43,7 @@ void exectsenums (){
 
    std::list<std::string> namesList (names.getStrings());
    namesList.sort();
-   for (auto&& name:namesList) printf("Enum called %s was found\n",name.c_str());
+   for (auto&& name:namesList)
+      printf("Enum called %s was found\n",name.c_str());
 
 }


### PR DESCRIPTION
This was fixed by root-project/root#15408.
The failure on Windows was due to typeinfo(enum_type) returning a name
with the format enum enumname and until the addition (in that PR) of
the name normalization step, this was incorrectly handled by TEnum::GetEnumThis was fixed by root-project/root#15408.
The failure on Windows was due to typeinfo(enum_type) returning a name
with the format enum enumname and until the addition (in that PR) of
the name normalization step, this was incorrectly handled by TEnum::GetEnum