### PR TITLE
[v626] Fix one more test failure from nodiscard warning

### DIFF
--- a/cling/stl/default/VectorSort.C
+++ b/cling/stl/default/VectorSort.C
@@ -41,7 +41,7 @@ int VectorSort() {
 
    // check the availability and validity of the iterator type
    // (this should be "const_iterator" btw - it's a CINT bug)
-   gROOT->ProcessLine(Form("((const vector<unsigned int>*)0x%lx)->end()", (long)&vui));
+   gROOT->ProcessLine(Form("static_cast<void>(((const vector<unsigned int>*)0x%lx)->end())", (long)&vui));
 
    // is the iterator dict valid? (not really - it ignores the const_)
    // a bit too noisy, so we skip it:


### PR DESCRIPTION
Following up on b6984a9ad383dd, fix up one more warning from a function marked as nodiscard.