### PR TITLE
Revert "[df] Fix tests for distributed GetColumnNames"

### DIFF
--- a/python/distrdf/backends/check_backend.py
+++ b/python/distrdf/backends/check_backend.py
@@ -121,8 +121,6 @@ class TestInitialization:
             RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
             df = RDataFrame(1, sparkcontext=connection)
 
-        # Run init method so that RDF can keep track of the defined column
-        init(123)
         df = df.Define("u", "userValue").Histo1D(
             ("name", "title", 1, 100, 130), "u")
         

--- a/python/distrdf/backends/check_definepersample.py
+++ b/python/distrdf/backends/check_definepersample.py
@@ -93,9 +93,6 @@ class TestDefinePerSample:
         elif backend == "spark":
             RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
             df = RDataFrame(self.maintreename, self.filenames, sparkcontext=connection)
-
-        # Declare code locally so that the RDF can keep track of the defined column
-        declare_definepersample_code()
         df1 = df.DefinePerSample("sample_weight", "samples_weights(rdfslot_, rdfsampleinfo_)")\
                 .DefinePerSample("sample_name", "samples_names(rdfslot_, rdfsampleinfo_)")
 


### PR DESCRIPTION
To comply with reverting "[rdf] Restrict distributed initialization to executors only" in root repo: PR #15984. 