### PR TITLE
[Python] Don't check `metakernel` availablility in nbdiff.py

### DIFF
--- a/python/JupyROOT/nbdiff.py
+++ b/python/JupyROOT/nbdiff.py
@@ -187,12 +187,6 @@ if __name__ == "__main__":
         raise ImportError("Cannot import jupyter")
 
     kernelName = getKernelName(nbFileName)
-    if kernelName == 'root':
-        try:
-            # We need metakernel for ROOT C++ notebooks
-            import metakernel
-        except:
-            raise ImportError("Cannot import metakernel")
 
     retCode = canReproduceNotebook(nbFileName, kernelName, needsCompare)
     sys.exit(retCode)


### PR DESCRIPTION
This is redundant. The `root` Python kernel itself should give a good
error is `metakernel` is not available.