### PR TITLE
[io] Fix unsequenced operation in IoBigEventGeneration

### DIFF
--- a/root/io/bigevent/IoBigEventGeneration.cxx
+++ b/root/io/bigevent/IoBigEventGeneration.cxx
@@ -256,7 +256,8 @@ void Event::AddTrack(Float_t random)
 
    TClonesArray &tracks = *fTracks;
    //new(tracks[fNtrack++]) Track(random);
-   new(tracks[fNtrack++]) BigTrack(random,fNtrack%100);
+   new(tracks[fNtrack]) BigTrack(random,fNtrack%100);
+   ++fNtrack;
 }
 
 //______________________________________________________________________________


### PR DESCRIPTION
The order of operations for fNevent was unspecified. Splitting the two expressions to make it well-defined.