### PR TITLE
Adapt to change in error case behavior.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -487,7 +487,9 @@ AutoDict_*.cxx
 /root/io/newstl/4-*
 /root/io/newstl/5-*
 /root/io/newstl/6-*
+/root/io/newstl/7-*
 /root/io/newstl/*.root
+/root/io/newstl/ArchivedDataFiles
 
 # /root/io/perf/
 /root/io/perf/*.root

--- a/root/io/newstl/TestHelpers.C
+++ b/root/io/newstl/TestHelpers.C
@@ -6,7 +6,7 @@
 #include "TObjString.h"
 #include <utility>
 
-void fillListOfDir(TString directory, TList &l) {
+void fillListOfDir(const TString &directory, TList &l) {
    
    void *dir = gSystem->OpenDirectory(directory);
 

--- a/root/io/newstl/TestHelpers.C
+++ b/root/io/newstl/TestHelpers.C
@@ -6,9 +6,8 @@
 #include "TObjString.h"
 #include <utility>
 
-void fillListOfDir(TList &l) {
+void fillListOfDir(TString directory, TList &l) {
    
-   TString directory = ".";
    void *dir = gSystem->OpenDirectory(directory);
 
    const char *file = 0;
@@ -24,13 +23,15 @@ void fillListOfDir(TList &l) {
          if (strcmp(file,"latest")==0) continue;
 
          TString s = file;
-//          cout << "found the directory " << file << endl;
          if ( (basename!=file) && s.Index(re) == kNPOS) continue;
 
-         TString vfile = gSystem->ConcatFileName(file,"vector.root");
+	 TString dirname = file;
+	 if (directory != ".")
+	    dirname = gSystem->ConcatFileName(directory, file);
+
+         TString vfile = gSystem->ConcatFileName(dirname, "vector.root");
          if (gSystem->GetPathInfo(vfile,(Long_t*)0,(Long_t*)0,(Long_t*)0,0)==0) {
-//             cout << "found vector in " << file << endl;
-            l.Add(new TObjString(file));
+            l.Add(new TObjString(dirname));
          } else {
 //             cout << "did not find vector in " << file << endl;
          }
@@ -38,17 +39,29 @@ void fillListOfDir(TList &l) {
       }
       gSystem->FreeDirectory(dir);
 
-      //sort the files in alphanumeric order
-      l.Sort();
+   }
+}
 
+void fillListOfDir(TList &l) {
+   fillListOfDir(".", l);
+   fillListOfDir("ArchivedDataFiles", l);
+   const char *otherdir = gSystem->Getenv("ROOT_NEWSTL_DATAFILE_DIR");
+   if (otherdir && otherdir[0])
+      fillListOfDir(otherdir, l);
+
+   // Sort the files in alphanumeric order
+   l.Sort();
+
+   if (gDebug > 3) {
       TIter next(&l);
       TObjString *obj;
       while ((obj = (TObjString*)next())) {
-         file = obj->GetName();
-//          cout << "found the directory " << obj->GetName() << endl;
+         const char *file = obj->GetName();
+         cout << "found the directory " << obj->GetName() << endl;
       }
    }
 }
+
 #ifdef __MAKECINT__
 #pragma link C++ function DebugTest;
 //#pragma link C++ class pair<float,int>+;

--- a/root/io/newstl/TestHelpers.C
+++ b/root/io/newstl/TestHelpers.C
@@ -57,7 +57,7 @@ void fillListOfDir(TList &l) {
       TObjString *obj;
       while ((obj = (TObjString*)next())) {
          const char *file = obj->GetName();
-         cout << "found the directory " << obj->GetName() << endl;
+         cout << "found the directory " << file << endl;
       }
    }
 }

--- a/root/meta/evolution/mixedBase_merge1.ref
+++ b/root/meta/evolution/mixedBase_merge1.ref
@@ -5,3 +5,5 @@ Warning in <CreateReadMemberWiseActions>:    The StreamerInfo of class ParticleI
    You should update the version to ClassDef(ParticleImplVec,11).
    The objects on this file might not be readable because:
    The in-memory layout version 10 for class 'ParticleImplVec' has a base class (Particle) with version 12 but the on-file layout version 10 recorded the version number 11 for this base class (Particle).
+Error in <TBufferFile::CheckByteCount>: object of class vector<ParticleImplVec> read too many bytes: 56 instead of 8
+Warning in <TBufferFile::CheckByteCount>: vector<ParticleImplVec>::Streamer() not in sync with data on file mixedBase_merge1.root, fix Streamer()


### PR DESCRIPTION
Companion PR of https://github.com/root-project/root/pull/16995

Instead of writing with the 'wrong' TStreamerInfo, the hadd of two file with conflicting StreamerInfo with the same version number write with the 'right' StreamerInfo ... but that StreamerInfo has missing fields with are now omitted in the writing.

The use case has 2 StreamerInfos:
(a)
v10 of ParticleImplVec
which inherits from v11 of Particle
which contains 3 floats

(b)
v10 (also) of ParticleImplVec
which inherits from v12 of Particle
which contains a float and moves the 3 pre-existing float into a base class (so they are 'missing' when using v11 of Particle).

The previous behavior of the hadd invocation was streaming
   v10-a of ParticleImplVec
but ended up continuing the streaming with
   v12 of Particle

Now the hadd invocation is still streaming
   v10-a of ParticleImplVec
but is continuing with streaming with its corresponding
   v11 of Particle
which has missing data member (those moved in the base) so during Streaming we could either write arbitrary values (0) or (the choice that is made) we just skip them leading to a more clear error at read time:

```
Error in <TBufferFile::CheckByteCount>: object of class vector<ParticleImplVec> read too many bytes: 56 instead of 8
```

Note that the `56` is actual another consequence of the 'broken' setup in which hadd had to run (duplicate version number) and the reading is incorrectly trying to read with version 12 of Particle.

Reminder: the point of these tests is to ensure that there is sufficient error output is case of this type of mixed up setup.