### PR TITLE
[PyROOT] Use PyROOT and not just cppyy in tests dealing with ROOT types

### DIFF
--- a/python/basic/PyROOT_datatypetest.py
+++ b/python/basic/PyROOT_datatypetest.py
@@ -56,8 +56,8 @@ class TestClassDATATYPES:
     def test02_instance_data_read_access(self):
         """Read access to instance public data and verify values"""
 
-        import cppyy
-        CppyyTestData = cppyy.gbl.CppyyTestData
+        import ROOT
+        CppyyTestData = ROOT.CppyyTestData
 
         c = CppyyTestData()
         assert isinstance(c, CppyyTestData)
@@ -152,8 +152,8 @@ class TestClassDATATYPES:
     def test03_instance_data_write_access(self):
         """Write access to instance public data and verify values"""
 
-        import cppyy
-        CppyyTestData = cppyy.gbl.CppyyTestData
+        import ROOT
+        CppyyTestData = ROOT.CppyyTestData
 
         c = CppyyTestData()
         assert isinstance(c, CppyyTestData)
@@ -334,8 +334,8 @@ class TestClassDATATYPES:
     def test05_class_read_access(self):
         """Read access to class public data"""
 
-        import cppyy
-        CppyyTestData = cppyy.gbl.CppyyTestData
+        import ROOT
+        CppyyTestData = ROOT.CppyyTestData
 
         c = CppyyTestData()
         assert isinstance(c, CppyyTestData)
@@ -394,8 +394,8 @@ class TestClassDATATYPES:
     def test06_class_data_write_access(self):
         """Write access to class public data"""
 
-        import cppyy
-        CppyyTestData = cppyy.gbl.CppyyTestData
+        import ROOT
+        CppyyTestData = ROOT.CppyyTestData
 
         c = CppyyTestData()
         assert isinstance(c, CppyyTestData)
@@ -525,8 +525,8 @@ class TestClassDATATYPES:
         """Access to a global builtin types"""
 
         # basic test with cross-check
-        import cppyy
-        gbl = cppyy.gbl
+        import ROOT
+        gbl = ROOT
 
         assert gbl.g_int == gbl.get_global_int()
 

--- a/python/regression/exec_root_6023.py
+++ b/python/regression/exec_root_6023.py
@@ -5,10 +5,10 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__))) # for common
 from common import check_cppyy_backend
 check_cppyy_backend()
 
-import cppyy
-cppyy.gbl.gROOT.ProcessLine('.L root_6023.h+')
+import ROOT
+ROOT.gROOT.ProcessLine('.L root_6023.h+')
 
-c = cppyy.gbl.instance()
+c = ROOT.instance()
 
 a = c.data
 b = c.value()


### PR DESCRIPTION
It is not a feature of cppyy, but only of our patches that cppyy can deal with `Long64_t` and the other basic ROOT typedefs.

In tests that have to do with these types, we should therefore use ROOT, so we don't rely on a patched cppyy and can move dealing with the ROOT types into our pythonizations.