### PR TITLE
Fix issues seen in high parallel ctest run

### DIFF
--- a/root/io/hadd/CMakeLists.txt
+++ b/root/io/hadd/CMakeLists.txt
@@ -88,7 +88,7 @@ ROOTTEST_ADD_TEST(test_hadd_args_n_1
                   PRECMD ${CMAKE_COMMAND} -E rm -f hadd_args_n_1_out.root
                   COMMAND ${ROOT_hadd_CMD} -n=1 hadd_args_n_1_out.root hadd_args_in.root
                   OUTREF hadd_args_n_1.ref
-                  POSTCMD ${ROOT_root_CMD} -q -b -l "hadd_args_verify.C(\"hadd_args_n0_out.root\")"
+                  POSTCMD ${ROOT_root_CMD} -q -b -l "hadd_args_verify.C(\"hadd_args_n_1_out.root\")"
 )
 
 ROOTTEST_ADD_TEST(test_hadd_args_jfa
@@ -110,7 +110,7 @@ ROOTTEST_ADD_TEST(test_hadd_args_j
                   PRECMD ${CMAKE_COMMAND} -E rm -f hadd_args_j_out.root
                   COMMAND ${ROOT_hadd_CMD} -j hadd_args_j_out.root hadd_args_in.root
                   PASSRC 0
-                  POSTCMD ${ROOT_root_CMD} -q -b -l "hadd_args_verify.C(\"hadd_args_n0_out.root\")"
+                  POSTCMD ${ROOT_root_CMD} -q -b -l "hadd_args_verify.C(\"hadd_args_j_out.root\")"
 )
 
 ROOTTEST_ADD_TEST(test_hadd_args_ff_dbg_j_2
@@ -118,7 +118,7 @@ ROOTTEST_ADD_TEST(test_hadd_args_ff_dbg_j_2
                   PRECMD ${CMAKE_COMMAND} -E rm -f hadd_args_ff_dbg_j_2_out.root
                   COMMAND ${ROOT_hadd_CMD} -ff hadd_args_ff_dbg_j_2_out.root hadd_args_in.root hadd_args_in.root -dbg -j 2
                   OUTREF hadd_args_ff_dbg_j_2.ref
-                  POSTCMD ${ROOT_root_CMD} -q -b -l "hadd_args_verify.C(\"hadd_args_n0_out.root\")"
+                  POSTCMD ${ROOT_root_CMD} -q -b -l "hadd_args_verify.C(\"hadd_args_ff_dbg_j_2_out.root\")"
 )
 
 ROOTTEST_ADD_TEST(test_hadd_args_minusminus
@@ -126,7 +126,7 @@ ROOTTEST_ADD_TEST(test_hadd_args_minusminus
                   PRECMD ${CMAKE_COMMAND} -E rm -f -- --hadd_args_out.root
                   COMMAND ${ROOT_hadd_CMD} -f0 -- --hadd_args_out.root hadd_args_in.root
                   OUTREF hadd_args_minusminus.ref
-                  POSTCMD ${ROOT_root_CMD} -q -b -l "hadd_args_verify.C(\"hadd_args_n0_out.root\")"
+                  POSTCMD ${ROOT_root_CMD} -q -b -l "hadd_args_verify.C(\"--hadd_args_out.root\")"
 )
 
 ROOTTEST_ADD_TEST(test_hadd_args_minusminus2
@@ -135,7 +135,7 @@ ROOTTEST_ADD_TEST(test_hadd_args_minusminus2
                   COMMAND ${ROOT_hadd_CMD} -f --hadd_args2_out.root -- hadd_args_in.root
                   PASSREGEX "Warning in <hadd>: unknown flag: --hadd_args2_out.root"
                   PASSRC 1
-                  POSTCMD ${ROOT_root_CMD} -q -b -l "hadd_args_verify.C(\"hadd_args_n0_out.root\")"
+                  POSTCMD ${ROOT_root_CMD} -q -b -l "hadd_args_verify.C(\"--hadd_args2_out.root\")"
 )
 
 ROOTTEST_ADD_TEST(test_hadd_args_multiple_pos
@@ -150,7 +150,7 @@ ROOTTEST_ADD_TEST(test_hadd_args_cachesize
                   PRECMD ${CMAKE_COMMAND} -E rm -f hadd_args_cachesize_out.root
                   COMMAND ${ROOT_hadd_CMD} hadd_args_cachesize_out.root hadd_args_in.root -cachesize 100M -f
                   OUTREF hadd_args_cachesize.ref
-                  POSTCMD ${ROOT_root_CMD} -q -b -l "hadd_args_verify.C(\"hadd_args_n0_out.root\")"
+                  POSTCMD ${ROOT_root_CMD} -q -b -l "hadd_args_verify.C(\"hadd_args_cachesize_out.root\")"
 )
 
 ROOTTEST_ADD_TEST(test_hadd_args_missing_arg

--- a/root/tree/evolution/Makefile
+++ b/root/tree/evolution/Makefile
@@ -149,7 +149,7 @@ ifneq ($(ClingWorkAroundMissingDynamicScope),)
 cloning.log: CALLROOTEXE += -e 'gROOT->ProcessLine(".L cloningTwo.C+");' 
 endif
 
-cloning.root: cloningOne_C.$(DllSuf)
+cloning.root: cloningOne_C.$(DllSuf) cloningTwo_C.$(DllSuf)
 	$(CMDECHO) $(CALLROOTEXE) -q -b -l 'runcloning.C(1)' > cloning_root.log
 
 cloning.log: cloningTwo_C.$(DllSuf) cloning.root


### PR DESCRIPTION
* root/io/hadd: Correct the filename needing to be checked (shown as reading a non-existent file)
* root/tree/evolution: Add missing dependency (shown as reading a partial build library file)

The companion PR is https://github.com/root-project/root/pull/17700