### PR TITLE
Explicitly set CPPYY_API_PATH in execNormalizationInf test

### DIFF
--- a/root/meta/tclass/regression/CMakeLists.txt
+++ b/root/meta/tclass/regression/CMakeLists.txt
@@ -11,6 +11,7 @@ if(ROOT_pyroot_FOUND)
                   MACRO execNormalizationInf.py
                   OUTREF execNormalizationInf.py.ref
                   ENVIRONMENT CLING_STANDARD_PCH=none
+                  CPPYY_API_PATH=none
                   CPPYY_BACKEND_LIBRARY=${CMAKE_BINARY_DIR}/lib/libcppyy_backend.so)
 endif()
 


### PR DESCRIPTION
This will avoid warnings in the code that tries to automatically figure out the CPPYY_API_PATH.