### PR TITLE
Revert "[test] Dictionary data member type contains a std::function"

### DIFF
--- a/root/meta/rootcling/CMakeLists.txt
+++ b/root/meta/rootcling/CMakeLists.txt
@@ -28,7 +28,3 @@ ROOTTEST_ADD_TEST(selectUnion
 ROOTTEST_ADD_TEST(ROOT10798
                   COMMAND ${ROOT_rootcling_CMD} -f ROOT10798Dict.cxx ${CMAKE_CURRENT_SOURCE_DIR}/ROOT10798LinkDef.h)
 
-# Issue #18833
-ROOTTEST_ADD_TEST(streamerInfoStdFunction
-                  COMMAND ${ROOT_rootcling_CMD} -f streamerInfoStdFunction.Dict.cc ${CMAKE_CURRENT_SOURCE_DIR}/streamerInfoStdFunction.h -reflex ${CMAKE_CURRENT_SOURCE_DIR}/streamerInfoStdFunction.xml
-                  OUTREF streamerInfoStdFunction.ref)

--- a/root/meta/rootcling/streamerInfoStdFunction.h
+++ b/root/meta/rootcling/streamerInfoStdFunction.h
@@ -1,9 +1,0 @@
-#include <functional>
-#include <vector>
-
-struct Foo {};
-struct egammaMVACalibTool
-{
-  std::vector<std::vector<std::function<float(int, const Foo*)> > > m_funcs;
-};
-

--- a/root/meta/rootcling/streamerInfoStdFunction.xml
+++ b/root/meta/rootcling/streamerInfoStdFunction.xml
@@ -1,4 +1,0 @@
-<lcgdict>
-   <class name="egammaMVACalibTool" />
-</lcgdict>
-


### PR DESCRIPTION
This reverts commit 134488dbb224e4cb2fb35447cfce299d297ccdcd.