### PR TITLE
[ntuple] add initial testing infrastructure

### DIFF
--- a/root/ntuple/.rootrc
+++ b/root/ntuple/.rootrc
@@ -1,0 +1,1 @@
+Rint.History:            .root_hist

--- a/root/ntuple/CMakeLists.txt
+++ b/root/ntuple/CMakeLists.txt
@@ -1,0 +1,7 @@
+if(NOT ROOT_root7_FOUND)
+  return()
+endif()
+
+ROOTTEST_ADD_TEST(test_Basics
+                  MACRO basics.C
+                  OUTREF test_basics.ref)

--- a/root/ntuple/basics.C
+++ b/root/ntuple/basics.C
@@ -1,0 +1,34 @@
+#include <ROOT/RLogger.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleReader.hxx>
+#include <ROOT/RNTupleWriter.hxx>
+
+#include <TSystem.h>
+
+#include <string>
+#include <utility>
+
+void basics()
+{
+   using ROOT::Experimental::RLogScopedVerbosity;
+   using ROOT::Experimental::RNTupleModel;
+   using ROOT::Experimental::RNTupleWriter;
+   using ROOT::Experimental::RNTupleReader;
+
+   const std::string kFileName{"test_rntuple_basics.root"s};
+
+   auto noPrereleaseWarning = RLogScopedVerbosity(ROOT::Experimental::NTupleLog(),
+                                                  ROOT::Experimental::ELogLevel::kError);
+
+   {
+      auto model = RNTupleModel::Create();
+      auto ptrE = model->MakeField<int>("E", 137);
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", kFileName);
+      writer->Fill();
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", kFileName);
+   reader->Show(0);
+
+   gSystem->Unlink(kFileName.c_str());
+}

--- a/root/ntuple/test_basics.ref
+++ b/root/ntuple/test_basics.ref
@@ -1,0 +1,5 @@
+Processing /home/jakob/Documents/CERN/ROOT/roottest/root/ntuple/basics.C...
+
+{
+  "E": 137
+}


### PR DESCRIPTION
Add the ntuple subfolder with a first, trivial test. Open the scope for RNTuple integration tests.