### PR TITLE
[PyROOT] Migrate from `TPython::Eval()` to `TPython::Exec()`

### DIFF
--- a/python/cling/PyClassTest2.C
+++ b/python/cling/PyClassTest2.C
@@ -18,7 +18,7 @@ void PyClassTest2() {
    TPython::Exec( "sys.stdout.write( \'instance count: %d\\n\' % (MyOtherPyClass.count,) )" );
    TPython::Exec( "op = MyOtherPyClass()" );
    TPython::Exec( "sys.stdout.write( \'instance count: %d\\n\' % (MyOtherPyClass.count,) )" );
-   TPython::Eval( "op" );
+   TPython::Exec( "op" );
    TPython::Exec( "del op" );
    TPython::Exec( "sys.stdout.write( \'instance count: %d\\n\' % (MyOtherPyClass.count,) )" );
 }

--- a/python/cling/PyClassTest4.C
+++ b/python/cling/PyClassTest4.C
@@ -1,14 +1,16 @@
 #include "TPython.h"
 #include <iostream>
 
-void PyClassTest4() {
-// python classes live in "MyPyClass.py" and "MyModule.py", which must have been
-// loaded in a separate line or macro, or this one won't compile
+void PyClassTest4()
+{
+   // python classes live in "MyPyClass.py" and "MyModule.py", which must have been
+   // loaded in a separate line or macro, or this one won't compile
 
-// test access to C++ classes derived from python classes
-   Derived1* a = (Derived1*)TPython::Eval( "ROOT.Derived1( 42 )" );
-   std::cout << "Derived1 (42):  " << a->fVal << std::endl;
+   // test access to C++ classes derived from python classes
+   std::any result;
+   TPython::Exec(R"(val = ROOT.Derived1( 42 ); _anyresult = ROOT.std.make_any["Derived1*", "Derived1*"](val))", &result);
+   std::cout << "Derived1 (42):  " << std::any_cast<Derived1*>(result)->fVal << std::endl;
 
-   Derived2* b = (Derived2*)TPython::Eval( "ROOT.Derived2( 5.0 )" );
-   std::cout << "Derived2 (5.0): " << b->fVal << std::endl;
+   TPython::Exec(R"(val = ROOT.Derived2( 5.0 ); _anyresult = ROOT.std.make_any["Derived2*", "Derived2*"](val))", &result);
+   std::cout << "Derived2 (5.0): " << std::any_cast<Derived2*>(result)->fVal << std::endl;
 }


### PR DESCRIPTION
Sister PR of https://github.com/root-project/root/pull/16175.