### PR TITLE
[RDF] avoid using deprecated ROOT::ECompressionAlgorithm in writeFcc.C

### DIFF
--- a/root/dataframe/writeFcc.C
+++ b/root/dataframe/writeFcc.C
@@ -35,5 +35,5 @@ void writeFcc()
     .Snapshot<colType>("t",
                        "fccMockup.root",
                        {"electrons"},
-                       {"RECREATE", ROOT::kLZ4, 4, 0, 0, false}); // non split!
+                       {"RECREATE", ROOT::RCompressionSetting::EAlgorithm::kLZ4, 4, 0, 0, false}); // non split!
 }


### PR DESCRIPTION
Required for [#15821](https://github.com/root-project/root/pull/15821)