### PR TITLE
Revert "[PyROOT] Update expected exception in `TPyException` regressi…

### DIFF
--- a/python/regression/PyROOT_regressiontests.py
+++ b/python/regression/PyROOT_regressiontests.py
@@ -84,16 +84,8 @@ class Regression02PyException(MyTestCase):
          with self.assertRaisesRegex(SyntaxError, "test error message"):
             ROOT.ThrowPyException()
 
-         # test of overloaded function. Note that there are two overloads of
-         # ThrowPyException, and cppyy will summarize what happens for all of
-         # the overloads in a TypeError that looks like this:
-         #
-         #    TypeError: none of the 2 overloaded methods succeeded. Full details:
-         #      static void MyThrowingClass::ThrowPyException(int) =>
-         #        SyntaxError: overloaded int test error message
-         #      static void MyThrowingClass::ThrowPyException(double) =>
-         #        SyntaxError: overloaded double test error message
-         with self.assertRaisesRegex(TypeError, "none of the 2 overloaded methods succeeded. Full details:"):
+         # test of overloaded function
+         with self.assertRaisesRegex(SyntaxError, "overloaded int test error message"):
             ROOT.MyThrowingClass.ThrowPyException(1)
 
 


### PR DESCRIPTION
…on test"

This reverts commit 26a6ee9ecca7abf3ab16eefdeb04ab045c17b720, which is not necessary anymore since the change of exception types was fixed upstream in CPyCppyy.

Goes together with:
https://github.com/root-project/root/pull/15485