### PR TITLE
[DF] Add RNTuple as a possible dependency

### DIFF
--- a/root/dataframe/CMakeLists.txt
+++ b/root/dataframe/CMakeLists.txt
@@ -11,6 +11,10 @@ endif()
 
 set(DFLIBRARIES Core RIO Hist Tree MathCore TreePlayer ROOTDataFrame ROOTVecOps)
 
+if(ROOT_root7_FOUND)
+  list(APPEND DFLIBRARIES ROOTNTuple)
+endif()
+
 # ROOT-9975
 ROOTTEST_ADD_TEST(test_ROOT9975
                   COPY_TO_BUILDDIR ROOT9975.root


### PR DESCRIPTION
Necessary for Snapshot-related tests, now that snapshotting to RNTuple is being added (https://github.com/root-project/root/pull/15750).