### PR TITLE
[io] fix missing include in io-datamodelevolution-00-test2

### DIFF
--- a/root/io/datamodelevolution/00/test2.cxx
+++ b/root/io/datamodelevolution/00/test2.cxx
@@ -2,6 +2,7 @@
 #include "TFile.h"
 #include "TTree.h"
 #include "TError.h"
+#include "TBranch.h"
 
 #include "TBufferFile.h"
 #include "TStreamerInfo.h"


### PR DESCRIPTION
the test fails to run otherwise (on debian12 - cling)