### PR TITLE
[hadd] add tests for RNTupleMerger compression

### DIFF
--- a/root/io/hadd/CMakeLists.txt
+++ b/root/io/hadd/CMakeLists.txt
@@ -10,7 +10,7 @@ ROOTTEST_ADD_TEST(test_MergeChangeComp_explicit
                   COPY_TO_BUILDDIR merge_gen_input_tuples.C merge_changeComp_check_output.C
                   PRECMD ${ROOT_root_CMD} -q -b -l "merge_gen_input_tuples.C(\"test_comp_in1.root\", \"test_comp_in2.root\")"
                   COMMAND ${ROOT_hadd_CMD} -f404 test_comp_out.root test_comp_in1.root test_comp_in2.root
-                  POSTCMD ${ROOT_root_CMD} -q -b -l "merge_changeComp_check_output.C(404, \"test_comp_out.root\", \"test_comp_in1.root\", \"test_comp_in2.root\")"
+                  POSTCMD ${ROOT_root_CMD} -q -b -l "merge_changeComp_check_output.C(404, 404, \"test_comp_out.root\", \"test_comp_in1.root\", \"test_comp_in2.root\")"
 )
 
 # merge 2 RNTuples without passing a compression
@@ -18,7 +18,7 @@ ROOTTEST_ADD_TEST(test_MergeChangeComp_default
                   DEPENDS test_MergeChangeComp_explicit
                   PRECMD ${ROOT_root_CMD} -q -b -l "merge_gen_input_tuples.C(\"test_comp_in_def_1.root\", \"test_comp_in_def_2.root\")"
                   COMMAND ${ROOT_hadd_CMD} -f test_comp_out_def.root test_comp_in_def_1.root test_comp_in_def_2.root
-                  POSTCMD ${ROOT_root_CMD} -q -b -l "merge_changeComp_check_output.C(505, \"test_comp_out_def.root\", \"test_comp_in_def_1.root\", \"test_comp_in_def_2.root\")"
+                  POSTCMD ${ROOT_root_CMD} -q -b -l "merge_changeComp_check_output.C(505, 101, \"test_comp_out_def.root\", \"test_comp_in_def_1.root\", \"test_comp_in_def_2.root\")"
 )
 
 # merge 2 RNTuples using the first tuple's compression
@@ -27,7 +27,7 @@ ROOTTEST_ADD_TEST(test_MergeChangeComp_first
                   DEPENDS test_MergeChangeComp_explicit
                   PRECMD ${ROOT_root_CMD} -q -b -l "merge_gen_input_tuples.C(\"test_comp_in_ff_1.root\", \"test_comp_in_ff_2.root\")"
                   COMMAND ${ROOT_hadd_CMD} -ff test_comp_out_ff.root test_comp_in_ff_2.root test_comp_in_ff_1.root
-                  POSTCMD ${ROOT_root_CMD} -q -b -l "merge_changeComp_check_output.C(101, \"test_comp_out_ff.root\", \"test_comp_in_ff_1.root\", \"test_comp_in_ff_2.root\")"
+                  POSTCMD ${ROOT_root_CMD} -q -b -l "merge_changeComp_check_output.C(101, 101, \"test_comp_out_ff.root\", \"test_comp_in_ff_1.root\", \"test_comp_in_ff_2.root\")"
 )
 
 ROOTTEST_ADD_TEST(test_TreeChangeComp

--- a/root/io/hadd/CMakeLists.txt
+++ b/root/io/hadd/CMakeLists.txt
@@ -5,11 +5,29 @@ if(ROOT_pyroot_FOUND)
                       MACRO input_validation.py)
 endif()
 
-ROOTTEST_ADD_TEST(test_MergeChangeComp
+# merge 2 RNTuples passing an explicit compression
+ROOTTEST_ADD_TEST(test_MergeChangeComp_explicit
                   COPY_TO_BUILDDIR merge_gen_input_tuples.C merge_changeComp_check_output.C
                   PRECMD ${ROOT_root_CMD} -q -b -l "merge_gen_input_tuples.C(\"test_comp_in1.root\", \"test_comp_in2.root\")"
                   COMMAND ${ROOT_hadd_CMD} -f404 test_comp_out.root test_comp_in1.root test_comp_in2.root
                   POSTCMD ${ROOT_root_CMD} -q -b -l "merge_changeComp_check_output.C(404, \"test_comp_out.root\", \"test_comp_in1.root\", \"test_comp_in2.root\")"
+)
+
+# merge 2 RNTuples without passing a compression
+ROOTTEST_ADD_TEST(test_MergeChangeComp_default
+                  DEPENDS test_MergeChangeComp_explicit
+                  PRECMD ${ROOT_root_CMD} -q -b -l "merge_gen_input_tuples.C(\"test_comp_in_def_1.root\", \"test_comp_in_def_2.root\")"
+                  COMMAND ${ROOT_hadd_CMD} -f test_comp_out_def.root test_comp_in_def_1.root test_comp_in_def_2.root
+                  POSTCMD ${ROOT_root_CMD} -q -b -l "merge_changeComp_check_output.C(505, \"test_comp_out_def.root\", \"test_comp_in_def_1.root\", \"test_comp_in_def_2.root\")"
+)
+
+# merge 2 RNTuples using the first tuple's compression
+# NOTE: merge_gen_input_tuples.C generates the first tuple as 505 and the second as 101
+ROOTTEST_ADD_TEST(test_MergeChangeComp_first
+                  DEPENDS test_MergeChangeComp_explicit
+                  PRECMD ${ROOT_root_CMD} -q -b -l "merge_gen_input_tuples.C(\"test_comp_in_ff_1.root\", \"test_comp_in_ff_2.root\")"
+                  COMMAND ${ROOT_hadd_CMD} -ff test_comp_out_ff.root test_comp_in_ff_2.root test_comp_in_ff_1.root
+                  POSTCMD ${ROOT_root_CMD} -q -b -l "merge_changeComp_check_output.C(101, \"test_comp_out_ff.root\", \"test_comp_in_ff_1.root\", \"test_comp_in_ff_2.root\")"
 )
 
 ROOTTEST_ADD_TEST(test_TreeChangeComp

--- a/root/io/hadd/merge_changeComp_check_output.C
+++ b/root/io/hadd/merge_changeComp_check_output.C
@@ -13,7 +13,15 @@ int merge_changeComp_check_output(int expectedCompression, const char *fnameOut,
 {
    using namespace ROOT::Experimental;
 
-   auto noPrereleaseWarning = RLogScopedVerbosity(NTupleLog(), ROOT::Experimental::ELogLevel::kError);
+   // Check compression of the tfile
+   {
+      auto f1 = std::unique_ptr<TFile>(TFile::Open(fnameOut, "READ"));
+      if (f1->GetCompressionSettings() != expectedCompression) {
+         std::cerr << "Expected TFile compression to be " << expectedCompression << " but it is "
+                   << f1->GetCompressionSettings() << "\n";
+         return 1;
+      }
+   }
 
    Internal::RPageSourceFile source("ntpl", fnameOut, RNTupleReadOptions());
    source.Attach();

--- a/root/io/hadd/merge_changeComp_check_output.C
+++ b/root/io/hadd/merge_changeComp_check_output.C
@@ -8,16 +8,16 @@
 
 #include <TSystem.h>
 
-int merge_changeComp_check_output(int expectedCompression, const char *fnameOut, const char *fnameIn1,
-                                  const char *fnameIn2)
+int merge_changeComp_check_output(int expectedCompressionRNT, int expectedCompressionTFile,
+                                  const char *fnameOut, const char *fnameIn1, const char *fnameIn2)
 {
    using namespace ROOT::Experimental;
 
    // Check compression of the tfile
    {
       auto f1 = std::unique_ptr<TFile>(TFile::Open(fnameOut, "READ"));
-      if (f1->GetCompressionSettings() != expectedCompression) {
-         std::cerr << "Expected TFile compression to be " << expectedCompression << " but it is "
+      if (f1->GetCompressionSettings() != expectedCompressionTFile) {
+         std::cerr << "Expected TFile compression to be " << expectedCompressionTFile << " but it is "
                    << f1->GetCompressionSettings() << "\n";
          return 1;
       }
@@ -28,14 +28,14 @@ int merge_changeComp_check_output(int expectedCompression, const char *fnameOut,
 
    Internal::RClusterPool pool{source};
 
-   const auto expCompAlgo = ROOT::RCompressionSetting::AlgorithmFromCompressionSettings(expectedCompression);
+   const auto expCompAlgo = ROOT::RCompressionSetting::AlgorithmFromCompressionSettings(expectedCompressionRNT);
    const auto &desc = source.GetSharedDescriptorGuard();
    auto clusterIter = desc->GetClusterIterable();
    for (const auto &clusterDesc : clusterIter) {
       // check advertised compression
       int advertisedCompression = clusterDesc.GetColumnRange(0).fCompressionSettings;
-      if (advertisedCompression != expectedCompression) {
-         std::cerr << "Expected advertised compression to be " << expectedCompression << " but it is "
+      if (advertisedCompression != expectedCompressionRNT) {
+         std::cerr << "Expected advertised compression to be " << expectedCompressionRNT << " but it is "
                    << advertisedCompression << "\n";
          return 1;
       }


### PR DESCRIPTION
Verify that hadd behaves as intended for the 3 interesting cases regarding compression:
1. explicit compression given
2. no explicit compression given (default compression)
3. use first input's compression

Goes with https://github.com/root-project/root/pull/16949