### PR TITLE
[CMake] Raise minimum required CMake version to 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 project(roottest)
 


### PR DESCRIPTION
To be consistent with the main ROOT repository and to avoid this warning:

```txt
CMake Deprecation Warning at roottest/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.
```