### PR TITLE
[PyROOT] Don't use `force_flush` module

### DIFF
--- a/python/cling/MyModule.py
+++ b/python/cling/MyModule.py
@@ -1,10 +1,8 @@
-from force_flush import print_flushed
-
-print_flushed( 'loading MyModule.py ... ' )
+print( 'loading MyModule.py ... ', flush=True )
 
 class MyPyClass( object ):
    def __init__( self ):
-      print_flushed( 'in MyModule.MyPyClass.__init__' )
+      print( 'in MyModule.MyPyClass.__init__', flush=True )
 
    def gime( self, what ):
       return what

--- a/python/cling/MyOtherPyClass.py
+++ b/python/cling/MyOtherPyClass.py
@@ -1,27 +1,25 @@
-from force_flush import print_flushed
-
-print_flushed( 'creating class MyOtherPyClass ... ' )
+print( 'creating class MyOtherPyClass ... ', flush=True )
 
 class MyOtherPyClass:
    count = 0
 
    def __init__( self ):
-      print_flushed( 'in MyOtherPyClass.__init__' )
+      print( 'in MyOtherPyClass.__init__', flush=True )
       MyOtherPyClass.count += 1
 
    def __del__( self ):
-      print_flushed( 'in MyOtherPyClass.__del__' )
+      print( 'in MyOtherPyClass.__del__', flush=True )
       MyOtherPyClass.count -= 1
 
    def hop( self ):
-      print_flushed( 'hop' )
+      print( 'hop', flush=True )
 
    def duck( self ):
-      print_flushed( 'quack' )
+      print( 'quack', flush=True )
 
 
 # include a class that may interfere with the previous one due to
 # same-named method in it
 class MyYetAnotherPyClass:
    def hop( self ):
-      print_flushed( 'another hop' )
+      print( 'another hop', flush=True )

--- a/python/cling/MyPyClass.py
+++ b/python/cling/MyPyClass.py
@@ -1,10 +1,8 @@
-from force_flush import print_flushed
-
-print_flushed( 'creating class MyPyClass ... ' )
+print( 'creating class MyPyClass ... ', flush=True )
 
 class MyPyClass:
    def __init__( self ):
-      print_flushed( 'in MyPyClass.__init__' )
+      print( 'in MyPyClass.__init__', flush=True )
 
    def gime( self, what ):
       return what


### PR DESCRIPTION
With Python 3, force flushing is built into the `print()` function and enabled with an optional parameter.

This avoids failure in environments where the `force_flush` module is not available.