### PR TITLE
[PyROOT] Loop nJIT function more to prevent sporadic failures

### DIFF
--- a/python/numba/PyROOT_numbatests.py
+++ b/python/numba/PyROOT_numbatests.py
@@ -84,7 +84,7 @@ class TestClasNumba:
 
         assert (False not in
                 tuple(math.isclose(x, y) for x, y in numba_calc_pt_vec(vec_lv)))
-        assert self.compare(calc_pt_vec, numba_calc_pt_vec, 1, vec_lv)
+        assert self.compare(calc_pt_vec, numba_calc_pt_vec, 10, vec_lv)
 
     def test03_inheritance(self):
         """This test shows one of the limitations of the current support"""


### PR DESCRIPTION
The comparisons in execution times sometimes suffers a failure when the numba function is slower than pure python. This increases the number of loops to ensure the njit outperforms bare python.