### PR TITLE
[cmake][win][skip-ci] Set the CMAKE_SKIP_TEST_ALL_DEPENDENCY variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ if(NOT DEFINED Python3_EXECUTABLE)
 endif()
 
 if(MSVC)
-
+  set(CMAKE_SKIP_TEST_ALL_DEPENDENCY TRUE)
   set(libsuffix .dll)
   set(exesuffix .exe)
   set(CMAKE_CXX_FLAGS "/nologo /Zc:__cplusplus /MD /GR /EHsc- /W3 /D_WIN32")


### PR DESCRIPTION
This should partially solve the issue with the rebuild (linking) of ROOT when building the tests.
See also: https://cmake.org/cmake/help/latest/variable/CMAKE_SKIP_TEST_ALL_DEPENDENCY.html
Requires CMake v3.29