### PR TITLE
[cmake][win] Disable problematic tests

### DIFF
--- a/root/io/stdpair/CMakeLists.txt
+++ b/root/io/stdpair/CMakeLists.txt
@@ -13,9 +13,11 @@ ROOT_ADD_TEST(roottest-root-io-stdpair-collection-build
               COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} ${build_config} --target G__CmsPairCollection${fast}  CmsPairCollection${fast} -- ${always-make}
               FIXTURES_SETUP InputFiles)
 
-ROOT_ADD_TEST(roottest-root-io-stdpair-pair-build 
-              COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} ${build_config} --target G__CmsPair${fast}  CmsPair${fast} -- ${always-make}
-              FIXTURES_SETUP InputFiles)
+if(NOT MSVC OR win_broken_tests)
+    ROOT_ADD_TEST(roottest-root-io-stdpair-pair-build
+                  COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} ${build_config} --target G__CmsPair${fast}  CmsPair${fast} -- ${always-make}
+                  FIXTURES_SETUP InputFiles)
+endif()
 
 ROOTTEST_ADD_TEST(CopyRootFiles
                   COMMAND ${CMAKE_COMMAND} -E echo "Copying root files"

--- a/root/meta/CMakeLists.txt
+++ b/root/meta/CMakeLists.txt
@@ -31,12 +31,14 @@ ROOTTEST_ADD_TEST(execpragmasTest
                   MACRO execpragmasTest.C+
                   OUTREF execpragmasTest.ref)
 
-ROOTTEST_GENERATE_EXECUTABLE(loadernotapp loadernotapp.cxx LIBRARIES ROOT::Core ROOT::Hist)
+if(NOT MSVC OR win_broken_tests)
+    ROOTTEST_GENERATE_EXECUTABLE(loadernotapp loadernotapp.cxx LIBRARIES ROOT::Core ROOT::Hist)
 
-ROOTTEST_ADD_TEST(loadernotapp
-                  EXEC ${CMAKE_CURRENT_BINARY_DIR}/loadernotapp
-                  OUTREF loadernotapp.ref
-                  DEPENDS ${GENERATE_EXECUTABLE_TEST})
+    ROOTTEST_ADD_TEST(loadernotapp
+                      EXEC ${CMAKE_CURRENT_BINARY_DIR}/loadernotapp
+                      OUTREF loadernotapp.ref
+                      DEPENDS ${GENERATE_EXECUTABLE_TEST})
+endif()
 
 ROOTTEST_COMPILE_MACRO(fornamespace.C)
 


### PR DESCRIPTION
Disable a couple of tests that are triggering full (sort of) rebuild of ROOT