### PR TITLE
Update gtest target names to CMake 3.23's canonical names.

### DIFF
--- a/cmake/modules/RoottestMacros.cmake
+++ b/cmake/modules/RoottestMacros.cmake
@@ -1120,7 +1120,14 @@ function(ROOTTEST_ADD_UNITTEST_DIR)
 
   add_executable(${binary} ${unittests_SRC})
   target_include_directories(${binary} PRIVATE ${GTEST_INCLUDE_DIR})
-  target_link_libraries(${binary} gtest gtest_main ${libraries})
+  if(TARGET GTest::gtest AND TARGET GTest::gtest_main)
+    # Canonical target names since CMake 3.20, and also now used in ROOT:
+    target_link_libraries(${binary} GTest::gtest GTest::gtest_main ${libraries})
+  else()
+    # Fallback solution, which just names the libraries. Might lead to undefined symbol
+    # errors if the libraries are not found:
+    target_link_libraries(${binary} gtest gtest_main ${libraries})
+  endif()
 
   if(MSVC AND DEFINED ROOT_SOURCE_DIR)
     if(TARGET ROOTStaticSanitizerConfig)

--- a/cmake/modules/SearchInstalledSoftwareRoottest.cmake
+++ b/cmake/modules/SearchInstalledSoftwareRoottest.cmake
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-if(NOT TARGET gtest)
+if(NOT TARGET GTest::gtest AND NOT TARGET gtest)
 
   set(_gtest_byproduct_binary_dir
     ${CMAKE_CURRENT_BINARY_DIR}/googletest-prefix/src/googletest-build)
@@ -94,7 +94,7 @@ if(NOT TARGET gtest)
   set_property(TARGET gmock PROPERTY IMPORTED_LOCATION ${_G_LIBRARY_PATH}/${CMAKE_STATIC_LIBRARY_PREFIX}gmock${CMAKE_STATIC_LIBRARY_SUFFIX})
   set_property(TARGET gmock_main PROPERTY IMPORTED_LOCATION ${_G_LIBRARY_PATH}/${CMAKE_STATIC_LIBRARY_PREFIX}gmock_main${CMAKE_STATIC_LIBRARY_SUFFIX})
 
-endif(NOT TARGET gtest)
+endif()
 
 #---Find timeout binary---------------------------------------------------------
 if(NOT MSVC)


### PR DESCRIPTION
ROOT is being updated to use the canonical gtest CMake taragets, so roottest needs to follow. Otherwise, it would try to download its own googletest.

This is a companion to https://github.com/root-project/root/pull/8709