### PR TITLE
[CMake] Set the minimum required version to 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 project(roottest)
 


### PR DESCRIPTION
This is required to build LLVM18.
This version of CMake was eleased in March 2021 https://github.com/Kitware/CMake/releases/tag/v3.20.0

Associated PR in ROOT https://github.com/root-project/root/pull/16396
