### PR TITLE
[treeformula] Avoid using deprecated sprintf

### DIFF
--- a/root/treeformula/references/TreeFormulaReferencesGeneration.cxx
+++ b/root/treeformula/references/TreeFormulaReferencesGeneration.cxx
@@ -143,8 +143,8 @@ void Event::Build(Int_t ev, Int_t arg5, Float_t ptmin) {
   if (ev >= 10000) nch += 3;
   if (fEventName) delete [] fEventName;
   fEventName = new char[nch];
-  sprintf(fEventName,"Event%d_Run%d",ev,200);
-  sprintf(etype,"type%d",ev%5);
+  snprintf(fEventName, nch, "Event%d_Run%d", ev, 200);
+  snprintf(etype, 20, "type%d", ev % 5);
   SetType(etype);
   SetHeader(ev, 200, 960312, random);
   SetNseg(Int_t(10*ntrack+20*sigmas));


### PR DESCRIPTION
To avoid warnings such as
/Users/vpadulan/Programs/rootproject/roottest/root/treeformula/references/TreeFormulaReferencesGeneration.cxx:146:3: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
  146 |   sprintf(fEventName,"Event%d_Run%d",ev,200);
      |   ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/usr/include/_stdio.h:274:1: note: 'sprintf' has been explicitly marked deprecated here
  274 | __deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
      | ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/usr/include/sys/cdefs.h:218:48: note: expanded from macro '__deprecated_msg'
  218 |         #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))