### PR TITLE
[skip-ci] [df] Adapt to unified API (local and distributed)

### DIFF
--- a/python/distrdf/backends/check_cloned_actions.py
+++ b/python/distrdf/backends/check_cloned_actions.py
@@ -19,15 +19,8 @@ class TestAsNumpy:
 
         datasetname = "Events"
         filename = "../data/ttree/distrdf_roottest_check_cloned_actions_asnumpy.root"
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            distrdf = RDataFrame(datasetname, filename,
-                                 daskclient=connection, npartitions=nparts)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            distrdf = RDataFrame(datasetname, filename,
-                                 sparkcontext=connection, npartitions=nparts)
+        connection, _ = payload
+        distrdf = ROOT.RDataFrame(datasetname, filename, executor=connection, npartitions=nparts)
 
         localdf = ROOT.RDataFrame("Events", filename)
 

--- a/python/distrdf/backends/check_definepersample.py
+++ b/python/distrdf/backends/check_definepersample.py
@@ -18,13 +18,8 @@ class TestDefinePerSample:
         string of operations.
         """
 
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            df = RDataFrame(self.maintreename, self.filenames, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            df = RDataFrame(self.maintreename, self.filenames, sparkcontext=connection)
+        connection, _ = payload
+        df = ROOT.RDataFrame(self.maintreename, self.filenames, executor=connection)
 
         # Associate a number to each sample
         definepersample_code = """
@@ -86,13 +81,8 @@ class TestDefinePerSample:
             ''')
 
         DistRDF.initialize(declare_definepersample_code)
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            df = RDataFrame(self.maintreename, self.filenames, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            df = RDataFrame(self.maintreename, self.filenames, sparkcontext=connection)
+        connection, _ = payload
+        df = ROOT.RDataFrame(self.maintreename, self.filenames, executor=connection)
         df1 = df.DefinePerSample("sample_weight", "samples_weights(rdfslot_, rdfsampleinfo_)")\
                 .DefinePerSample("sample_name", "samples_names(rdfslot_, rdfsampleinfo_)")
 

--- a/python/distrdf/backends/check_distribute_cppcode.py
+++ b/python/distrdf/backends/check_distribute_cppcode.py
@@ -62,26 +62,16 @@ class TestDeclare:
             """
         )
 
-    def _distribute_single_declare_check_filter_and_histo(self, connection, backend):
+    def _distribute_single_declare_check_filter_and_histo(self, connection):
 
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            rdf = RDataFrame(10, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            rdf = RDataFrame(10, sparkcontext=connection)
+        rdf = ROOT.RDataFrame(10, executor=connection)
 
         self._mydeclare_1(rdf)
         self._check_rdf_histos_1(rdf)
 
-    def _distribute_multiple_declares_check_filter_and_histo(self, connection, backend):
+    def _distribute_multiple_declares_check_filter_and_histo(self, connection):
 
-        if backend == "spark":
-            RDataFrame1 = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            rdf = RDataFrame1(10, sparkcontext=connection)
-        elif backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            rdf = RDataFrame(10, daskclient=connection)
+        rdf = ROOT.RDataFrame(10, executor=connection)
 
         self._mydeclare_1(rdf)
         self._mydeclare_2(rdf)
@@ -93,9 +83,9 @@ class TestDeclare:
         Tests for the distribution of headers to the workers and their
         corresponding inclusion.
         """
-        connection, backend = payload
-        self._distribute_single_declare_check_filter_and_histo(connection, backend)
-        self._distribute_multiple_declares_check_filter_and_histo(connection, backend)
+        connection, _ = payload
+        self._distribute_single_declare_check_filter_and_histo(connection)
+        self._distribute_multiple_declares_check_filter_and_histo(connection)
 
 
 if __name__ == "__main__":

--- a/python/distrdf/backends/check_explicit_api.py
+++ b/python/distrdf/backends/check_explicit_api.py
@@ -1,0 +1,92 @@
+import pytest
+
+import ROOT
+
+import DistRDF
+
+
+class TestExplicitAPI:
+    """
+    Tests for compatibility with using full names to classes and functions of
+    distributed RDataFrame.
+    """
+
+    def test_histo_variations(self, payload):
+        connection, backend = payload
+        if backend == "dask":
+            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
+            df = RDataFrame(10, npartitions=2, daskclient=connection)
+        elif backend == "spark":
+            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
+            df = RDataFrame(10, npartitions=2, sparkcontext=connection)
+        df = df.Define("x", "1")
+        df1 = df.Vary("x", "ROOT::RVecI{-2,2}", ["down", "up"])
+        h = df1.Histo1D(("name", "title", 10, -10, 10), "x")
+        histos = DistRDF.VariationsFor(h)
+
+        expectednames = ["nominal", "x:up", "x:down"]
+        expectedmeans = [1, 2, -2]
+        for varname, mean in zip(expectednames, expectedmeans):
+            histo = histos[varname]
+            assert isinstance(histo, ROOT.TH1D)
+            assert histo.GetEntries() == 10
+            assert histo.GetMean() == mean
+
+    def test_rungraphs_3histos(self, payload):
+        """
+        Submit three different Dask RDF graphs concurrently
+        """
+        # Create a test file for processing
+        treename = "tree"
+        filename = "../data/ttree/distrdf_roottest_check_rungraphs.root"
+        nentries = 10000
+        connection, backend = payload
+        if backend == "dask":
+            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
+        elif backend == "spark":
+            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
+
+        histoproxies = [
+            RDataFrame(treename, filename, npartitions=2,
+                       executor=connection).Histo1D((col, col, 1, 40, 45), col)
+            for col in ["b1", "b2", "b3"]
+        ]
+
+        # Before triggering the computation graphs values are None
+        for proxy in histoproxies:
+            assert proxy.proxied_node.value is None
+
+        DistRDF.RunGraphs(histoproxies)
+
+        # After RunGraphs all histograms are correctly assigned to the
+        # node objects
+        for proxy in histoproxies:
+            histo = proxy.proxied_node.value
+            assert isinstance(histo, ROOT.TH1D)
+            assert histo.GetEntries() == nentries
+            assert histo.GetMean() == 42
+
+    def test_redefine_one_column(self, payload):
+        """Test that values of one column can be properly redefined."""
+        # A simple dataframe with ten sequential numbers from 0 to 9
+        connection, backend = payload
+        if backend == "dask":
+            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
+            df = RDataFrame(10, daskclient=connection)
+        elif backend == "spark":
+            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
+            df = RDataFrame(10, sparkcontext=connection)
+        df_before = df.Define("x", "1")
+        df_after = df_before.Redefine("x", "2")
+
+        # Initial sum should be equal to 10
+        sum_before = df_before.Sum("x")
+        # Sum after the redefinition should be equal to 20
+        sum_after = df_after.Sum("x")
+
+        assert sum_before.GetValue() == 10.0
+        assert sum_after.GetValue() == 20.0
+
+
+if __name__ == "__main__":
+    pytest.main(args=[__file__])

--- a/python/distrdf/backends/check_friend_trees.py
+++ b/python/distrdf/backends/check_friend_trees.py
@@ -43,13 +43,8 @@ class TestDaskFriendTrees:
         mainchain.AddFriend(friendchain)
 
         # Create a DistRDF RDataFrame with the main and the friend chains
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            df = RDataFrame(mainchain, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            df = RDataFrame(mainchain, sparkcontext=connection)
+        connection, _ = payload
+        df = ROOT.RDataFrame(mainchain, executor=connection)
 
         # Create histograms
         h_parent = df.Histo1D(("main", "main", 10, 0, 20), "x")
@@ -70,13 +65,8 @@ class TestDaskFriendTrees:
             maintree.AddFriend(friendtree)
 
             # Create a DistRDF RDataFrame with the main and the friend trees
-            connection, backend = payload
-            if backend == "dask":
-                RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-                df = RDataFrame(maintree, daskclient=connection)
-            elif backend == "spark":
-                RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-                df = RDataFrame(maintree, sparkcontext=connection)
+            connection, _ = payload
+            df = ROOT.RDataFrame(maintree, executor=connection)
 
             # Create histograms
             h_parent = df.Histo1D(("main", "main", 10, 0, 20), "x")
@@ -100,13 +90,8 @@ class TestDaskFriendTrees:
 
         chain.AddFriend(chainFriend, "myfriend")
 
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            df = RDataFrame(chain, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            df = RDataFrame(chain, sparkcontext=connection)
+        connection, _ = payload
+        df = ROOT.RDataFrame(chain, executor=connection)
 
         h_parent = df.Histo1D(("main", "main", 10, 0, 20), "rnd")
         h_friend = df.Histo1D(("friend", "friend", 10, 10, 30), "myfriend.rnd")

--- a/python/distrdf/backends/check_friend_trees_alignment.py
+++ b/python/distrdf/backends/check_friend_trees_alignment.py
@@ -40,13 +40,8 @@ class TestDaskFriendTreesAlignment:
 
         chain = create_chain()
 
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            df = RDataFrame(chain, daskclient=connection, npartitions=nparts)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            df = RDataFrame(chain, sparkcontext=connection, npartitions=nparts)
+        connection, _ = payload
+        df = ROOT.RDataFrame(chain, executor=connection, npartitions=nparts)
 
         s1 = df.Sum("x")
         s2 = df.Sum("friend.x")

--- a/python/distrdf/backends/check_histo_write.py
+++ b/python/distrdf/backends/check_histo_write.py
@@ -28,13 +28,8 @@ class TestDaskHistoWrite:
             treename = "T"
             filename = "../data/ttree/distrdf_roottest_check_friend_trees_main.root"
             # Create a DistRDF RDataFrame with the parent and the friend trees
-            connection, backend = payload
-            if backend == "dask":
-                RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-                df = RDataFrame(treename, filename, daskclient=connection)
-            elif backend == "spark":
-                RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-                df = RDataFrame(treename, filename, sparkcontext=connection)
+            connection, _ = payload
+            df = ROOT.RDataFrame(treename, filename, executor=connection)
 
             # Create histogram
             histo = df.Histo1D(("x", "x", 100, 0, 20), "x")

--- a/python/distrdf/backends/check_inv_mass.py
+++ b/python/distrdf/backends/check_inv_mass.py
@@ -10,19 +10,14 @@ from DistRDF.Backends import Dask
 class TestDaskHistograms:
     """Integration tests to check the working of DistRDF."""
 
-    def build_distrdf_graph(self, connection, backend):
+    def build_distrdf_graph(self, connection):
         """
         Create a DistRDF graph with a fixed set of operations and return it.
         """
         
         treename = "data"
         files = ["http://root.cern/files/teaching/CMS_Open_Dataset.root", ]
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            rdf = RDataFrame(treename, files, npartitions=5, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            rdf = RDataFrame(treename, files, npartitions=5, sparkcontext=connection)
+        rdf = ROOT.RDataFrame(treename, files, executor=connection, npartitions=5)
 
         # Define the analysis cuts
         chargeCutStr = "C1 != C2"
@@ -85,8 +80,8 @@ class TestDaskHistograms:
         physics_variables = ["pt1_h", "pt2_h", "invMass_h", "phis_h"]
 
         DaskResult = namedtuple("DaskResult", physics_variables)
-        connection, backend = payload
-        daskresults = DaskResult(*self.build_distrdf_graph(connection, backend))
+        connection, _ = payload
+        daskresults = DaskResult(*self.build_distrdf_graph(connection))
 
         daskresults.pt1_h.Draw("PL PLC PMC")  # Trigger Event-loop, Dask
 

--- a/python/distrdf/backends/check_live_visualize.py
+++ b/python/distrdf/backends/check_live_visualize.py
@@ -6,9 +6,6 @@ from DistRDF import LiveVisualize
 
 import ROOT
 
-
-RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-
 # Callback functions
 def set_marker(graph):
     graph.SetMarkerStyle(5)
@@ -49,7 +46,7 @@ class TestLiveVisualizationCallback:
             # This feature is only available with the Dask backend
             return
         num_entries = 50
-        d = RDataFrame(num_entries, daskclient=connection)
+        d = ROOT.RDataFrame(num_entries, executor=connection)
         graph = d.Define("x", "rdfentry_").Define("y", "x*x").Graph("x", "y")
 
         # Create a temp file to store the number of data points
@@ -78,7 +75,7 @@ class TestLiveVisualizationCallback:
         if backend != "dask":
             # This feature is only available with the Dask backend
             return
-        d = RDataFrame(100, daskclient=connection)
+        d = ROOT.RDataFrame(100, executor=connection)
         dd = d.Define("x", "rdfentry_").Define("y1", "x*x").Define("y2", "x+10")
         graph1 = dd.Graph("x", "y1")
         graph2 = dd.Graph("x", "y2")
@@ -98,7 +95,7 @@ class TestLiveVisualizationCallback:
         if backend != "dask":
             # This feature is only available with the Dask backend
             return
-        d = RDataFrame(100, daskclient=connection)
+        d = ROOT.RDataFrame(100, executor=connection)
         graph = d.Define("x", "rdfentry_").Define("y1", "x*x").Define("y2", "x+10").Graph("x", "y1")
 
         # Use functools.partial to pass a callback that takes 2 arguments 
@@ -121,7 +118,7 @@ class TestInvalidArgument:
         if backend != "dask":
             # This feature is only available with the Dask backend
             return
-        d = RDataFrame(100, daskclient=connection)
+        d = ROOT.RDataFrame(100, executor=connection)
         df = d.Define("x", "rdfentry_").Define("y", "x*x")
         graph = df.Graph("x", "y")
         
@@ -141,7 +138,7 @@ class TestInvalidArgument:
         if backend != "dask":
             # This feature is only available with the Dask backend
             return
-        d = RDataFrame(100, daskclient=connection)
+        d = ROOT.RDataFrame(100, executor=connection)
         graph = d.Define("x", "rdfentry_").Define("y", "x*x").Graph("x", "y")
 
         with pytest.warns(UserWarning, match="The provided callback is not callable. Skipping callback."):
@@ -169,8 +166,8 @@ class TestUnsupportedCall:
         if backend != "dask":
             # This feature is only available with the Dask backend
             return
-        d1 = RDataFrame(100, daskclient=connection)
-        d2 = RDataFrame(50, daskclient=connection)
+        d1 = ROOT.RDataFrame(100, executor=connection)
+        d2 = ROOT.RDataFrame(50, executor=connection)
 
         graph1 = d1.Define("x1", "rdfentry_").Define("y1", "x1*x1").Graph("x1", "y1")
         graph2 = d2.Define("x2", "rdfentry_").Define("y2", "x2+10").Graph("x2", "y2")
@@ -187,7 +184,7 @@ class TestUnsupportedCall:
         if backend != "dask":
             # This feature is only available with the Dask backend
             return
-        d = RDataFrame(100, daskclient=connection)
+        d = ROOT.RDataFrame(100, executor=connection)
         df = d.Define("x", "rdfentry_")
         sum = df.Sum("x")
         
@@ -203,7 +200,7 @@ class TestUnsupportedCall:
         if backend != "dask":
             # This feature is only available with the Dask backend
             return
-        d = RDataFrame(100, daskclient=connection)
+        d = ROOT.RDataFrame(100, executor=connection)
         graph = d.Define("x", "rdfentry_").Define("y", "x*x").Graph("x", "y")
 
         # Trigger the computation graph

--- a/python/distrdf/backends/check_reducer_merge.py
+++ b/python/distrdf/backends/check_reducer_merge.py
@@ -59,14 +59,8 @@ class TestReducerMerge:
     def test_histo1d_merge(self, payload):
         """Check the working of Histo1D merge operation in the reducer."""
         # Operations with DistRDF
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            rdf_py = RDataFrame(10, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            rdf_py = RDataFrame(10, sparkcontext=connection)
-
+        connection, _ = payload
+        rdf_py = ROOT.RDataFrame(10, executor=connection)
         histo_py = rdf_py.Histo1D(("name", "title", 10, 0, 10), "rdfentry_")
 
         # Operations with PyROOT
@@ -81,13 +75,8 @@ class TestReducerMerge:
         modelTH2D = ("", "", 64, -4, 4, 64, -4, 4)
 
         # Operations with DistRDF
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            rdf_py = RDataFrame(10, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            rdf_py = RDataFrame(10, sparkcontext=connection)
+        connection, _ = payload
+        rdf_py = ROOT.RDataFrame(10, executor=connection)
 
         columns_py = self.define_two_columns(rdf_py)
         histo_py = columns_py.Histo2D(modelTH2D, "x", "y")
@@ -104,13 +93,8 @@ class TestReducerMerge:
         """Check the working of Histo3D merge operation in the reducer."""
         modelTH3D = ("", "", 64, -4, 4, 64, -4, 4, 64, -4, 4)
         # Operations with DistRDF
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            rdf_py = RDataFrame(10, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            rdf_py = RDataFrame(10, sparkcontext=connection)
+        connection, _ = payload
+        rdf_py = ROOT.RDataFrame(10, executor=connection)
         columns_py = self.define_three_columns(rdf_py)
         histo_py = columns_py.Histo3D(modelTH3D, "x", "y", "z")
 
@@ -130,13 +114,8 @@ class TestReducerMerge:
         modelTHND = ("name", "title", 4, nbins, xmin, xmax)
         colnames = ("x0", "x1", "x2", "x3")
 
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            distrdf = RDataFrame(100, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            distrdf = RDataFrame(100, sparkcontext=connection)
+        connection, _ = payload
+        distrdf = ROOT.RDataFrame(100, executor=connection)
 
         rdf = ROOT.RDataFrame(100)
 
@@ -152,13 +131,8 @@ class TestReducerMerge:
     def test_profile1d_merge(self, payload):
         """Check the working of Profile1D merge operation in the reducer."""
         # Operations with DistRDF
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            rdf_py = RDataFrame(10, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            rdf_py = RDataFrame(10, sparkcontext=connection)
+        connection, _ = payload
+        rdf_py = ROOT.RDataFrame(10, executor=connection)
 
         columns_py = self.define_two_columns(rdf_py)
         profile_py = columns_py.Profile1D(("", "", 64, -4, 4), "x", "y")
@@ -176,13 +150,8 @@ class TestReducerMerge:
         model = ("", "", 64, -4, 4, 64, -4, 4)
 
         # Operations with DistRDF
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            rdf_py = RDataFrame(10, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            rdf_py = RDataFrame(10, sparkcontext=connection)
+        connection, _ = payload
+        rdf_py = ROOT.RDataFrame(10, executor=connection)
 
         columns_py = self.define_three_columns(rdf_py)
         profile_py = columns_py.Profile2D(model, "x", "y", "z")
@@ -198,13 +167,8 @@ class TestReducerMerge:
     def test_tgraph_merge(self, payload):
         """Check the working of TGraph merge operation in the reducer."""
         # Operations with DistRDF
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            rdf_py = RDataFrame(10, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            rdf_py = RDataFrame(10, sparkcontext=connection)
+        connection, _ = payload
+        rdf_py = ROOT.RDataFrame(10, executor=connection)
 
         columns_py = self.define_two_columns(rdf_py)
         graph_py = columns_py.Graph("x", "y")
@@ -227,13 +191,8 @@ class TestReducerMerge:
     def test_tgraphasymmerrors_merge(self, payload):
         """Check the working of TGraphAsymmErrors merge operation in the reducer."""
         # Operations with DistRDF
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            rdf_py = RDataFrame(10, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            rdf_py = RDataFrame(10, sparkcontext=connection)
+        connection, _ = payload
+        rdf_py = ROOT.RDataFrame(10, executor=connection)
 
         columns_py = self.define_two_columns(rdf_py)
         err_columns_py = self.define_two_err_columns(columns_py)
@@ -260,13 +219,8 @@ class TestReducerMerge:
 
     def test_distributed_count(self, payload):
         """Test support for `Count` operation in distributed backend"""
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            rdf_py = RDataFrame(100, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            rdf_py = RDataFrame(100, sparkcontext=connection)
+        connection, _ = payload
+        rdf_py = ROOT.RDataFrame(100, executor=connection)
 
         count = rdf_py.Count()
 
@@ -274,13 +228,8 @@ class TestReducerMerge:
 
     def test_distributed_sum(self, payload):
         """Test support for `Sum` operation in distributed backend"""
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            rdf_py = RDataFrame(10, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            rdf_py = RDataFrame(10, sparkcontext=connection)
+        connection, _ = payload
+        rdf_py = ROOT.RDataFrame(10, executor=connection)
 
         rdf_def = rdf_py.Define("x", "rdfentry_")
         rdf_sum = rdf_def.Sum("x")
@@ -312,13 +261,8 @@ class TestReducerMerge:
         """Test support for `AsNumpy` pythonization in distributed backend"""
 
         # Let's create a simple dataframe with ten rows and two columns
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            df = RDataFrame(10, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            df = RDataFrame(10, sparkcontext=connection)
+        connection, _ = payload
+        df = ROOT.RDataFrame(10, executor=connection)
 
         df = df.Define("x", "(int)rdfentry_").Define("y", "1.f/(1.f+rdfentry_)")
 
@@ -333,13 +277,8 @@ class TestReducerMerge:
         """
 
         # Let's create a simple dataframe with ten rows and two columns
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            df = RDataFrame(10, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            df = RDataFrame(10, sparkcontext=connection)
+        connection, _ = payload
+        df = ROOT.RDataFrame(10, executor=connection)
 
         df = df.Define("x", "(int)rdfentry_").Define("y", "1.f/(1.f+rdfentry_)")
 
@@ -360,13 +299,8 @@ class TestReducerMerge:
         """Test that `AsNumpy` can be still called lazily in distributed mode"""
 
         # Let's create a simple dataframe with ten rows and two columns
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            df = RDataFrame(10, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            df = RDataFrame(10, sparkcontext=connection)
+        connection, _ = payload
+        df = ROOT.RDataFrame(10, executor=connection)
 
         df = df.Define("x", "(int)rdfentry_").Define("y", "1.f/(1.f+rdfentry_)")
 
@@ -399,13 +333,8 @@ class TestReducerMerge:
     def test_distributed_snapshot(self, payload):
         """Test support for `Snapshot` in distributed backend"""
         # A simple dataframe with ten sequential numbers from 0 to 9
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            df = RDataFrame(10, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            df = RDataFrame(10, sparkcontext=connection)
+        connection, _ = payload
+        df = ROOT.RDataFrame(10, executor=connection)
 
         df = df.Define("x", "rdfentry_")
 
@@ -420,13 +349,8 @@ class TestReducerMerge:
         argument "columnList".
         """
         # A simple dataframe with ten sequential numbers from 0 to 9
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            df = RDataFrame(10, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            df = RDataFrame(10, sparkcontext=connection)
+        connection, _ = payload
+        df = ROOT.RDataFrame(10, executor=connection)
         df = (
             df
             .Define("a", "rdfentry_")
@@ -451,13 +375,8 @@ class TestReducerMerge:
     def test_distributed_snapshot_lazy(self, payload):
         """Test that `Snapshot` can be still called lazily in distributed mode"""
         # A simple dataframe with ten sequential numbers from 0 to 9
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            df = RDataFrame(10, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            df = RDataFrame(10, sparkcontext=connection)
+        connection, _ = payload
+        df = ROOT.RDataFrame(10, executor=connection)
         df = df.Define("x", "rdfentry_")
 
         opts = ROOT.RDF.RSnapshotOptions()
@@ -472,13 +391,8 @@ class TestReducerMerge:
     def test_redefine_one_column(self, payload):
         """Test that values of one column can be properly redefined."""
         # A simple dataframe with ten sequential numbers from 0 to 9
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            df = RDataFrame(10, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            df = RDataFrame(10, sparkcontext=connection)
+        connection, _ = payload
+        df = ROOT.RDataFrame(10, executor=connection)
         df_before = df.Define("x", "1")
         df_after = df_before.Redefine("x", "2")
 
@@ -497,13 +411,8 @@ class TestReducerMerge:
         treename = "tree"
         filename = "../data/ttree/distrdf_roottest_check_reducer_merge_1.root"
 
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            df = RDataFrame(treename, filename, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            df = RDataFrame(treename, filename, sparkcontext=connection)
+        connection, _ = payload
+        df = ROOT.RDataFrame(treename, filename, executor=connection)
 
         std = df.StdDev("v")
         expected = 29.0114
@@ -517,13 +426,8 @@ class TestReducerMerge:
         treename = "tree"
         filename = "../data/ttree/distrdf_roottest_check_reducer_merge_1.root"
 
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            df = RDataFrame(treename, filename, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            df = RDataFrame(treename, filename, sparkcontext=connection)
+        connection, _ = payload
+        df = ROOT.RDataFrame(treename, filename, executor=connection)
 
         df = (
             df.Define("vec_v", "std::vector<double>({v, v+1, v+2})")

--- a/python/distrdf/backends/check_rungraphs.py
+++ b/python/distrdf/backends/check_rungraphs.py
@@ -16,15 +16,8 @@ class TestRunGraphs:
         treename = "tree"
         filename = "../data/ttree/distrdf_roottest_check_rungraphs.root"
         nentries = 10000
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            df = RDataFrame(treename, filename, npartitions=2,
-                            daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            df = RDataFrame(treename, filename, npartitions=2,
-                            sparkcontext=connection)
+        connection, _ = payload
+        df = ROOT.RDataFrame(treename, filename, executor=connection, npartitions=2)
         histoproxies = [
             df.Histo1D((col, col, 1, 40, 45), col)
             for col in ["b1", "b2", "b3"]
@@ -34,7 +27,7 @@ class TestRunGraphs:
         for proxy in histoproxies:
             assert proxy.proxied_node.value is None
 
-        DistRDF.RunGraphs(histoproxies)
+        ROOT.RDF.RunGraphs(histoproxies)
 
         # After RunGraphs all histograms are correctly assigned to the
         # node objects

--- a/python/distrdf/backends/check_variations.py
+++ b/python/distrdf/backends/check_variations.py
@@ -9,17 +9,12 @@ class TestVariations:
     """Tests usage of systematic variations with Dask backend"""
 
     def test_histo(self, payload):
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            df = RDataFrame(10, npartitions=2, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            df = RDataFrame(10, npartitions=2, sparkcontext=connection)
+        connection, _ = payload
+        df = ROOT.RDataFrame(10, executor=connection, npartitions=2)
         df = df.Define("x", "1")
         df1 = df.Vary("x", "ROOT::RVecI{-2,2}", ["down", "up"])
         h = df1.Histo1D(("name", "title", 10, -10, 10), "x")
-        histos = DistRDF.VariationsFor(h)
+        histos = ROOT.RDF.Experimental.VariationsFor(h)
 
         expectednames = ["nominal", "x:up", "x:down"]
         expectedmeans = [1, 2, -2]
@@ -30,16 +25,11 @@ class TestVariations:
             assert histo.GetMean() == mean
 
     def test_graph(self, payload):
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            df = RDataFrame(10, npartitions=2, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            df = RDataFrame(10, npartitions=2, sparkcontext=connection)
+        connection, _ = payload
+        df = ROOT.RDataFrame(10, executor=connection, npartitions=2)
         df = df.Define("x", "1")
         g = df.Vary("x", "ROOT::RVecI{-1, 2}", nVariations=2).Graph("x", "x")
-        gs = DistRDF.VariationsFor(g)
+        gs = ROOT.RDF.Experimental.VariationsFor(g)
 
         assert g.GetMean() == 1
 
@@ -51,17 +41,12 @@ class TestVariations:
             assert graph.GetMean() == mean
 
     def test_mixed(self, payload):
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            df = RDataFrame(10, npartitions=2, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            df = RDataFrame(10, npartitions=2, sparkcontext=connection)
+        connection, _ = payload
+        df = ROOT.RDataFrame(10, executor=connection, npartitions=2)
         df = df.Define("x", "1").Define("y", "42")
         h = df.Vary("x", "ROOT::RVecI{-1, 2}",
                     variationTags=["down", "up"]).Histo1D(("name", "title", 10, -500, 500), "x", "y")
-        histos = DistRDF.VariationsFor(h)
+        histos = ROOT.RDF.Experimental.VariationsFor(h)
 
         expectednames = ["nominal", "x:down", "x:up"]
         expectedmeans = [1, -1, 2]
@@ -73,18 +58,13 @@ class TestVariations:
             assert histo.GetMean() == mean
 
     def test_simultaneous(self, payload):
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            df = RDataFrame(10, npartitions=2, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            df = RDataFrame(10, npartitions=2, sparkcontext=connection)
+        connection, _ = payload
+        df = ROOT.RDataFrame(10, executor=connection, npartitions=2)
         df = df.Define("x", "1").Define("y", "42")
         h = df.Vary(["x", "y"],
                     "ROOT::RVec<ROOT::RVecI>{{-1, 2, 3}, {41, 43, 44}}",
                     ["down", "up", "other"], "xy").Histo1D(("name", "title", 10, -500, 500), "x", "y")
-        histos = DistRDF.VariationsFor(h)
+        histos = ROOT.RDF.Experimental.VariationsFor(h)
 
         expectednames = ["nominal", "xy:down", "xy:up", "xy:other"]
         expectedmeans = [1, -1, 2, 3]
@@ -96,20 +76,15 @@ class TestVariations:
             assert graph.GetMean() == mean
 
     def test_varyfiltersum(self, payload):
-        connection, backend = payload
-        if backend == "dask":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
-            df = RDataFrame(10, npartitions=2, daskclient=connection)
-        elif backend == "spark":
-            RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
-            df = RDataFrame(10, npartitions=2, sparkcontext=connection)
+        connection, _ = payload
+        df = ROOT.RDataFrame(10, executor=connection, npartitions=2)
         df = df.Define("x", "1")
         df_sum = df.Vary(
             "x", "ROOT::RVecI{-1*x, 2*x}", ("down", "up"), "myvariation").Filter("x > 0").Sum("x")
 
         assert df_sum.GetValue() == 10
 
-        sums = DistRDF.VariationsFor(df_sum)
+        sums = ROOT.RDF.Experimental.VariationsFor(df_sum)
 
         expectednames = ["nominal", "myvariation:down", "myvariation:up"]
         expectedsums = [10, 0, 20]

--- a/python/distrdf/backends/conftest.py
+++ b/python/distrdf/backends/conftest.py
@@ -55,7 +55,7 @@ def payload(request):
     ```
     def test_my_feature(payload):
         connection, backend = payload
-        df = RDataFrame(10, daskclient=connection)
+        df = RDataFrame(10, executor=connection)
     ```
 
     The environment variable "DISTRDF_BACKENDS_IN_USE" is set at configuration

--- a/python/distrdf/backends/test_all.py
+++ b/python/distrdf/backends/test_all.py
@@ -6,6 +6,7 @@ from check_backend import *
 from check_cloned_actions import *
 from check_distribute_cppcode import * 
 from check_definepersample import *
+from check_explicit_api import *
 from check_friend_trees_alignment import *
 from check_friend_trees import *
 from check_histo_write import *


### PR DESCRIPTION
And also add tests that still use explicit full names to distributed RDataFrame functions and classes, to check compatibility with previous usage.

Sibling PR of https://github.com/root-project/root/pull/16681