### PR TITLE
Fix two test failures with functions marked nodiscard.

### DIFF
--- a/cling/dict/CMakeLists.txt
+++ b/cling/dict/CMakeLists.txt
@@ -16,7 +16,6 @@ ROOTTEST_ADD_TEST(runtemplateAutodict
 ROOTTEST_ADD_TEST(runoperators
                   MACRO runoperators.C
                   OUTREF operators.ref
-                  ${WILLFAIL_ON_WIN32}
                   LABELS roottest regression cling)
 
 ROOTTEST_ADD_TEST(runalgebra

--- a/cling/dict/runoperators.C
+++ b/cling/dict/runoperators.C
@@ -23,6 +23,6 @@ void runoperators() {
    std::vector<myiterator> v;
    std::vector<myiterator>::iterator iter;
    for( iter = v.begin(); iter != v.end(); ++iter) {
-      iter + 1;
+      static_cast<void>(iter + 1);
    }
 }

--- a/cling/stl/default/CMakeLists.txt
+++ b/cling/stl/default/CMakeLists.txt
@@ -12,9 +12,13 @@ else()
   set(testcint OUTREF)
 endif()
 
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(is_failing ${WILLFAIL_ON_WIN32})
+endif()
+
 ROOTTEST_ADD_TEST(VectorSort
                   MACRO VectorSort.C
                   ${testcint} VectorSort.ref
                   # OUTCNV VectorSort_convert.sh
-                  ${WILLFAIL_ON_WIN32}
+                  ${is_failing}
                   LABELS roottest regression cling)

--- a/cling/stl/default/VectorSort.C
+++ b/cling/stl/default/VectorSort.C
@@ -53,7 +53,7 @@ int VectorSort() {
    // ensure that we can iterate, and that the precedence is correct,
    // and that the op++ doesn't operator on the elements:
    ++beg++;
-   *(++beg)++;
+   static_cast<void>(*(++beg)++);
    ++(*(++beg));
    beg = ++beg++;
    beg = ++beg++;


### PR DESCRIPTION
With gcc-15, the dereferencing and the + operator of iterators are marked nodiscard. This makes two tests fail, because the warning leads to a non-zero diff.