### PR TITLE
disable some geom-dependant tests when geom is OFF

### DIFF
--- a/root/io/TFile/CMakeLists.txt
+++ b/root/io/TFile/CMakeLists.txt
@@ -4,4 +4,6 @@
 # define a CTest test that calls 'make' in ${CMAKE_CURRENT_SOURCE_DIR}
 #
 #-------------------------------------------------------------------------------
-ROOTTEST_ADD_OLDTEST()
+if(geom)
+  ROOTTEST_ADD_OLDTEST()
+endif()

--- a/root/io/webfile/CMakeLists.txt
+++ b/root/io/webfile/CMakeLists.txt
@@ -4,4 +4,6 @@
 # define a CTest test that calls 'make' in ${CMAKE_CURRENT_SOURCE_DIR}
 #
 #-------------------------------------------------------------------------------
-ROOTTEST_ADD_OLDTEST()
+if(geom)
+  ROOTTEST_ADD_OLDTEST()
+endif()


### PR DESCRIPTION
Adapt roottests to geom being off. Related to [#16514](https://github.com/root-project/root/pull/16514)