### PR TITLE
[cmake][win] Suppress regeneration of makefiles when building tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ endif()
 
 if(MSVC)
   set(CMAKE_SKIP_TEST_ALL_DEPENDENCY TRUE)
+  set(CMAKE_SUPPRESS_REGENERATION TRUE)
   set(libsuffix .dll)
   set(exesuffix .exe)
   set(CMAKE_CXX_FLAGS "/nologo /Zc:__cplusplus /MD /GR /EHsc- /W3 /D_WIN32")


### PR DESCRIPTION
Should fix the issues with ZERO_CHECK not being accessible when compiling the tests in parallel