### PR TITLE
🚨  Remove compilation warning during ACLiC

### DIFF
--- a/root/io/TFile/execNestedCollectionStreamerInfo.cxx
+++ b/root/io/TFile/execNestedCollectionStreamerInfo.cxx
@@ -6,7 +6,7 @@
 #include <memory>
 
 struct Inside {
-  int fValue;
+  int fValue = 0;
 };
 
 struct Middle {


### PR DESCRIPTION
default initialise a variable to avoid warnings in the test which cause it to fail on many Linux flavours.
```
roottest/root/io/TFile/execNestedCollectionStreamerInfo.cxx: In function ‘bool CheckNestedCollectionStreamerInfo(bool)’:
  Warning: roottest/root/io/TFile/execNestedCollectionStreamerInfo.cxx:28:14: warning: ‘in.Inside::fValue’ may be used uninitialized [-Wmaybe-uninitialized]
     28 |       Inside in;
        |              ^~
```
@martamaja10 