### PR TITLE
[636][test] Dictionary data member type contains a std::function

### DIFF
--- a/root/meta/rootcling/CMakeLists.txt
+++ b/root/meta/rootcling/CMakeLists.txt
@@ -28,3 +28,7 @@ ROOTTEST_ADD_TEST(selectUnion
 ROOTTEST_ADD_TEST(ROOT10798
                   COMMAND ${ROOT_rootcling_CMD} -f ROOT10798Dict.cxx ${CMAKE_CURRENT_SOURCE_DIR}/ROOT10798LinkDef.h)
 
+# Issue #18833
+ROOTTEST_ADD_TEST(streamerInfoStdFunction
+                  COMMAND ${ROOT_rootcling_CMD} -f streamerInfoStdFunction.Dict.cc ${CMAKE_CURRENT_SOURCE_DIR}/streamerInfoStdFunction.h -reflex ${CMAKE_CURRENT_SOURCE_DIR}/streamerInfoStdFunction.xml
+                  OUTREF streamerInfoStdFunction.ref)

--- a/root/meta/rootcling/streamerInfoStdFunction.h
+++ b/root/meta/rootcling/streamerInfoStdFunction.h
@@ -1,0 +1,9 @@
+#include <functional>
+#include <vector>
+
+struct Foo {};
+struct egammaMVACalibTool
+{
+  std::vector<std::vector<std::function<float(int, const Foo*)> > > m_funcs;
+};
+

--- a/root/meta/rootcling/streamerInfoStdFunction.xml
+++ b/root/meta/rootcling/streamerInfoStdFunction.xml
@@ -1,0 +1,4 @@
+<lcgdict>
+   <class name="egammaMVACalibTool" />
+</lcgdict>
+


### PR DESCRIPTION
Port of commit 9ff60071f40ed88086e527b78bd0fc807458c83a in root's master branch after the merge of the roottest repo into root's one.

The fix this tests is very important and it justifies the backport of the test.

Sibling PR https://github.com/root-project/root/pull/18840